### PR TITLE
Fixes #TBFL - Work around SELinux issues when uploading reports

### DIFF
--- a/lib/foreman_inventory_upload/async/shell_process.rb
+++ b/lib/foreman_inventory_upload/async/shell_process.rb
@@ -9,7 +9,7 @@ module ForemanInventoryUpload
         klass_name = self.class.name
         logger.debug("Starting #{klass_name} with label #{instance_label}")
         progress_output = ProgressOutput.register(instance_label)
-        Open3.popen2e(hash_to_s(env), command) do |_stdin, stdout_stderr, wait_thread|
+        Open3.popen2e(hash_to_s(env), *preprocess_command(command)) do |_stdin, stdout_stderr, wait_thread|
           progress_output.status = "Running in pid #{wait_thread.pid}"
 
           stdout_stderr.each do |out_line|
@@ -32,6 +32,12 @@ module ForemanInventoryUpload
 
       def logger
         Foreman::Logging.logger('background')
+      end
+
+      private
+
+      def preprocess_command(command)
+        command.kind_of?(Array) ? command : [command]
       end
     end
   end

--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -21,7 +21,7 @@ module ForemanInventoryUpload
       end
 
       def command
-        ['/usr/bin/sh', File.join(File.dirname(@filename), ForemanInventoryUpload.upload_script_file)]
+        ['/bin/bash', File.join(File.dirname(@filename), ForemanInventoryUpload.upload_script_file)]
       end
 
       def env

--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -21,7 +21,7 @@ module ForemanInventoryUpload
       end
 
       def command
-        File.join(File.dirname(@filename), ForemanInventoryUpload.upload_script_file)
+        ['/usr/bin/sh', File.join(File.dirname(@filename), ForemanInventoryUpload.upload_script_file)]
       end
 
       def env

--- a/lib/foreman_inventory_upload/scripts/uploader.sh.erb
+++ b/lib/foreman_inventory_upload/scripts/uploader.sh.erb
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 DEST=<%= @upload_url %>
 RH_USERNAME=<%= @rh_username %>


### PR DESCRIPTION
Executing the script directly causes SELinux issues because the dynflow workers running in `foreman_rails_t` are not allowed to execute things of type `foreman_lib_t`. By wrapping the execution in a shell we work around this we effectively work around the original issue because `foreman_rails_t` is apparently allowed to execute `bin_t`.