### PR TITLE
[CP_24] - Reuse http_proxy_string in RestClient requests

### DIFF
--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -47,19 +47,13 @@ module ForemanInventoryUpload
           'FILES' => @filename,
           'CER_PATH' => @cer_path
         )
+
+        http_proxy_string = ForemanRhCloud.http_proxy_string(logger: logger)
         if http_proxy_string
           env_vars['http_proxy'] = http_proxy_string
           env_vars['https_proxy'] = http_proxy_string
         end
         env_vars
-      end
-
-      def http_proxy_string
-        @http_proxy_string ||= begin
-          if Setting[:content_default_http_proxy]
-            HttpProxy.unscoped.find_by(name: Setting[:content_default_http_proxy])&.full_url
-          end
-        end
       end
 
       def rh_credentials

--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -1,4 +1,6 @@
 require 'foreman_rh_cloud/engine.rb'
+require 'cgi'
+require 'uri'
 
 module ForemanRhCloud
   def self.base_url
@@ -13,5 +15,57 @@ module ForemanRhCloud
 
   def self.verify_ssl_method
     @verify_ssl_method ||= ENV['SATELLITE_RH_CLOUD_URL'] ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+  end
+
+  def self.http_proxy_string(logger: Foreman::Logging.logger('background'))
+    ForemanRhCloud.proxy_setting(logger: logger)
+  end
+
+  def self.transformed_http_proxy_string(logger: Foreman::Logging.logger('background'))
+    ForemanRhCloud.transform_scheme(ForemanRhCloud.proxy_setting(logger: logger))
+  end
+
+  def self.proxy_setting(logger: Foreman::Logging.logger('background'))
+    HttpProxy.default_global_content_proxy&.full_url ||
+    ForemanRhCloud.cdn_proxy(logger: logger) ||
+    ForemanRhCloud.global_foreman_proxy
+  end
+
+  def self.cdn_proxy(logger: Foreman::Logging.logger('app'))
+    proxy_config = SETTINGS[:katello][:cdn_proxy]
+    return nil unless proxy_config
+
+    uri = URI('')
+    uri.host = proxy_config[:host]
+    uri.port = proxy_config[:port]
+    uri.scheme = proxy_config[:scheme] || 'http'
+
+    if proxy_config[:user]
+      uri.user = CGI.escape(proxy_config[:user])
+      uri.password = CGI.escape(proxy_config[:password])
+    end
+    uri.to_s
+  rescue URI::Error => e
+    logger.warn("cdn_proxy parsing failed: #{e}")
+    nil
+  end
+
+  def self.global_foreman_proxy
+    Setting[:http_proxy]
+  end
+
+  # This method assumes uri_string contains uri-encoded username and p@$$word:
+  # http://user:p%40%24%24word@localhost:8888
+  def self.transform_scheme(uri_string)
+    transformed_uri = URI.parse(uri_string)
+
+    case transformed_uri.scheme
+    when "http"
+      transformed_uri.scheme = 'proxy'
+    when "https"
+      transformed_uri.scheme = 'proxys'
+    end
+
+    transformed_uri.to_s
   end
 end

--- a/lib/insights_cloud/async/insights_full_sync.rb
+++ b/lib/insights_cloud/async/insights_full_sync.rb
@@ -27,6 +27,7 @@ module InsightsCloud
           method: :get,
           url: InsightsCloud.hits_export_url,
           verify_ssl: ForemanRhCloud.verify_ssl_method,
+          proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
           headers: {
             Authorization: "Bearer #{rh_credentials}",
           }
@@ -40,6 +41,7 @@ module InsightsCloud
           method: :post,
           url: ForemanRhCloud.authentication_url,
           verify_ssl: ForemanRhCloud.verify_ssl_method,
+          proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
           payload: {
             grant_type: 'refresh_token',
             client_id: 'rhsm-api',

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -65,6 +65,7 @@ module InventorySync
           method: :get,
           url: ForemanInventoryUpload.inventory_export_url,
           verify_ssl: ForemanRhCloud.verify_ssl_method,
+          proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
           headers: {
             Authorization: "Bearer #{rh_credentials}",
             params: {
@@ -82,6 +83,7 @@ module InventorySync
           method: :post,
           url: ForemanRhCloud.authentication_url,
           verify_ssl: ForemanRhCloud.verify_ssl_method,
+          proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
           payload: {
             grant_type: 'refresh_token',
             client_id: 'rhsm-api',

--- a/test/unit/rh_cloud_http_proxy_test.rb
+++ b/test/unit/rh_cloud_http_proxy_test.rb
@@ -1,0 +1,65 @@
+require 'test_plugin_helper'
+
+class RhCloudHttpProxyTest < ActiveSupport::TestCase
+  setup do
+    @global_content_proxy_mock = 'http://global:content@localhost:8888'
+    @global_foreman_proxy_mock = 'http://global:foreman@localhost:8888'
+    @katello_cdn_proxy_mock = {
+      host: 'localhost',
+      port: '8888',
+      user: 'katello',
+      password: 'cdn',
+      scheme: 'http',
+    }
+    @katello_cdn_proxy_string_mock = 'http://katello:cdn@localhost:8888'
+  end
+
+  test 'selects global content proxy' do
+    setup_global_content_proxy
+    setup_global_foreman_proxy
+    setup_cdn_proxy do
+      assert_equal @global_content_proxy_mock, ForemanRhCloud.proxy_setting
+    end
+  end
+
+  test 'selects cdn proxy' do
+    setup_global_foreman_proxy
+    setup_cdn_proxy do
+      assert_equal @katello_cdn_proxy_string_mock, ForemanRhCloud.proxy_setting
+    end
+  end
+
+  test 'selects global foreman proxy' do
+    setup_global_foreman_proxy
+
+    assert_equal @global_foreman_proxy_mock, ForemanRhCloud.proxy_setting
+  end
+
+  def setup_global_content_proxy
+    http_proxy = FactoryBot.create(:http_proxy, url: @global_content_proxy_mock)
+    HttpProxy.stubs(:default_global_content_proxy).returns(http_proxy)
+  end
+
+  def setup_global_foreman_proxy
+    FactoryBot.create(:setting, :name => 'http_proxy', :value => @global_foreman_proxy_mock)
+  end
+
+  def setup_cdn_proxy
+    old_cdn_setting = SETTINGS[:katello][:cdn_proxy]
+    SETTINGS[:katello][:cdn_proxy] = @katello_cdn_proxy_mock
+    yield
+  ensure
+    SETTINGS[:katello][:cdn_proxy] = old_cdn_setting
+  end
+
+  test 'transform proxy scheme test' do
+    mock_http_proxy = 'http://user:password@localhost:8888'
+    mock_https_proxy = 'https://user:password@localhost:8888'
+
+    transformed_http_uri = URI.parse(ForemanRhCloud.transform_scheme(mock_http_proxy))
+    transformed_https_uri = URI.parse(ForemanRhCloud.transform_scheme(mock_https_proxy))
+
+    assert_equal 'proxy', transformed_http_uri.scheme
+    assert_equal 'proxys', transformed_https_uri.scheme
+  end
+end


### PR DESCRIPTION
(cherry picked from commit 1c3675c30c0664653707984ac9860aef56089967)

Conflicts:
	lib/foreman_inventory_upload/async/upload_report_job.rb