### PR TITLE
[CP 20] - Add tasks history button link (#243)

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/PageHeader.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/PageHeader.js
@@ -3,7 +3,7 @@ import { Grid } from 'patternfly-react';
 import InventorySettings from '../InventorySettings';
 import PageDescription from './components/PageDescription';
 import InventoryFilter from '../InventoryFilter';
-import DocsButton from './components/DocsButton';
+import ToolbarButtons from './components/ToolbarButtons';
 import { INVENTORY_PAGE_TITLE } from '../../ForemanInventoryConstants';
 import './pageHeader.scss';
 
@@ -27,7 +27,7 @@ const PageHeader = () => (
         <InventoryFilter />
       </Grid.Col>
       <Grid.Col xs={4} xsOffset={4}>
-        <DocsButton />
+        <ToolbarButtons />
       </Grid.Col>
     </Grid.Row>
   </React.Fragment>

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/__tests__/__snapshots__/PageHeader.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/__tests__/__snapshots__/PageHeader.test.js.snap
@@ -54,7 +54,7 @@ exports[`PageHeader rendering render without Props 1`] = `
       xs={4}
       xsOffset={4}
     >
-      <DocsButton />
+      <ToolbarButtons />
     </Col>
   </Row>
 </Fragment>

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/DocsButton/DocsButton.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/DocsButton/DocsButton.js
@@ -2,11 +2,9 @@ import React from 'react';
 import { Button, Icon } from 'patternfly-react';
 import { DOCS_BUTTON_TEXT } from '../../../../ForemanInventoryConstants';
 import { getInventoryDocsUrl } from '../../../../ForemanInventoryHelpers';
-import './docsButton.scss';
 
 const DocsButton = () => (
   <Button
-    className="docs_btn"
     href={getInventoryDocsUrl()}
     target="_blank"
     rel="noopener noreferrer"

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/DocsButton/__tests__/__snapshots__/DocsButton.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/DocsButton/__tests__/__snapshots__/DocsButton.test.js.snap
@@ -6,7 +6,6 @@ exports[`DocsButton rendering render without Props 1`] = `
   block={false}
   bsClass="btn"
   bsStyle="default"
-  className="docs_btn"
   disabled={false}
   href="https://access.redhat.com/products/subscription-central"
   rel="noopener noreferrer"

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/DocsButton/docsButton.scss
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/DocsButton/docsButton.scss
@@ -1,3 +1,0 @@
-.docs_btn {
-  float: right;
-}

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/HistoryButton/HistoryButton.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/HistoryButton/HistoryButton.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Button, Icon } from 'patternfly-react';
+import { ACTIONS_HISTORY_BUTTON_TEXT } from '../../../../ForemanInventoryConstants';
+import { getActionsHistoryUrl } from '../../../../ForemanInventoryHelpers';
+
+const HistoryButton = () => (
+  <Button
+    className="tasks_history_button"
+    href={getActionsHistoryUrl()}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <Icon name="history" />
+    {ACTIONS_HISTORY_BUTTON_TEXT}
+  </Button>
+);
+
+export default HistoryButton;

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/HistoryButton/__tests__/HistoryButton.test.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/HistoryButton/__tests__/HistoryButton.test.js
@@ -1,0 +1,14 @@
+import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
+
+import HistoryButton from '../HistoryButton';
+
+global.URL_PREFIX = '';
+
+const fixtures = {
+  'render without Props': {},
+};
+
+describe('HistoryButton', () => {
+  describe('rendering', () =>
+    testComponentSnapshotsWithFixtures(HistoryButton, fixtures));
+});

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/HistoryButton/__tests__/__snapshots__/HistoryButton.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/HistoryButton/__tests__/__snapshots__/HistoryButton.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HistoryButton rendering render without Props 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  className="tasks_history_button"
+  disabled={false}
+  href="/foreman_tasks/tasks?search=action++%3D++ForemanInventoryUpload%3A%3AAsync%3A%3AGenerateReportJob+or+action++%3D++ForemanInventoryUpload%3A%3AAsync%3A%3AGenerateAllReportsJob&page=1"
+  rel="noopener noreferrer"
+  target="_blank"
+>
+  <Icon
+    name="history"
+    type="fa"
+  />
+   Actions history
+</Button>
+`;

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/HistoryButton/index.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/HistoryButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './HistoryButton';

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/ToolbarButtons.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/ToolbarButtons.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import DocsButton from '../DocsButton';
+import HistoryButton from '../HistoryButton';
+import './toolbarButtons.scss';
+
+const ToolbarButtons = () => (
+  <div className="inventory_toolbar_buttons">
+    <HistoryButton />
+    <DocsButton />
+  </div>
+);
+
+export default ToolbarButtons;

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/__tests__/ToolbarButtons.test.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/__tests__/ToolbarButtons.test.js
@@ -1,0 +1,12 @@
+import { testComponentSnapshotsWithFixtures } from 'react-redux-test-utils';
+
+import ToolbarButtons from '../ToolbarButtons';
+
+const fixtures = {
+  'render without Props': {},
+};
+
+describe('ToolbarButtons', () => {
+  describe('rendering', () =>
+    testComponentSnapshotsWithFixtures(ToolbarButtons, fixtures));
+});

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/__tests__/__snapshots__/ToolbarButtons.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/__tests__/__snapshots__/ToolbarButtons.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ToolbarButtons rendering render without Props 1`] = `
+<div
+  className="inventory_toolbar_buttons"
+>
+  <HistoryButton />
+  <DocsButton />
+</div>
+`;

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/index.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/index.js
@@ -1,0 +1,1 @@
+export { default } from './ToolbarButtons';

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/toolbarButtons.scss
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/toolbarButtons.scss
@@ -1,0 +1,7 @@
+.inventory_toolbar_buttons {
+  float: right;
+
+  .tasks_history_button {
+    margin-right: 5px;
+  }
+}

--- a/webpack/ForemanInventoryUpload/ForemanInventoryConstants.js
+++ b/webpack/ForemanInventoryUpload/ForemanInventoryConstants.js
@@ -3,3 +3,5 @@ import { translate as __ } from 'foremanReact/common/I18n';
 export const INVENTORY_PAGE_TITLE = __('Red Hat Inventory Uploads');
 
 export const DOCS_BUTTON_TEXT = __(' Documentation');
+
+export const ACTIONS_HISTORY_BUTTON_TEXT = __(' Actions history');

--- a/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
+++ b/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
@@ -5,3 +5,8 @@ export const inventoryUrl = path =>
 
 export const getInventoryDocsUrl = () =>
   'https://access.redhat.com/products/subscription-central';
+
+export const getActionsHistoryUrl = () =>
+  foremanUrl(
+    '/foreman_tasks/tasks?search=action++%3D++ForemanInventoryUpload%3A%3AAsync%3A%3AGenerateReportJob+or+action++%3D++ForemanInventoryUpload%3A%3AAsync%3A%3AGenerateAllReportsJob&page=1'
+  );


### PR DESCRIPTION
* Add action history button link (#239)

* Add tasks history button link

* split ToolbarButtons into smaller components
(cherry picked from commit ae8239937d1fbbfd2a7cc894107bbd950b076edd)

Conflicts:
	webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js

* downgrade tests
(cherry picked from commit 8af94de34e90a0068093aac2cb3aa23a80d11618)