### PR TITLE
Set cloudToken prop to not required

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButton.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButton.js
@@ -45,12 +45,13 @@ class SyncButton extends React.Component {
 }
 
 SyncButton.propTypes = {
-  cloudToken: PropTypes.string.isRequired,
+  cloudToken: PropTypes.string,
   handleSync: PropTypes.func.isRequired,
   status: PropTypes.string,
 };
 
 SyncButton.defaultProps = {
+  cloudToken: null,
   status: null,
 };
 


### PR DESCRIPTION
There is this warning in the console:

![Selection_349](https://user-images.githubusercontent.com/26363699/95674919-1d675300-0bbc-11eb-8adc-e94214596ee9.png)

And also since we can handle when string is empty or null, the prop doesn't have to be required.