### PR TITLE
[CP_22] - Add eslint spell-checker (#329)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "plugins": ["patternfly-react"],
+  "plugins": ["patternfly-react", "spellcheck"],
   "extends": ["plugin:patternfly-react/recommended"],
   "rules": {
     "prettier/prettier": ["error", {
@@ -11,7 +11,31 @@
     }],
     "import/extensions": ["error", {
       "ignore": ['foremanReact/.*']
-    }]
+    }],
+    "spellcheck/spell-checker": [
+      "error",
+      {
+        "identifiers": false,
+        "ignoreRequire": true,
+        "skipWords": [
+          "ansible",
+          "donut",
+          "jed",
+          "katello",
+          "knowledgebase",
+          "noopener",
+          "noreferrer",
+          "nowrap",
+          "pid",
+          "redhat",
+          "repo",
+          "theforeman",
+          "tooltip",
+          "unmount"
+        ],
+        "minLength": 3
+      }
+    ]
   },
   "settings": {
     "import/resolver": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "eslint": "^4.10.0",
     "eslint-import-resolver-babel-module": "^4.0.0",
     "eslint-plugin-patternfly-react": "0.2.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-spellcheck": "^0.0.17",
     "identity-obj-proxy": "^3.0.0",
     "jed": "^1.1.1",
     "jest-cli": "^23.6.0",

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
@@ -8,7 +8,7 @@ const Toast = ({ syncHosts, disconnectHosts }) => {
   return (
     <span>
       <p>
-        {__("Total org's hosts with subscriprion: ")}
+        {__('Hosts with subscription in organization: ')}
         <strong>{totalHosts}</strong>
       </p>
       <p>

--- a/webpack/ForemanInventoryUpload/Components/StatusChart/StatusChart.js
+++ b/webpack/ForemanInventoryUpload/Components/StatusChart/StatusChart.js
@@ -27,7 +27,7 @@ const StatusChart = ({ completed }) => {
     <Grid.Col sm={4}>
       <div className="status-chart">
         <DonutChart
-          id="donunt-chart-1"
+          id="donut-chart-1"
           size={{
             width: 210,
             height: 210,

--- a/webpack/ForemanInventoryUpload/Components/StatusChart/__tests__/__snapshots__/StatusChart.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/StatusChart/__tests__/__snapshots__/StatusChart.test.js.snap
@@ -43,7 +43,7 @@ exports[`StatusChart rendering render without Props 1`] = `
           "width": 11,
         }
       }
-      id="donunt-chart-1"
+      id="donut-chart-1"
       legend={
         Object {
           "show": false,

--- a/webpack/stories/decorators/withCardsDecorator.js
+++ b/webpack/stories/decorators/withCardsDecorator.js
@@ -4,7 +4,7 @@ export const withCardsDecorator = storyFn => (
   <div
     style={{
       width: '100%',
-      height: '100vh',
+      height: '100%',
       backgroundColor: '#F5F5F5',
       padding: '50px',
     }}


### PR DESCRIPTION
* Run spell-checker over JavaScript files for each PR (#327)

* Add eslint spell-checker plugin and npm command to run it

* Fix typo in chart id: "donunt" -> "donut"
(cherry picked from commit e06b521add9fdab069973406826343be9810dd38)

Conflicts:
	.eslintrc
	package.json

* Fix typo in hosts sync toast

(cherry picked from commit 3839714b5d7ea45ac2735722d52d03335f2d4645)

* Fix eslint spelling error in story styles

* Refactor lint script

Co-authored-by: Mirek Długosz <mzalewsk@redhat.com>
(cherry picked from commit c5992a66ca1082fb3647d19e9208264875c729fb)