### PR TITLE
Fix typo in hosts sync toast

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
@@ -8,7 +8,7 @@ const Toast = ({ syncHosts, disconnectHosts }) => {
   return (
     <span>
       <p>
-        {__("Total org's hosts with subscriprion: ")}
+        {__('Hosts with subscription in organization: ')}
         <strong>{totalHosts}</strong>
       </p>
       <p>


### PR DESCRIPTION
subscriprion -> subscription

Rephrased this line of message a little to be more formal. Fact that we are talking about number of hosts is obvious from context - some number will appear right after this message, in the same line. 