### PR TITLE
Add branch_info endpoint

### DIFF
--- a/app/controllers/concerns/redhat_access/candlepin_related.rb
+++ b/app/controllers/concerns/redhat_access/candlepin_related.rb
@@ -1,0 +1,17 @@
+module RedhatAccess
+  module CandlepinRelated
+    extend ActiveSupport::Concern
+
+    def upstream_owner(org)
+      # We use a cache because owner_details is a call to Candlepin
+      Rails.cache.fetch("insights_upstream_owner_#{org.id}", expires_in: 1.minute) do
+        org.owner_details['upstreamConsumer']
+      end
+    end
+
+    def cp_owner_id(org)
+      owner = upstream_owner(org)
+      owner['uuid'] if owner
+    end
+  end
+end

--- a/app/controllers/concerns/redhat_access/client_authentication.rb
+++ b/app/controllers/concerns/redhat_access/client_authentication.rb
@@ -1,0 +1,23 @@
+module RedhatAccess
+  module ClientAuthentication
+    extend ActiveSupport::Concern
+
+    include ::Katello::Authentication::ClientAuthentication
+
+    def authorize
+      client_authorized? || super
+    end
+
+    def client_authorized?
+      authenticate_client && valid_machine_user?
+    end
+
+    def valid_machine_user?
+      subscribed_host_by_uuid(User.current.uuid).present?
+    end
+
+    def subscribed_host_by_uuid(uuid)
+      @host ||= Host.unscoped.joins(:subscription_facet).where(:katello_subscription_facets => {:uuid => uuid }).first
+    end
+  end
+end

--- a/app/controllers/redhat_access/machine_telemetries_controller.rb
+++ b/app/controllers/redhat_access/machine_telemetries_controller.rb
@@ -1,0 +1,30 @@
+module RedhatAccess
+  class MachineTelemetriesController < ::Api::V2::BaseController
+    layout false
+
+    include ::RedhatAccess::ClientAuthentication
+    include ::RedhatAccess::CandlepinRelated
+
+    before_action :cert_uuid, :ensure_org, :ensure_branch_id, :only => [:branch_info]
+
+    def branch_info
+      render :json => ForemanRhCloud::BranchInfo.new.generate(@uuid, @host, @branch_id, request.host).to_json
+    end
+
+    private
+
+    def cert_uuid
+      @uuid ||= User.current.login
+    end
+
+    def ensure_org
+      @organization = @host.organization
+      return render_message 'Organization not found or invalid', :status => 400 unless @organization
+    end
+
+    def ensure_branch_id
+      @branch_id = cp_owner_id(@organization)
+      return render_message "Branch ID not found for organization #{@organization.title}", :status => 400 unless @branch_id
+    end
+  end
+end

--- a/app/models/setting/rh_cloud.rb
+++ b/app/models/setting/rh_cloud.rb
@@ -7,6 +7,7 @@ class Setting::RhCloud < Setting
       set('allow_auto_insights_sync', N_('Allow recommendations synchronization from Red Hat cloud'), false),
       set('obfuscate_inventory_hostnames', N_('Obfuscate host names sent to Red Hat cloud'), false),
       set('rh_cloud_token', N_('Authentication token to Red Hat cloud services. Used to authenticate requests to cloud APIs'), 'DEFAULT', N_('Red Hat Cloud token'), nil, encrypted: true),
+      set('include_parameter_tags', N_('Should import include parameter tags from Foreman?'), false),
     ]
   end
 

--- a/app/services/foreman_rh_cloud/branch_info.rb
+++ b/app/services/foreman_rh_cloud/branch_info.rb
@@ -1,0 +1,59 @@
+module ForemanRhCloud
+  class BranchInfo
+    def generate(uuid, host, branch_id, request_hostname)
+      {
+        :remote_leaf => uuid,
+        :remote_branch => branch_id,
+        :display_name => host.organization.name,
+        :hostname => request_hostname,
+        :product => {
+          :type => core_app_name,
+          :major_version => core_app_version.major,
+          :minor_version => core_app_version.minor,
+        },
+        :organization_id => host.organization.id,
+        :satellite_instance_id => Foreman.instance_id,
+        :labels => host_labels(host),
+      }
+    end
+
+    def core_app_name
+      return 'Satellite' if defined? ForemanThemeSatellite
+      'Foreman'
+    end
+
+    def core_app_version
+      return Foreman::Version.new(ForemanThemeSatellite::SATELLITE_VERSION) if defined? ForemanThemeSatellite
+      Foreman::Version.new
+    end
+
+    def new_label(key, value, namespace)
+      {
+        :namespace => namespace,
+        :key => key,
+        :value => value,
+      }
+    end
+
+    def labels_from_items(items, label_namespace, label_lamb, label_value_method = :to_s)
+      items.map { |item| new_label(label_lamb.call(item), item.public_send(label_value_method), label_namespace) }
+    end
+
+    def host_labels(host)
+      labels = [new_label('Organization', host.organization.name, 'Satellite')]
+      labels += labels_from_items(host.location.title.split('/'), 'Satellite', ->(item) { 'Location' }) if host.location
+      labels += labels_from_items(host.hostgroup.title.split('/'), 'Satellite', ->(item) { 'Host Group' }) if host.hostgroup
+      labels += labels_from_items(host.host_collections, 'Satellite', ->(item) { 'Host Collection' }, :name)
+
+      if Setting[:include_parameter_tags]
+        labels += labels_from_items(
+          host.host_inherited_params_objects,
+          'SatelliteParameter',
+          ->(item) { item.name },
+          :value)
+      end
+
+      labels
+    end
+  end
+end

--- a/app/services/foreman_rh_cloud/branch_info.rb
+++ b/app/services/foreman_rh_cloud/branch_info.rb
@@ -18,12 +18,10 @@ module ForemanRhCloud
     end
 
     def core_app_name
-      return 'Satellite' if defined? ForemanThemeSatellite
       'Foreman'
     end
 
     def core_app_version
-      return Foreman::Version.new(ForemanThemeSatellite::SATELLITE_VERSION) if defined? ForemanThemeSatellite
       Foreman::Version.new
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,12 @@ Rails.application.routes.draw do
     get 'hits/:host_id', to: 'hits#index'
   end
 
+  namespace :redhat_access do
+    scope 'r/insights/v1' do
+      get 'branch_info', to: 'machine_telemetries#branch_info'
+    end
+  end
+
   namespace :foreman_rh_cloud do
     get 'inventory_upload', to: 'react#inventory_upload'
     get 'insights_cloud', to: 'react#insights_cloud'

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -12,6 +12,7 @@ module ForemanRhCloud
     config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/helpers/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
+    config.autoload_paths += Dir["#{config.root}/app/services"]
     config.autoload_paths += Dir["#{config.root}/app/overrides"]
     config.autoload_paths += Dir["#{config.root}/lib"]
 

--- a/test/controllers/redhat_access/machine_telemetries_controller_test.rb
+++ b/test/controllers/redhat_access/machine_telemetries_controller_test.rb
@@ -1,0 +1,59 @@
+require 'test_plugin_helper'
+
+module RedhatAccess
+  class MachineTelemetriesControllerTest < ActionController::TestCase
+    setup do
+      User.current = User.find_by(login: 'secret_admin')
+
+      @env = FactoryBot.create(:katello_k_t_environment)
+      cv = @env.content_views << FactoryBot.create(:katello_content_view, organization: @env.organization)
+
+      @host = FactoryBot.create(
+        :host,
+        :with_subscription,
+        :with_content,
+        :with_hostgroup,
+        :with_parameter,
+        content_view: cv.first,
+        lifecycle_environment: @env,
+        organization: @env.organization
+      )
+
+      @host.subscription_facet.pools << FactoryBot.create(:katello_pool, account_number: '5678', cp_id: 1)
+
+      uuid = @host.subscription_facet.uuid
+
+      @user = ::Katello::CpConsumerUser.new({ :uuid => uuid, :login => uuid })
+
+      @controller.stub(:set_client_user, @user) do
+        User.current = @user
+      end
+
+      @controller.stubs(:cp_owner_id).returns('test-branch-id')
+    end
+
+    test 'should get branch info' do
+      get :branch_info
+
+      assert_response :success
+    end
+
+    test 'should handle missing organization' do
+      Host::Managed.any_instance.stubs(:organization).returns(nil)
+      get :branch_info
+
+      res = JSON.parse(@response.body)
+      assert_equal "Organization not found or invalid", res['message']
+      assert_response 400
+    end
+
+    test 'should handle missing branch id' do
+      @controller.stubs(:cp_owner_id).returns(nil)
+      get :branch_info
+
+      res = JSON.parse(@response.body)
+      assert_equal "Branch ID not found for organization #{@host.organization.title}", res['message']
+      assert_response 400
+    end
+  end
+end

--- a/test/factories/inventory_upload_factories.rb
+++ b/test/factories/inventory_upload_factories.rb
@@ -61,6 +61,18 @@ FactoryBot.define do
   end
 end
 
+FactoryBot.define do
+  factory :katello_host_collection_host, :class => Katello::HostCollectionHosts do
+    host_id { nil }
+    host_collection_id { nil }
+  end
+
+  factory :katello_host_collection, :class => Katello::HostCollection do
+    sequence(:name) { |n| "Host Collection #{n}" }
+    organization_id { nil }
+  end
+end
+
 FactoryBot.modify do
   factory :host do
     transient do

--- a/test/unit/services/foreman_rh_cloud/branch_info_test.rb
+++ b/test/unit/services/foreman_rh_cloud/branch_info_test.rb
@@ -1,0 +1,60 @@
+require 'test_plugin_helper'
+
+class BranchInfoTest < ActiveSupport::TestCase
+  setup do
+    User.current = User.find_by(login: 'secret_admin')
+
+    @env = FactoryBot.create(:katello_k_t_environment)
+    cv = @env.content_views << FactoryBot.create(:katello_content_view, organization: @env.organization)
+
+    @host = FactoryBot.create(
+      :host,
+      :with_subscription,
+      :with_content,
+      :with_hostgroup,
+      :with_parameter,
+      content_view: cv.first,
+      lifecycle_environment: @env,
+      organization: @env.organization
+    )
+
+    @host.subscription_facet.pools << FactoryBot.create(:katello_pool, account_number: '5678', cp_id: 1)
+  end
+
+  test 'should generate branch info for host' do
+    uuid = 'abcd-1234-qwerty'
+    branch_id = 'efgh-ijkl-mnop'
+    hostname = 'test.host.example.com'
+    info = ::ForemanRhCloud::BranchInfo.new.generate(uuid, @host, branch_id, hostname)
+
+    assert_equal uuid, info[:remote_leaf]
+    assert_equal branch_id, info[:remote_branch]
+    assert_equal @host.organization.title, info[:display_name]
+    assert_equal hostname, info[:hostname]
+    assert_equal @host.organization.id, info[:organization_id]
+    assert_equal Foreman.instance_id, info[:satellite_instance_id]
+  end
+
+  test 'should generate appropriate labels' do
+    2.times { FactoryBot.create(:katello_host_collection, :organization_id => @host.organization.id) }
+
+    FactoryBot.create(:setting, :settings_type => 'boolean', :default => true, :name => :include_parameter_tags)
+
+    Katello::HostCollection.all.map do |collection|
+      FactoryBot.create(:katello_host_collection_host, :host_id => @host.id, :host_collection_id => collection.id)
+    end
+
+    labels = ::ForemanRhCloud::BranchInfo.new.generate('a1', @host, 'branch', 'foo')[:labels]
+
+    org_label = labels.find { |label| label[:key] == 'Organization' }
+    loc_label = labels.find { |label| label[:key] == 'Location' }
+    assert_equal @host.organization.title, org_label[:value]
+    assert_equal @host.location.title, loc_label[:value]
+
+    hg_label = labels.find { |label| label[:key] == 'Host Group' }
+    host_colections = labels.select { |label| label[:key] == 'Host Collection' }
+    assert_equal @host.hostgroup.name, hg_label[:value]
+    assert_equal 2, host_colections.count
+    refute_empty labels.select { |label| label[:namespace] == 'SatelliteParameter' }
+  end
+end


### PR DESCRIPTION
Moving an endpoint from redhat-access plugin.
branch_info provides insights-client
with information about a consumer from
Candlepin and Katello.