### PR TITLE
Fix download file path

### DIFF
--- a/app/controllers/foreman_inventory_upload/uploads_controller.rb
+++ b/app/controllers/foreman_inventory_upload/uploads_controller.rb
@@ -11,14 +11,10 @@ module ForemanInventoryUpload
 
     def download_file
       filename = ForemanInventoryUpload.facts_archive_name(params[:organization_id])
-      path = Rails.root.join(ForemanInventoryUpload.uploads_folder, filename)
-      unless File.exist? path
-        return throw_flash_error(
-          "Path doesn't exist: #{path}"
-        )
-      end
+      files = Dir["{#{ForemanInventoryUpload.uploads_file_path(filename)},#{ForemanInventoryUpload.done_file_path(filename)}}"]
 
-      send_file path, disposition: 'attachment', filename: filename
+      return send_file files.first, disposition: 'attachment', filename: filename unless files.empty?
+      throw_flash_error "File doesn't exist"
     end
 
     def throw_flash_error(message)

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -18,6 +18,18 @@ module ForemanInventoryUpload
     )
   end
 
+  def self.uploads_file_path(filename)
+    File.join(ForemanInventoryUpload.uploads_folder, filename)
+  end
+
+  def self.done_folder
+    File.join(ForemanInventoryUpload.uploads_folder, 'done/')
+  end
+
+  def self.done_file_path(filename)
+    File.join(ForemanInventoryUpload.done_folder, filename)
+  end
+
   def self.generated_reports_folder
     @generated_reports_folder ||= ensure_folder(
       File.join(


### PR DESCRIPTION
when file is moved to `uploads/done/` the download file action raise an error that the file doesn't exists in `uploads/`.

in this PR the `download_file` action will look also if the file was moved to the `done/` folder.

I also added `uploads_file_path`, `done_folder`, `done_file_path` properties 
to `lib/foreman_inventory_upload.rb`