### PR TITLE
Add rake tasks for report upload and generate + upload together

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,22 @@ In UI: Configure -> Inventory Upload -> Restart
 
 From command-line:
 
+    # generate and upload report for all organizations
+    /usr/sbin/foreman-rake rh_cloud_inventory:report:generate_upload
+
+    # generate and upload report for specific organization
+    export organization_id=1
+    /usr/sbin/foreman-rake rh_cloud_inventory:report:generate_upload
+
+    # generate report for specific organization (don't upload)
     export organization_id=1
     export target=/var/lib/foreman/red_hat_inventory/generated_reports/
     /usr/sbin/foreman-rake rh_cloud_inventory:report:generate
+
+    # upload previously generated report (needs to be named 'report_for_#{organization_id}.tar.gz')
+    export organization_id=1
+    export target=/var/lib/foreman/red_hat_inventory/generated_reports/
+    /usr/sbin/foreman-rake rh_cloud_inventory:report:upload
 
 #### Fetch hosts remediation data
 


### PR DESCRIPTION
Add two more rake tasks, to enable full plugin functionality from command line:
* `rh_cloud_inventory:report:generate_upload` will both generate and upload report
* `rh_cloud_inventory:report:upload` will upload report from directory specified by `target` environment variable; it very much requires to call `rh_cloud_inventory:report:generate` first

This is requested by Insights QE team, who are working on end-to-end FiFi scenarios, and they don't want to involve entire UI interaction machinery only to upload report.