### PR TITLE
[master] fix travis js script

### DIFF
--- a/script/travis_run_js_tests.sh
+++ b/script/travis_run_js_tests.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -ev
 
-if [[ $( git diff --name-only origin/master..HEAD webpack/ .travis.yml babel.config.js .eslintrc package.json | wc -l ) -ne 0 ]]; then
-  npm run test;
-  npm run publish-coverage;
-  npm run lint;
-fi
+npm run test;
+npm run publish-coverage;
+npm run lint;


### PR DESCRIPTION
the JS tests stopped from running with the error:
```bash
git diff --name-only origin/foreman_1_24..HEAD webpack/ .travis.yml .babelrc .eslintrc package.json | wc -l 
fatal: ambiguous argument 'origin/foreman_1_24..HEAD': unknown revision or path not in the working tree.
```