### PR TITLE
Add toast with error message for generate report action

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/AccountList/AccountListActions.js
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/AccountListActions.js
@@ -1,4 +1,5 @@
 import API from 'foremanReact/API';
+import { addToast } from 'foremanReact/redux/actions/toasts';
 import { inventoryUrl } from '../../ForemanInventoryHelpers';
 import {
   INVENTORY_ACCOUNT_STATUS_POLLING,
@@ -46,7 +47,7 @@ export const stopAccountStatusPolling = pollingProcessID => dispatch => {
   });
 };
 
-export const restartProcess = (accountID, activeTab) => dispatch => {
+export const restartProcess = (accountID, activeTab) => async dispatch => {
   let processController = null;
   let processStatusName = null;
 
@@ -58,12 +59,22 @@ export const restartProcess = (accountID, activeTab) => dispatch => {
     processStatusName = 'generate_report_status';
   }
 
-  API.post(inventoryUrl(`${accountID}/${processController}`));
-  dispatch({
-    type: INVENTORY_PROCESS_RESTART,
-    payload: {
-      accountID,
-      processStatusName,
-    },
-  });
+  try {
+    await API.post(inventoryUrl(`${accountID}/${processController}`));
+    dispatch({
+      type: INVENTORY_PROCESS_RESTART,
+      payload: {
+        accountID,
+        processStatusName,
+      },
+    });
+  } catch (error) {
+    dispatch(
+      addToast({
+        sticky: true,
+        type: 'error',
+        message: error.message,
+      })
+    );
+  }
 };

--- a/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/AccountListActions.test.js
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/AccountListActions.test.js
@@ -22,6 +22,13 @@ const fixtures = {
   'should stopAccountStatusPolling': () =>
     stopAccountStatusPolling(pollingProcessID),
   'should restartProcess': () => restartProcess(accountID, activeTab),
+  'should invoke toast notification upon failure': () => {
+    API.post.mockImplementationOnce(() =>
+      Promise.reject(new Error('test error'))
+    );
+
+    return restartProcess(accountID, activeTab);
+  },
 };
 
 describe('AccountList actions', () => testActionSnapshotWithFixtures(fixtures));

--- a/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/__snapshots__/AccountListActions.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/__snapshots__/AccountListActions.test.js.snap
@@ -32,6 +32,23 @@ Array [
 ]
 `;
 
+exports[`AccountList actions should invoke toast notification upon failure 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "message": Object {
+          "message": "test error",
+          "sticky": true,
+          "type": "error",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
 exports[`AccountList actions should restartProcess 1`] = `
 Array [
   Array [


### PR DESCRIPTION
Adds a toast with error message:

![image](https://user-images.githubusercontent.com/10046168/94596050-4589b480-0294-11eb-8804-28b949f31232.png)
