### PR TITLE
Add empty states to insights page

### DIFF
--- a/app/controllers/insights_cloud/hits_controller.rb
+++ b/app/controllers/insights_cloud/hits_controller.rb
@@ -7,6 +7,7 @@ module InsightsCloud
 
       render json: {
         hits: hits,
+        hasToken: Setting[:rh_cloud_token].length > 1,
       }, status: :ok
     end
 

--- a/app/controllers/insights_cloud/settings_controller.rb
+++ b/app/controllers/insights_cloud/settings_controller.rb
@@ -9,6 +9,14 @@ module InsightsCloud
       render_setting(:insightsSyncEnabled, :allow_auto_insights_sync)
     end
 
+    def save_token_and_sync
+      token = Setting::RhCloud.find_by_name("rh_cloud_token")
+      token.value = params.require(:value)
+      token.save!
+      InsightsCloud::Async::InsightsFullSync.perform_now
+      redirect_to(:controller => "hits", :action => 'index')
+    end
+
     private
 
     def render_setting(node_name, setting)

--- a/app/models/setting/rh_cloud.rb
+++ b/app/models/setting/rh_cloud.rb
@@ -1,4 +1,6 @@
 class Setting::RhCloud < Setting
+  ::Setting::BLANK_ATTRS.concat %w{rh_cloud_token}
+
   def self.default_settings
     return unless ActiveRecord::Base.connection.table_exists?('settings')
     return unless super
@@ -7,7 +9,7 @@ class Setting::RhCloud < Setting
       set('allow_auto_insights_sync', N_('Allow recommendations synchronization from Red Hat cloud'), false),
       set('obfuscate_inventory_hostnames', N_('Obfuscate host names sent to Red Hat cloud'), false),
       set('obfuscate_inventory_ips', N_('Obfuscate ip addresses sent to Red Hat cloud'), false),
-      set('rh_cloud_token', N_('Authentication token to Red Hat cloud services. Used to authenticate requests to cloud APIs'), 'DEFAULT', N_('Red Hat Cloud token'), nil, encrypted: true),
+      set('rh_cloud_token', N_('Authentication token to Red Hat cloud services. Used to authenticate requests to cloud APIs'), nil, N_('Red Hat Cloud token'), nil, encrypted: true),
       set('exclude_installed_packages', N_('Exclude installed packages from Red Hat cloud inventory report'), false),
     ]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
       end
     end
     match 'hits/:host_id', to: 'hits#show', via: :get
+    post 'save_token_and_sync', to: 'settings#save_token_and_sync'
   end
 
   namespace :foreman_rh_cloud do

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "raf": "^3.4.0",
     "stylelint": "^9.3.0",
     "stylelint-config-standard": "^18.0.0",
-    "surge": "^0.20.3"
+    "surge": "^0.20.3",
+    "redux-mock-store": "^1.2.2"
   },
   "dependencies": {
     "jed": "^1.1.1",

--- a/webpack/InsightsCloudSync/Components/ErrorEmptyState.js
+++ b/webpack/InsightsCloudSync/Components/ErrorEmptyState.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { translate as __, sprintf } from 'foremanReact/common/I18n';
+import { selectError } from '../InsightsCloudSyncSelectors';
+
+export const ErrorEmptyState = () => {
+  const error = useSelector(selectError);
+  return (
+    <EmptyState variant={EmptyStateVariant.xl}>
+      <EmptyStateIcon icon={ExclamationCircleIcon} />
+      <EmptyStateBody>
+        <p>
+          {sprintf(
+            __(
+              'Something went wrong while getting the data, the server returned the following error: %s'
+            ),
+            error
+          )}
+        </p>
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};

--- a/webpack/InsightsCloudSync/Components/InsightsHeader/InsightsHeader.scss
+++ b/webpack/InsightsCloudSync/Components/InsightsHeader/InsightsHeader.scss
@@ -1,0 +1,4 @@
+.insights-header {
+  margin-bottom: '15px';
+  overflow: auto;
+}

--- a/webpack/InsightsCloudSync/Components/InsightsHeader/index.js
+++ b/webpack/InsightsCloudSync/Components/InsightsHeader/index.js
@@ -1,38 +1,14 @@
 import React from 'react';
-import { Icon } from 'patternfly-react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import InsightsSettings from '../InsightsSettings';
-import { cloudTokenSettingUrl } from '../../InsightsCloudSyncHelpers';
+import './InsightsHeader.scss';
 
 const InsightsHeader = () => (
-  <div className="insights-header" style={{ marginBottom: '15px' }}>
+  <div className="insights-header">
     <InsightsSettings />
     <p>
       {__(`Insights synchronization process is used to provide Insights
              recommendations output for hosts managed here`)}
-    </p>
-    <p>
-      {__(`1. Obtain an Red Hat API token: `)}
-      <a
-        href="https://access.redhat.com/management/api"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        access.redhat.com <Icon name="external-link" />
-      </a>
-      <br />
-      {__("2. Copy the token to 'Red Hat Cloud token' setting: ")}
-      <a
-        href={cloudTokenSettingUrl()}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {__('Red Hat Cloud token')} <Icon name="external-link" />
-      </a>
-      <br />
-      {__(
-        '3. Now you can synchronize recommendations manually using the "Sync now" button.'
-      )}
     </p>
   </div>
 );

--- a/webpack/InsightsCloudSync/Components/InsightsSettings/insightsSettings.scss
+++ b/webpack/InsightsCloudSync/Components/InsightsSettings/insightsSettings.scss
@@ -1,4 +1,5 @@
 .insights_settings {
+  margin-left: 10px;
   border: 1px solid #ededed;
   border-radius: 4px;
   padding: 10px;

--- a/webpack/InsightsCloudSync/Components/NoTokenEmptyState.js
+++ b/webpack/InsightsCloudSync/Components/NoTokenEmptyState.js
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  Button,
+  TextInput,
+  FormGroup,
+  GridItem,
+  Grid,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon, RocketIcon } from '@patternfly/react-icons';
+import { post } from 'foremanReact/redux/API';
+import { translate as __ } from 'foremanReact/common/I18n';
+import {
+  INSIGHTS_HITS_API_KEY,
+  INSIGHTS_SAVE_AND_SYNC_PATH,
+} from '../InsightsCloudSyncConstants';
+
+export const NoTokenEmptyState = () => {
+  const [token, setToken] = useState('');
+  const dispatch = useDispatch();
+  const onSave = () => {
+    dispatch(
+      post({
+        key: INSIGHTS_HITS_API_KEY,
+        url: INSIGHTS_SAVE_AND_SYNC_PATH,
+        params: { value: token },
+      })
+    );
+  };
+  return (
+    <EmptyState variant={EmptyStateVariant.xl}>
+      <EmptyStateIcon icon={RocketIcon} />
+      <EmptyStateBody>
+        <p>
+          {__(`Insights synchronization process is used to provide Insights
+               recommendations output for hosts managed here`)}
+        </p>
+        <p>
+          {__(
+            `To use recommendations please add a token to 'Red Hat Cloud token' setting here or in the settings page`
+          )}
+          <br />
+          {__(`You can obtain a Red Hat API token here: `)}
+          <a
+            href="https://access.redhat.com/management/api"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            access.redhat.com <ExternalLinkAltIcon />
+          </a>
+          <br />
+        </p>
+
+        <br />
+        <FormGroup
+          label={__('Red Hat Cloud token:')}
+          fieldId="input-cloud-token"
+        >
+          <Grid>
+            <GridItem span={3} />
+            <GridItem span={6}>
+              <TextInput
+                value={token}
+                type="password"
+                onChange={newValue => setToken(newValue)}
+                aria-label="input-cloud-token"
+              />
+            </GridItem>
+          </Grid>
+        </FormGroup>
+      </EmptyStateBody>
+      <Button variant="primary" onClick={onSave} isDisabled={!token.length}>
+        {__('Save setting and sync recommendations')}
+      </Button>
+    </EmptyState>
+  );
+};

--- a/webpack/InsightsCloudSync/Components/__tests__/ErrorEmptyState.test.js
+++ b/webpack/InsightsCloudSync/Components/__tests__/ErrorEmptyState.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { mount } from '@theforeman/test';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+
+import { ErrorEmptyState } from '../ErrorEmptyState';
+
+const mockStore = configureMockStore();
+const store = mockStore({});
+describe('ErrorEmptyState', () => {
+  it('render', () => {
+    const component = mount(
+      <Provider store={store}>
+        <ErrorEmptyState />
+      </Provider>
+    );
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/webpack/InsightsCloudSync/Components/__tests__/InsightsHeader.test.js
+++ b/webpack/InsightsCloudSync/Components/__tests__/InsightsHeader.test.js
@@ -1,0 +1,10 @@
+import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
+
+import InsightsHeader from '../InsightsHeader';
+
+const fixtures = {
+  render: {},
+};
+
+describe('InsightsHeader', () =>
+  testComponentSnapshotsWithFixtures(InsightsHeader, fixtures));

--- a/webpack/InsightsCloudSync/Components/__tests__/NoTokenEmptyState.test.js
+++ b/webpack/InsightsCloudSync/Components/__tests__/NoTokenEmptyState.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { mount } from '@theforeman/test';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+
+import { NoTokenEmptyState } from '../NoTokenEmptyState';
+
+const mockStore = configureMockStore();
+const store = mockStore({});
+describe('NoTokenEmptyState', () => {
+  it('render', () => {
+    const component = mount(
+      <Provider store={store}>
+        <NoTokenEmptyState />
+      </Provider>
+    );
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/webpack/InsightsCloudSync/Components/__tests__/__snapshots__/ErrorEmptyState.test.js.snap
+++ b/webpack/InsightsCloudSync/Components/__tests__/__snapshots__/ErrorEmptyState.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorEmptyState render 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <ErrorEmptyState>
+    <EmptyState
+      variant="xl"
+    >
+      <div
+        className="pf-c-empty-state pf-m-xl"
+      >
+        <div
+          className="pf-c-empty-state__content"
+        >
+          <EmptyStateIcon
+            icon={[Function]}
+          >
+            <ExclamationCircleIcon
+              aria-hidden="true"
+              className="pf-c-empty-state__icon"
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden="true"
+                aria-labelledby={null}
+                className="pf-c-empty-state__icon"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                />
+              </svg>
+            </ExclamationCircleIcon>
+          </EmptyStateIcon>
+          <EmptyStateBody>
+            <div
+              className="pf-c-empty-state__body"
+            >
+              <p>
+                Something went wrong while getting the data, the server returned the following error: [object Object]
+              </p>
+            </div>
+          </EmptyStateBody>
+        </div>
+      </div>
+    </EmptyState>
+  </ErrorEmptyState>
+</Provider>
+`;

--- a/webpack/InsightsCloudSync/Components/__tests__/__snapshots__/InsightsHeader.test.js.snap
+++ b/webpack/InsightsCloudSync/Components/__tests__/__snapshots__/InsightsHeader.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InsightsHeader render 1`] = `
+<div
+  className="insights-header"
+>
+  <Connect(InsightsSettings) />
+  <p>
+    Insights synchronization process is used to provide Insights
+             recommendations output for hosts managed here
+  </p>
+</div>
+`;

--- a/webpack/InsightsCloudSync/Components/__tests__/__snapshots__/NoTokenEmptyState.test.js.snap
+++ b/webpack/InsightsCloudSync/Components/__tests__/__snapshots__/NoTokenEmptyState.test.js.snap
@@ -1,0 +1,214 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoTokenEmptyState render 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <NoTokenEmptyState>
+    <EmptyState
+      variant="xl"
+    >
+      <div
+        className="pf-c-empty-state pf-m-xl"
+      >
+        <div
+          className="pf-c-empty-state__content"
+        >
+          <EmptyStateIcon
+            icon={[Function]}
+          >
+            <RocketIcon
+              aria-hidden="true"
+              className="pf-c-empty-state__icon"
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden="true"
+                aria-labelledby={null}
+                className="pf-c-empty-state__icon"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M505.12019,19.09375c-1.18945-5.53125-6.65819-11-12.207-12.1875C460.716,0,435.507,0,410.40747,0,307.17523,0,245.26909,55.20312,199.05238,128H94.83772c-16.34763.01562-35.55658,11.875-42.88664,26.48438L2.51562,253.29688A28.4,28.4,0,0,0,0,264a24.00867,24.00867,0,0,0,24.00582,24H127.81618l-22.47457,22.46875c-11.36521,11.36133-12.99607,32.25781,0,45.25L156.24582,406.625c11.15623,11.1875,32.15619,13.15625,45.27726,0l22.47457-22.46875V488a24.00867,24.00867,0,0,0,24.00581,24,28.55934,28.55934,0,0,0,10.707-2.51562l98.72834-49.39063c14.62888-7.29687,26.50776-26.5,26.50776-42.85937V312.79688c72.59753-46.3125,128.03493-108.40626,128.03493-211.09376C512.07526,76.5,512.07526,51.29688,505.12019,19.09375ZM384.04033,168A40,40,0,1,1,424.05,128,40.02322,40.02322,0,0,1,384.04033,168Z"
+                />
+              </svg>
+            </RocketIcon>
+          </EmptyStateIcon>
+          <EmptyStateBody>
+            <div
+              className="pf-c-empty-state__body"
+            >
+              <p>
+                Insights synchronization process is used to provide Insights
+               recommendations output for hosts managed here
+              </p>
+              <p>
+                To use recommendations please add a token to 'Red Hat Cloud token' setting here or in the settings page
+                <br />
+                You can obtain a Red Hat API token here: 
+                <a
+                  href="https://access.redhat.com/management/api"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  access.redhat.com 
+                  <ExternalLinkAltIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      />
+                    </svg>
+                  </ExternalLinkAltIcon>
+                </a>
+                <br />
+              </p>
+              <br />
+              <FormGroup
+                fieldId="input-cloud-token"
+                label="Red Hat Cloud token:"
+              >
+                <div
+                  className="pf-c-form__group"
+                >
+                  <div
+                    className="pf-c-form__group-label"
+                  >
+                    <label
+                      className="pf-c-form__label"
+                      htmlFor="input-cloud-token"
+                    >
+                      <span
+                        className="pf-c-form__label-text"
+                      >
+                        Red Hat Cloud token:
+                      </span>
+                    </label>
+                     
+                  </div>
+                  <div
+                    className="pf-c-form__group-control"
+                  >
+                    <Grid>
+                      <div
+                        className="pf-l-grid"
+                      >
+                        <GridItem
+                          span={3}
+                        >
+                          <div
+                            className="pf-l-grid__item pf-m-3-col"
+                          />
+                        </GridItem>
+                        <GridItem
+                          span={6}
+                        >
+                          <div
+                            className="pf-l-grid__item pf-m-6-col"
+                          >
+                            <TextInput
+                              aria-label="input-cloud-token"
+                              onChange={[Function]}
+                              type="password"
+                              value=""
+                            >
+                              <TextInputBase
+                                aria-label="input-cloud-token"
+                                className=""
+                                innerRef={null}
+                                isDisabled={false}
+                                isLeftTruncated={false}
+                                isReadOnly={false}
+                                isRequired={false}
+                                onChange={[Function]}
+                                type="password"
+                                validated="default"
+                                value=""
+                              >
+                                <input
+                                  aria-invalid={false}
+                                  aria-label="input-cloud-token"
+                                  className="pf-c-form-control"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  readOnly={false}
+                                  required={false}
+                                  type="password"
+                                  value=""
+                                />
+                              </TextInputBase>
+                            </TextInput>
+                          </div>
+                        </GridItem>
+                      </div>
+                    </Grid>
+                  </div>
+                </div>
+              </FormGroup>
+            </div>
+          </EmptyStateBody>
+          <Button
+            isDisabled={true}
+            onClick={[Function]}
+            variant="primary"
+          >
+            <button
+              aria-disabled={true}
+              aria-label={null}
+              className="pf-c-button pf-m-primary pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-primary-1"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={null}
+              type="button"
+            >
+              Save setting and sync recommendations
+            </button>
+          </Button>
+        </div>
+      </div>
+    </EmptyState>
+  </NoTokenEmptyState>
+</Provider>
+`;

--- a/webpack/InsightsCloudSync/InsightsCloudSync.js
+++ b/webpack/InsightsCloudSync/InsightsCloudSync.js
@@ -2,14 +2,18 @@
 import React, { useEffect } from 'react';
 import { Button } from 'patternfly-react';
 import PropTypes from 'prop-types';
+import { EmptyState, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
 import { useForemanSettings } from 'foremanReact/Root/Context/ForemanContext';
+import { STATUS } from 'foremanReact/constants';
 import InsightsHeader from './Components/InsightsHeader';
 import {
   INSIGHTS_SYNC_PAGE_TITLE,
   INSIGHTS_SEARCH_PROPS,
 } from './InsightsCloudSyncConstants';
+import { NoTokenEmptyState } from './Components/NoTokenEmptyState';
+import { ErrorEmptyState } from './Components/ErrorEmptyState';
 
 const InsightsCloudSync = ({
   syncInsights,
@@ -17,6 +21,8 @@ const InsightsCloudSync = ({
   fetchInsights,
   page,
   perPage: urlPerPage,
+  hasToken,
+  status,
 }) => {
   const { perPage: appPerPage } = useForemanSettings();
   const perPage = urlPerPage || appPerPage;
@@ -25,7 +31,38 @@ const InsightsCloudSync = ({
   useEffect(() => {
     fetchInsights({ page, perPage, searchQuery: query });
   }, []);
+  if (status === STATUS.ERROR) {
+    return (
+      <PageLayout
+        header={`${INSIGHTS_SYNC_PAGE_TITLE} ${__('ERROR')}`}
+        searchable={false}
+      >
+        <ErrorEmptyState />
+      </PageLayout>
+    );
+  }
 
+  // TODO: add here && !data.length
+  if (status === STATUS.PENDING) {
+    return (
+      <PageLayout
+        header={`${INSIGHTS_SYNC_PAGE_TITLE} ${__('Loading')}`}
+        searchable={false}
+      >
+        <EmptyState>
+          <EmptyStateIcon variant="container" component={Spinner} />
+        </EmptyState>
+      </PageLayout>
+    );
+  }
+
+  if (!hasToken) {
+    return (
+      <PageLayout header={INSIGHTS_SYNC_PAGE_TITLE} searchable={false}>
+        <NoTokenEmptyState />
+      </PageLayout>
+    );
+  }
   return (
     <PageLayout
       searchable
@@ -53,12 +90,16 @@ InsightsCloudSync.propTypes = {
   page: PropTypes.number,
   perPage: PropTypes.number,
   query: PropTypes.string,
+  hasToken: PropTypes.bool,
+  status: PropTypes.string,
 };
 
 InsightsCloudSync.defaultProps = {
   page: 1,
   perPage: null,
   query: '',
+  hasToken: false,
+  status: STATUS.PENDING,
 };
 
 export default InsightsCloudSync;

--- a/webpack/InsightsCloudSync/InsightsCloudSync.test.js
+++ b/webpack/InsightsCloudSync/InsightsCloudSync.test.js
@@ -5,8 +5,21 @@ import InsightsCloudSync from './InsightsCloudSync';
 
 const fixtures = {
   render: {
+    status: 'RESOLVED',
     syncInsights: noop,
+    fetchInsights: noop,
     query: '',
+    hasToken: true,
+  },
+  'render no token': {
+    status: 'RESOLVED',
+    syncInsights: noop,
+    fetchInsights: noop,
+    hasToken: false,
+  },
+  'render error': {
+    status: 'ERROR',
+    syncInsights: noop,
     fetchInsights: noop,
   },
 };

--- a/webpack/InsightsCloudSync/InsightsCloudSyncConstants.js
+++ b/webpack/InsightsCloudSync/InsightsCloudSyncConstants.js
@@ -6,6 +6,9 @@ export const INSIGHTS_CLOUD_SYNC_SUCCESS = 'INSIGHTS_CLOUD_SYNC_SUCCESS';
 export const INSIGHTS_SYNC_PAGE_TITLE = __('Red Hat Insights');
 export const INSIGHTS_PATH = foremanUrl('/foreman_rh_cloud/insights_cloud');
 export const INSIGHTS_HITS_PATH = '/insights_cloud/hits';
+export const INSIGHTS_SAVE_AND_SYNC_PATH = foremanUrl(
+  '/insights_cloud/save_token_and_sync'
+);
 export const INSIGHTS_HITS_API_KEY = 'INSIGHTS_HITS';
 export const INSIGHTS_SEARCH_PROPS = {
   ...getControllerSearchProps('/insights_cloud/hits'),

--- a/webpack/InsightsCloudSync/InsightsCloudSyncSelectors.js
+++ b/webpack/InsightsCloudSync/InsightsCloudSyncSelectors.js
@@ -1,5 +1,11 @@
 import URI from 'urijs';
 import { selectRouterLocation } from 'foremanReact/routes/RouterSelector';
+import {
+  selectAPIResponse,
+  selectAPIStatus,
+  selectAPIError,
+} from 'foremanReact/redux/API/APISelectors';
+import { INSIGHTS_HITS_API_KEY } from './InsightsCloudSyncConstants';
 
 export const selectQuery = state => selectRouterLocation(state).query;
 
@@ -23,3 +29,12 @@ export const selectQueryParams = state => ({
   perPage: selectPerPage(state),
   searchQuery: selectSearch(state),
 });
+
+export const selectHasToken = state =>
+  selectAPIResponse(state, INSIGHTS_HITS_API_KEY).hasToken;
+
+export const selectStatus = state =>
+  selectAPIStatus(state, INSIGHTS_HITS_API_KEY);
+
+export const selectError = state =>
+  selectAPIError(state, INSIGHTS_HITS_API_KEY);

--- a/webpack/InsightsCloudSync/__snapshots__/InsightsCloudSync.test.js.snap
+++ b/webpack/InsightsCloudSync/__snapshots__/InsightsCloudSync.test.js.snap
@@ -41,3 +41,21 @@ exports[`InsightsCloudSync render 1`] = `
   </p>
 </PageLayout>
 `;
+
+exports[`InsightsCloudSync render error 1`] = `
+<PageLayout
+  header="Red Hat Insights ERROR"
+  searchable={false}
+>
+  <ErrorEmptyState />
+</PageLayout>
+`;
+
+exports[`InsightsCloudSync render no token 1`] = `
+<PageLayout
+  header="Red Hat Insights"
+  searchable={false}
+>
+  <NoTokenEmptyState />
+</PageLayout>
+`;

--- a/webpack/InsightsCloudSync/index.js
+++ b/webpack/InsightsCloudSync/index.js
@@ -8,6 +8,8 @@ import {
   selectPage,
   selectPerPage,
   selectSearch,
+  selectHasToken,
+  selectStatus,
 } from './InsightsCloudSyncSelectors';
 
 // map state to props
@@ -15,6 +17,8 @@ const mapStateToProps = state => ({
   query: selectSearch(state),
   page: selectPage(state),
   perPage: selectPerPage(state),
+  hasToken: selectHasToken(state),
+  status: selectStatus(state),
 });
 
 // map action dispatchers to props

--- a/webpack/__mocks__/foremanReact/redux/API/APISelectors.js
+++ b/webpack/__mocks__/foremanReact/redux/API/APISelectors.js
@@ -1,0 +1,10 @@
+export const selectAPIResponse = (state, key) => ({
+  data: {
+    text: 'some-data',
+    key,
+  },
+});
+
+export const selectAPIStatus = (state, key) => 'PENDING';
+export const selectAPIByKey = (state, key) => state[key];
+export const selectAPIError = (state, key) => ({ error: `${key} ERRROR` });

--- a/webpack/__mocks__/foremanReact/redux/API/index.js
+++ b/webpack/__mocks__/foremanReact/redux/API/index.js
@@ -1,0 +1,7 @@
+export default {
+  get: jest.fn(),
+  put: jest.fn(),
+  post: jest.fn(),
+  delete: jest.fn(),
+  patch: jest.fn(),
+};

--- a/webpack/__mocks__/foremanReact/routes/RouterSelector.js
+++ b/webpack/__mocks__/foremanReact/routes/RouterSelector.js
@@ -1,0 +1,1 @@
+export const selectRouterLocation = () => ({ query: 'some-query' });


### PR DESCRIPTION
Depends on: https://github.com/theforeman/foreman_rh_cloud/pull/421
Added the following empty states:
- Loading: when the table pr will be available I'll change the condition to: `status === 'PENDING' && !data.length`
![Screenshot from 2020-12-22 16-53-24](https://user-images.githubusercontent.com/30431079/102901428-463a7d00-4476-11eb-80c8-1735da6c1513.png)
- Error: shows the error that was received
![Screenshot from 2020-12-22 16-53-34](https://user-images.githubusercontent.com/30431079/102901418-42a6f600-4476-11eb-9242-43c23af3c40b.png)

- No token: if the token length is less than 1 then the user is shown instructions on how to add a token:
![Screenshot from 2020-12-22 16-49-47](https://user-images.githubusercontent.com/30431079/102901275-15f2de80-4476-11eb-983d-eca287ab56b9.png)

Also changed the default value for the token setting to be empty
