### PR TITLE
Run the generation task as admin

### DIFF
--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -12,17 +12,19 @@ namespace :rh_cloud_inventory do
         puts "Must specify either portal_user or organization_id"
       end
 
-      if portal_user
-        puts "Generating report for all organizations associated with #{portal_user}"
-        base_folder = File.join(base_folder, portal_user)
-        organizations = ForemanInventoryUpload::Generators::Queries.organizations_for_user(portal_user).pluck(:id)
-      end
+      User.as_anonymous_admin do
+        if portal_user
+          puts "Generating report for all organizations associated with #{portal_user}"
+          base_folder = File.join(base_folder, portal_user)
+          organizations = ForemanInventoryUpload::Generators::Queries.organizations_for_user(portal_user).pluck(:id)
+        end
 
-      organizations.each do |organization|
-        target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization))
-        archived_report_generator = ForemanInventoryUpload::Generators::ArchivedReport.new(target, Logger.new(STDOUT))
-        archived_report_generator.render(organization: organization)
-        puts "Successfully generated #{target} for organization id #{organization}"
+        organizations.each do |organization|
+          target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization))
+          archived_report_generator = ForemanInventoryUpload::Generators::ArchivedReport.new(target, Logger.new(STDOUT))
+          archived_report_generator.render(organization: organization)
+          puts "Successfully generated #{target} for organization id #{organization}"
+        end
       end
     end
   end

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -147,6 +147,10 @@ class ReportGeneratorTest < ActiveSupport::TestCase
   end
 
   test 'generates a report with satellite facts' do
+    hostgroup = FactoryBot.create(:hostgroup)
+    @host.hostgroup = hostgroup
+    @host.save!
+
     Foreman.expects(:instance_id).twice.returns('satellite-id')
     batch = Host.where(id: @host.id).in_batches.first
     generator = create_generator(batch)
@@ -166,6 +170,7 @@ class ReportGeneratorTest < ActiveSupport::TestCase
     assert_tag(@host.content_view.name, actual_host, 'content_view')
     assert_tag(@host.location.name, actual_host, 'location')
     assert_tag(@host.organization.name, actual_host, 'organization')
+    assert_tag(@host.hostgroup.name, actual_host, 'hostgroup')
 
     assert_equal false, satellite_facts['is_hostname_obfuscated']
 


### PR DESCRIPTION
Hostgroup tag was missing form the report, since the report was not running under a specific user. Now the report will run under administrator permissions.