### PR TITLE
BZ 1824183 - add infrastructure_type field to system_profile

### DIFF
--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -19,6 +19,7 @@ module ForemanInventoryUpload
               'lscpu::flags',
               'distribution::version',
               'distribution::id',
+              'virt::is_guest',
             ]).pluck(:name, :id)
           ]
       end

--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -123,6 +123,10 @@ module ForemanInventoryUpload
         @stream.simple_field('subscription_status', host.subscription_status_label)
         @stream.simple_field('katello_agent_running', host.content_facet&.katello_agent_installed?)
         @stream.simple_field('satellite_managed', true)
+        @stream.simple_field(
+          'infrastructure_type',
+          ActiveModel::Type::Boolean.new.cast(fact_value(host, 'virt::is_guest')) ? 'virtual' : 'physical'
+        )
         unless (installed_products = host.subscription_facet&.installed_products).empty?
           @stream.array_field('installed_products') do
             @stream.raw(installed_products.map do |product|

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -37,6 +37,7 @@ class ReportGeneratorTest < ActiveSupport::TestCase
       'distribution::name',
       'distribution::version',
       'distribution::id',
+      'virt::is_guest',
     ]
   end
 
@@ -216,5 +217,35 @@ class ReportGeneratorTest < ActiveSupport::TestCase
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 'Red Hat Test Linux 7.1 (TestId)', actual_profile['os_release']
+  end
+
+  test 'sets infrastructure_type to "virtual" based on virt.is_guest fact' do
+    FactoryBot.create(:fact_value, fact_name: fact_names['virt::is_guest'], value: true, host: @host)
+
+    batch = Host.where(id: @host.id).in_batches.first
+    generator = ForemanInventoryUpload::Generators::Slice.new(batch, [], 'slice_123')
+
+    json_str = generator.render
+    actual = JSON.parse(json_str.join("\n"))
+
+    assert_equal 'slice_123', actual['report_slice_id']
+    assert_not_nil(actual_host = actual['hosts'].first)
+    assert_not_nil(actual_profile = actual_host['system_profile'])
+    assert_equal 'virtual', actual_profile['infrastructure_type']
+  end
+
+  test 'sets infrastructure_type to "physical" based on virt.is_guest fact' do
+    FactoryBot.create(:fact_value, fact_name: fact_names['virt::is_guest'], value: false, host: @host)
+
+    batch = Host.where(id: @host.id).in_batches.first
+    generator = ForemanInventoryUpload::Generators::Slice.new(batch, [], 'slice_123')
+
+    json_str = generator.render
+    actual = JSON.parse(json_str.join("\n"))
+
+    assert_equal 'slice_123', actual['report_slice_id']
+    assert_not_nil(actual_host = actual['hosts'].first)
+    assert_not_nil(actual_profile = actual_host['system_profile'])
+    assert_equal 'physical', actual_profile['infrastructure_type']
   end
 end


### PR DESCRIPTION
System profile's "infrastructure_type" field should be reported as "virtual" or "physical"