### PR TITLE
Enable to link into host details insights tab

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
         "skipWords": [
           "ansible",
           "donut",
+          "href",
           "ips",
           "ipv4",
           "jed",

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -72,6 +72,7 @@ module ForemanRhCloud
           context.add_pagelet :main_tabs,
             partial: 'hosts/insights_tab',
             name: _('Insights'),
+            id: 'insights',
             onlyif: proc { |host| host.insights }
         end
       end

--- a/webpack/InsightsHostDetailsTab/InsightsTab.js
+++ b/webpack/InsightsHostDetailsTab/InsightsTab.js
@@ -9,6 +9,11 @@ class InsightsHostDetailsTab extends React.Component {
   componentDidMount() {
     const { fetchHits, hostID } = this.props;
     fetchHits(hostID);
+
+    const { hash } = window.location;
+    if (hash === '#insights') {
+      document.querySelector(`li > a[href='${hash}']`).click();
+    }
   }
 
   render() {


### PR DESCRIPTION
got to `/hosts/{host-uuid}#insights`