### PR TITLE
Run spell-checker over JavaScript files for each PR

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,36 @@
 {
-  "plugins": ["@theforeman/foreman"],
+  "plugins": [
+    "@theforeman/foreman",
+    "spellcheck"
+  ],
   "extends": [
     "plugin:@theforeman/foreman/core",
     "plugin:@theforeman/foreman/plugins"
-  ]
+  ],
+  "rules": {
+    "spellcheck/spell-checker": [
+      "error",
+      {
+        "identifiers": false,
+        "ignoreRequire": true,
+        "skipWords": [
+          "ansible",
+          "donut",
+          "jed",
+          "katello",
+          "knowledgebase",
+          "noopener",
+          "noreferrer",
+          "nowrap",
+          "pid",
+          "redhat",
+          "repo",
+          "theforeman",
+          "tooltip",
+          "unmount"
+        ],
+        "minLength": 3
+      }
+    ]
+  }
 }

--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Install plugin npm dependencies
         run: npm install
       - name: Run plugin linter
-        run: npm run lint
+        run: |
+          npm run lint
+          npm run lint:spelling
       - name: Run plugin tests
         run: npm run test
       - name: Publish Coveralls

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "tfm-lint --plugin -d /webpack",
+    "lint:spelling": "eslint ./",
     "test": "tfm-test --plugin",
     "test:watch": "tfm-test --plugin --watchAll",
     "test:current": "tfm-test --plugin --watch",
@@ -32,6 +33,7 @@
     "@theforeman/eslint-plugin-foreman": "^4.0.2",
     "babel-eslint": "^10.0.0",
     "eslint": "^6.7.2",
+    "eslint-plugin-spellcheck": "^0.0.17",
     "prettier": "^1.13.5",
     "raf": "^3.4.0",
     "stylelint": "^9.3.0",

--- a/webpack/ForemanInventoryUpload/Components/StatusChart/StatusChart.js
+++ b/webpack/ForemanInventoryUpload/Components/StatusChart/StatusChart.js
@@ -27,7 +27,7 @@ const StatusChart = ({ completed }) => {
     <Grid.Col sm={4}>
       <div className="status-chart">
         <DonutChart
-          id="donunt-chart-1"
+          id="donut-chart-1"
           size={{
             width: 210,
             height: 210,

--- a/webpack/ForemanInventoryUpload/Components/StatusChart/__tests__/__snapshots__/StatusChart.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/StatusChart/__tests__/__snapshots__/StatusChart.test.js.snap
@@ -43,7 +43,7 @@ exports[`StatusChart rendering render without Props 1`] = `
           "width": 11,
         }
       }
-      id="donunt-chart-1"
+      id="donut-chart-1"
       legend={
         Object {
           "show": false,


### PR DESCRIPTION
In the past, it did happen that typo in user-facing string slipped in and made it into released version. I thought it might be useful to prevent this from happening again and include spell-checker in development pipeline.

This PR adds [eslint-plugin-spellcheck](https://github.com/aotaduy/eslint-plugin-spellcheck) module, which does exactly that. I added new entries to eslint configuration and new `npm run` command, as well as included this command in github actions workflow.

New `npm run` is required, because `tfm-lint` ignores existing eslintrc file and provides no way to change this behavior during runtime.

Second commit fixes one spurious spelling mistake found by running `npm run lint:spelling`. ~~Spell checker still complains about "subscriprion" - this is addressed in #326 . That's why github action "test_js" fail now. I can close the other PR and include both typo fixes in one commit here.~~ Since #326 is merged and this is rebased, github pipeline passes without error.