### PR TITLE
Fixes #28936 - Add description to plugin roles

### DIFF
--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -30,7 +30,7 @@ module ForemanRhCloud
         end
 
         # Add a new role called 'Discovery' if it doesn't exist
-        role 'ForemanRhCloud', [:view_foreman_rh_cloud]
+        role 'ForemanRhCloud', [:view_foreman_rh_cloud], 'TODO'
 
         # Adding a sub menu after hosts menu
         sub_menu :top_menu, :foreman_rh_cloud, :caption => N_('RH Cloud'), :icon => 'fa fa-cloud-upload' do


### PR DESCRIPTION
PR is part of  [Add default descriptions to all roles added from plugins](https://projects.theforeman.org/issues/28936) task.