### PR TITLE
[1_24] Fix branch name in travis js tests script

### DIFF
--- a/script/travis_run_js_tests.sh
+++ b/script/travis_run_js_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ev
 
-if [[ $( git diff --name-only origin/master..HEAD webpack/ .travis.yml .babelrc .eslintrc package.json | wc -l ) -ne 0 ]]; then
+if [[ $( git diff --name-only origin/foreman_1_24..HEAD webpack/ .travis.yml .babelrc .eslintrc package.json | wc -l ) -ne 0 ]]; then
   npm run test;
   npm run coveralls;
   npm run lint;


### PR DESCRIPTION
After @ShimShtein comment on the 1.20 CP.
I realized that I didn't change the branch name from `master` to `foreman_1_24`