### PR TITLE
BZ 1825760 - stringify env hash keys and values

### DIFF
--- a/lib/foreman_inventory_upload/async/async_helpers.rb
+++ b/lib/foreman_inventory_upload/async/async_helpers.rb
@@ -1,0 +1,13 @@
+module ForemanInventoryUpload
+  module Async
+    module AsyncHelpers
+      extend ActiveSupport::Concern
+
+      def hash_to_s(hash)
+        hash.each_with_object({}) do |(k, v), a|
+          a[k.to_s] = v.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_inventory_upload/async/shell_process.rb
+++ b/lib/foreman_inventory_upload/async/shell_process.rb
@@ -3,11 +3,13 @@ require 'open3'
 module ForemanInventoryUpload
   module Async
     class ShellProcess < ::ApplicationJob
+      include AsyncHelpers
+
       def perform(instance_label)
         klass_name = self.class.name
         logger.debug("Starting #{klass_name} with label #{instance_label}")
         progress_output = ProgressOutput.register(instance_label)
-        Open3.popen2e(env, command) do |_stdin, stdout_stderr, wait_thread|
+        Open3.popen2e(hash_to_s(env), command) do |_stdin, stdout_stderr, wait_thread|
           progress_output.status = "Running in pid #{wait_thread.pid}"
 
           stdout_stderr.each do |out_line|


### PR DESCRIPTION
Description of problem:
schedule inventory plugin sync failed due to 'organization_id' typecasting.

```bash
2020-04-17T10:01:22 [I|app|] Performed ForemanInventoryUpload::Async::GenerateAllReportsJob (Job ID: 160d2769-88b7-4a3f-96b6-f803d
42c675a) from Dynflow(default) in 6512.74ms
2020-04-17T10:01:22 [I|app|] Performing ForemanInventoryUpload::Async::GenerateReportJob (Job ID: d5b032b1-ccfd-44a2-8444-2c4a5f91
4518) from Dynflow(default) with arguments: "/var/lib/foreman/red_hat_inventory/generated_reports/", 1
2020-04-17T10:01:22 [E|app|] Error performing ForemanInventoryUpload::Async::GenerateReportJob (Job ID: d5b032b1-ccfd-44a2-8444-2c
4a5f914518) from Dynflow(default) in 0.62ms: TypeError (no implicit conversion of Integer into String):
/opt/rh/rh-ruby25/root/usr/share/ruby/open3.rb:199:in `spawn'
/opt/rh/rh-ruby25/root/usr/share/ruby/open3.rb:199:in `popen_run'
/opt/rh/rh-ruby25/root/usr/share/ruby/open3.rb:190:in `popen2e'
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_rh_cloud-1.0.4.1/lib/foreman_inventory_upload/async/shell_process.rb:10:in `perform'
/opt/theforeman/tfm/root/usr/share/gems/gems/foreman_rh_cloud-1.0.4.1/lib/foreman_inventory_upload/async/generate_report_job.rb:12:in `perform'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activejob-5.2.1/lib/active_job/execution.rb:39:in `block in perform_now'
/opt/theforeman/tfm-ror52/root/usr/share/gems/gems/activesupport-5.2.1/lib/active_support/callbacks.rb:109:in `block in run_callbacks'
```
