### PR TITLE
New insights status for the host

### DIFF
--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -75,9 +75,9 @@ module InsightsCloud::Api
       return unless request.path == '/redhat_access/r/insights/platform/ingress/v1/upload' ||
                     request.path.include?('/redhat_access/r/insights/uploads/')
 
+      data = @cloud_response.code.to_s.start_with?('2')
       host_status = @host.get_status(InsightsClientReportStatus)
-      host_status.update(reported_at: DateTime.now)
-      host_status.update(status: host_status.to_status(data: @cloud_response.code.to_s.start_with?('2')))
+      host_status.update(reported_at: Time.now.utc, status: host_status.to_status(data: data))
     end
   end
 end

--- a/app/models/insights_client_report_status.rb
+++ b/app/models/insights_client_report_status.rb
@@ -36,7 +36,7 @@ class InsightsClientReportStatus < HostStatus::Status
     end
   end
 
-  def to_status(data: nil)
+  def to_status(data: false)
     if insights_param
       return REPORTING if data
       return in_interval? ? REPORTING : NO_REPORT
@@ -45,12 +45,14 @@ class InsightsClientReportStatus < HostStatus::Status
     data ? NOT_MANAGED_WITH_DATA : NOT_MANAGED
   end
 
+  private
+
   def in_interval?
     return false unless reported_at
     (Time.now.utc - reported_at).to_i < REPORT_INTERVAL.to_i
   end
 
   def insights_param
-    host.host_parameters.find_by(name: 'host_registration_insights')&.value
+    host.host_params_hash.dig('host_registration_insights', :value)
   end
 end

--- a/app/models/insights_client_report_status.rb
+++ b/app/models/insights_client_report_status.rb
@@ -1,0 +1,56 @@
+class InsightsClientReportStatus < HostStatus::Status
+  REPORT_INTERVAL = 48.hours
+
+  REPORTING             = 0 # host_registration_insights = true & getting data
+  NO_REPORT             = 1 # host_registration_insights = true & not getting data
+  NOT_MANAGED           = 2 # host_registration_insights = false
+  NOT_MANAGED_WITH_DATA = 3 # host_registration_insights = false & getting data
+
+  def self.status_name
+    N_('Insights')
+  end
+
+  def to_label(_options = {})
+    case status
+      when REPORTING
+        N_('Reporting')
+      when NO_REPORT
+        N_('Not reporting')
+      when NOT_MANAGED
+        N_('Not reporting (not set by registration)')
+      when NOT_MANAGED_WITH_DATA
+        N_('Reporting (not set by registration)')
+    end
+  end
+
+  def to_global(_options = {})
+    case status
+      when REPORTING
+        ::HostStatus::Global::OK
+      when NO_REPORT
+        ::HostStatus::Global::ERROR
+      when NOT_MANAGED
+        ::HostStatus::Global::OK
+      when NOT_MANAGED_WITH_DATA
+        ::HostStatus::Global::WARN
+    end
+  end
+
+  def to_status(data: nil)
+    if insights_param
+      return REPORTING if data
+      return in_interval? ? REPORTING : NO_REPORT
+    end
+
+    data ? NOT_MANAGED_WITH_DATA : NOT_MANAGED
+  end
+
+  def in_interval?
+    return false unless reported_at
+    (Time.now.utc - reported_at).to_i < REPORT_INTERVAL.to_i
+  end
+
+  def insights_param
+    host.host_param('host_registration_insights')
+  end
+end

--- a/app/models/insights_client_report_status.rb
+++ b/app/models/insights_client_report_status.rb
@@ -51,6 +51,6 @@ class InsightsClientReportStatus < HostStatus::Status
   end
 
   def insights_param
-    host.host_param('host_registration_insights')
+    host.host_parameters.find_by(name: 'host_registration_insights')&.value
   end
 end

--- a/app/subscribers/foreman_rh_cloud/insights_subscriber.rb
+++ b/app/subscribers/foreman_rh_cloud/insights_subscriber.rb
@@ -1,0 +1,9 @@
+module ForemanRhCloud
+  class InsightsSubscriber < ::Foreman::BaseSubscriber
+    def call(*args)
+      host = args.first.payload[:object]
+      host_status = host.get_status(InsightsClientReportStatus)
+      host_status.update(status: host_status.to_status)
+    end
+  end
+end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -78,7 +78,10 @@ module ForemanRhCloud
 
         register_global_js_file 'global'
 
-        register_custom_status(InventorySync::InventoryStatus)
+        register_custom_status InventorySync::InventoryStatus
+        register_custom_status InsightsClientReportStatus
+
+        subscribe 'host_created.event.foreman', ForemanRhCloud::InsightsSubscriber
 
         extend_page 'hosts/show' do |context|
           context.add_pagelet :main_tabs,

--- a/test/models/insights_client_report_status_test.rb
+++ b/test/models/insights_client_report_status_test.rb
@@ -1,0 +1,61 @@
+require 'test_plugin_helper'
+
+class InsightsClientReportStatusTest < ActiveSupport::TestCase
+  describe 'to_status' do
+    let(:host) { FactoryBot.create(:host, :managed) }
+
+    setup do
+      CommonParameter.where(name: 'host_registration_insights').destroy_all
+    end
+
+    test 'host_registration_insights = true & is getting data' do
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true, host: host)
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
+
+      assert_equal 0, host_status.to_status(data: true)
+    end
+
+    test 'host_registration_insights = true & no data in less than 48 hours' do
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true, host: host)
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
+      host_status.update(reported_at: 1.day.ago)
+      assert_equal 0, host_status.to_status
+    end
+
+    test 'host_registration_insights = true & no data in more than 48 hours' do
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true, host: host)
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
+      host_status.update(reported_at: 3.days.ago)
+      assert_equal 1, host_status.to_status
+    end
+
+    test 'host_registration_insights = false & no data' do
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: false, host: host)
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
+      assert_equal 2, host_status.to_status
+    end
+
+    test 'host_registration_insights = false & getting data' do
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: false, host: host)
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
+      assert_equal 3, host_status.to_status(data: true)
+    end
+
+    test 'host_registration_insights = nil & is getting data' do
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
+      assert_equal 3, host_status.to_status(data: true)
+    end
+
+    test 'host_registration_insights = nil & no data in less than 48 hours' do
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
+      host_status.update(reported_at: 1.day.ago)
+      assert_equal 2, host_status.to_status
+    end
+
+    test 'host_registration_insights = nil & no data in more than 48 hours' do
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
+      host_status.update(reported_at: 3.days.ago)
+      assert_equal 2, host_status.to_status
+    end
+  end
+end

--- a/test/models/insights_client_report_status_test.rb
+++ b/test/models/insights_client_report_status_test.rb
@@ -9,34 +9,34 @@ class InsightsClientReportStatusTest < ActiveSupport::TestCase
     end
 
     test 'host_registration_insights = true & is getting data' do
-      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true, host: host)
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true)
       host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
 
       assert_equal 0, host_status.to_status(data: true)
     end
 
     test 'host_registration_insights = true & no data in less than 48 hours' do
-      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true, host: host)
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true)
       host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
       host_status.update(reported_at: 1.day.ago)
       assert_equal 0, host_status.to_status
     end
 
     test 'host_registration_insights = true & no data in more than 48 hours' do
-      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true, host: host)
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true)
       host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
       host_status.update(reported_at: 3.days.ago)
       assert_equal 1, host_status.to_status
     end
 
     test 'host_registration_insights = false & no data' do
-      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: false, host: host)
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: false)
       host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
       assert_equal 2, host_status.to_status
     end
 
     test 'host_registration_insights = false & getting data' do
-      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: false, host: host)
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: false)
       host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
       assert_equal 3, host_status.to_status(data: true)
     end
@@ -55,6 +55,22 @@ class InsightsClientReportStatusTest < ActiveSupport::TestCase
     test 'host_registration_insights = nil & no data in more than 48 hours' do
       host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
       host_status.update(reported_at: 3.days.ago)
+      assert_equal 2, host_status.to_status
+    end
+
+    test 'override param on host level from `false` to `true`' do
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: false)
+      FactoryBot.create(:host_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true, host: host)
+
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
+      assert_equal 0, host_status.to_status(data: true)
+    end
+
+    test 'override param on host level from `true` to `false`' do
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true)
+      FactoryBot.create(:host_parameter, name: 'host_registration_insights', key_type: 'boolean', value: false, host: host)
+
+      host_status = Host.find_by_name(host.name).reload.get_status(InsightsClientReportStatus)
       assert_equal 2, host_status.to_status
     end
   end


### PR DESCRIPTION
```  
REPORTING             = 0 # host_registration_insights = true & getting data
NO_REPORT             = 1 # host_registration_insights = true & not getting data
NOT_MANAGED           = 2 # host_registration_insights = false
NOT_MANAGED_WITH_DATA = 3 # host_registration_insights = false & getting data
```
host_registration_insights | sending data? | Insights status
-- | -- | --
`nil` | yes | `Reporting (not set by registration)`
`nil` | no | `Not reporting (not set by registration)`
`TRUE` | yes | `Reporting`
`TRUE` | no | `Not reporting`
`FALSE` | yes | `Reporting (not set by registration)`
`FALSE` | no | `Not reporting (not set by registration)`


