### PR TITLE
fix report system_profile os fields

### DIFF
--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -122,15 +122,8 @@ module ForemanInventoryUpload
             end.join(', '))
           end
         end
-        @stream.simple_field(
-          'os_release',
-          os_release_value(
-            name: fact_value(host, 'distribution::name'),
-            version: fact_value(host, 'distribution::version'),
-            codename: fact_value(host, 'distribution::id')
-          )
-        )
-        @stream.simple_field('os_kernel_version', fact_value(host, 'uname::release'))
+        @stream.simple_field('os_release', fact_value(host, 'distribution::version'))
+        @stream.simple_field('os_kernel_version', os_kernel_version(fact_value(host, 'uname::release')))
         @stream.simple_field('arch', host.architecture&.name)
         @stream.simple_field('subscription_status', host.subscription_status_label)
         @stream.simple_field('katello_agent_running', host.content_facet&.katello_agent_installed?)
@@ -189,6 +182,10 @@ module ForemanInventoryUpload
 
       def os_release_value(name:, version:, codename:)
         "#{name} #{version} (#{codename})"
+      end
+
+      def os_kernel_version(long_version)
+        long_version&.split("-")&.first
       end
     end
   end


### PR DESCRIPTION
Generated OS values:
```json
"os_release": "7.8",
"os_kernel_version": "3.10.0",
```
Those values before:
```json
"os_release": "Red Hat Enterprise Linux Server 7.8 (Maipo)",
"os_kernel_version": "3.10.0-1127.el7.x86_64",
```

background:

Some application expect those values to be "clean",
see the example of other reporting systems, the middle one was reported by `foreman_rh_cloud`:

![image](https://user-images.githubusercontent.com/26363699/89502287-6d492880-d7cd-11ea-870d-d70ff338290b.png)
