### PR TITLE
Disable inventory sync button while it's loading

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButton.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButton.js
@@ -21,7 +21,12 @@ class SyncButton extends React.Component {
     return (
       <React.Fragment>
         <SyncModal show={this.state.showModal} toggleModal={this.toggleModal} />
-        <Button className="sync_button" onClick={handleClick} bsSize="lg">
+        <Button
+          className="sync_button"
+          onClick={handleClick}
+          bsSize="lg"
+          disabled={status === STATUS.PENDING}
+        >
           {!cloudToken && (
             <span>
               <Icon name="warning" />{' '}


### PR DESCRIPTION
To disable double API calls to fetch host inventory from the cloud.