### PR TITLE
change deprecated api path to the new one

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,8 @@
           "repo",
           "theforeman",
           "tooltip",
-          "unmount"
+          "unmount",
+          "redux"
         ],
         "minLength": 3
       }

--- a/webpack/ForemanInventoryUpload/Components/AccountList/AccountListActions.js
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/AccountListActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { inventoryUrl } from '../../ForemanInventoryHelpers';
 import {

--- a/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/AccountListActions.test.js
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/AccountListActions.test.js
@@ -1,5 +1,5 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import {
   fetchAccountsStatus,
   startAccountStatusPolling,
@@ -12,7 +12,7 @@ import {
 } from '../AccountList.fixtures';
 import { accountID, activeTab } from '../../Dashboard/Dashboard.fixtures';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.get.mockImplementation(async () => fetchAccountsStatusResponse);
 
 const fixtures = {

--- a/webpack/ForemanInventoryUpload/Components/AutoUploadSwitcher/AutoUploadSwitcherActions.js
+++ b/webpack/ForemanInventoryUpload/Components/AutoUploadSwitcher/AutoUploadSwitcherActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { inventoryUrl } from '../../ForemanInventoryHelpers';
 import { AUTO_UPLOAD_TOGGLE } from './AutoUploadSwitcherConstants';

--- a/webpack/ForemanInventoryUpload/Components/AutoUploadSwitcher/__tests__/AutoUploadSwitcherActions.test.js
+++ b/webpack/ForemanInventoryUpload/Components/AutoUploadSwitcher/__tests__/AutoUploadSwitcherActions.test.js
@@ -1,12 +1,12 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { handleToggle } from '../AutoUploadSwitcherActions';
 import {
   handleToggleResponse,
   currentAutoUploadEnabled,
 } from '../AutoUploadSwitcher.fixtures';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.post.mockImplementation(async () => handleToggleResponse);
 
 const fixtures = {

--- a/webpack/ForemanInventoryUpload/Components/Dashboard/DashboardActions.js
+++ b/webpack/ForemanInventoryUpload/Components/Dashboard/DashboardActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { selectActiveTab } from './DashboardSelectors';
 import { inventoryUrl } from '../../ForemanInventoryHelpers';
 import {

--- a/webpack/ForemanInventoryUpload/Components/Dashboard/__tests__/DashboardActions.test.js
+++ b/webpack/ForemanInventoryUpload/Components/Dashboard/__tests__/DashboardActions.test.js
@@ -1,5 +1,5 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import {
   startPolling,
   stopPolling,
@@ -16,7 +16,7 @@ import {
 } from '../Dashboard.fixtures';
 import { rhCloudStateWrapper } from '../../../../ForemanRhCloudTestHelpers';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.get.mockImplementation(() => serverMock);
 
 const runWithGetState = (state, action, params) => dispatch => {

--- a/webpack/ForemanInventoryUpload/Components/ExcludePackagesSwitcher/ExcludePackagesSwitcherActions.js
+++ b/webpack/ForemanInventoryUpload/Components/ExcludePackagesSwitcher/ExcludePackagesSwitcherActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { inventoryUrl } from '../../ForemanInventoryHelpers';
 import { EXCLUDE_PACKAGES_TOGGLE } from './ExcludePackagesSwitcherConstants';

--- a/webpack/ForemanInventoryUpload/Components/ExcludePackagesSwitcher/__tests__/ExcludePackagesSwitcherActions.test.js
+++ b/webpack/ForemanInventoryUpload/Components/ExcludePackagesSwitcher/__tests__/ExcludePackagesSwitcherActions.test.js
@@ -1,9 +1,9 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { handleToggle } from '../ExcludePackagesSwitcherActions';
 import { handleToggleResponse } from '../ExcludePackagesSwitcher.fixtures';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.post.mockImplementation(async () => handleToggleResponse);
 
 const fixtures = {

--- a/webpack/ForemanInventoryUpload/Components/ExcludePackagesSwitcher/__tests__/integration.test.js
+++ b/webpack/ForemanInventoryUpload/Components/ExcludePackagesSwitcher/__tests__/integration.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { IntegrationTestHelper } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import ExcludePackagesSwitcher from '../index';
 import reducers from '../../../../ForemanRhCloudReducers';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.post.mockImplementation(async () => ({
   data: {
     excludePackages: false,

--- a/webpack/ForemanInventoryUpload/Components/HostObfuscationSwitcher/HostObfuscationSwitcherActions.js
+++ b/webpack/ForemanInventoryUpload/Components/HostObfuscationSwitcher/HostObfuscationSwitcherActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { inventoryUrl } from '../../ForemanInventoryHelpers';
 import { HOST_OBFUSCATION_TOGGLE } from './HostObfuscationSwitcherConstants';

--- a/webpack/ForemanInventoryUpload/Components/HostObfuscationSwitcher/__tests__/HostObfuscationSwitcherActions.test.js
+++ b/webpack/ForemanInventoryUpload/Components/HostObfuscationSwitcher/__tests__/HostObfuscationSwitcherActions.test.js
@@ -1,12 +1,12 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { handleToggle } from '../HostObfuscationSwitcherActions';
 import {
   handleToggleResponse,
   currentHostObfuscationEnabled,
 } from '../HostObfuscationSwitcher.fixtures';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.post.mockImplementation(async () => handleToggleResponse);
 
 const fixtures = {

--- a/webpack/ForemanInventoryUpload/Components/IpsObfuscationSwitcher/IpsObfuscationSwitcherActions.js
+++ b/webpack/ForemanInventoryUpload/Components/IpsObfuscationSwitcher/IpsObfuscationSwitcherActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { inventoryUrl } from '../../ForemanInventoryHelpers';
 import { IPS_OBFUSCATION_TOGGLE } from './IpsObfuscationSwitcherConstants';

--- a/webpack/ForemanInventoryUpload/Components/IpsObfuscationSwitcher/__tests__/IpsObfuscationSwitcherActions.test.js
+++ b/webpack/ForemanInventoryUpload/Components/IpsObfuscationSwitcher/__tests__/IpsObfuscationSwitcherActions.test.js
@@ -1,9 +1,9 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { handleToggle } from '../IpsObfuscationSwitcherActions';
 import { handleToggleResponse } from '../IpsObfuscationSwitcher.fixtures';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.post.mockImplementation(async () => handleToggleResponse);
 
 const fixtures = {

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButtonActions.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButtonActions.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { inventoryUrl } from '../../../../ForemanInventoryHelpers';
 import Toast from './components/Toast';

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/__tests__/SyncButtonActions.test.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/__tests__/SyncButtonActions.test.js
@@ -1,9 +1,9 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { handleSync } from '../SyncButtonActions';
 import { successResponse } from './SyncButtonFixtures';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.post.mockImplementation(async () => successResponse);
 
 const fixtures = {

--- a/webpack/InsightsCloudSync/Components/InsightsSettings/InsightsSettingsActions.js
+++ b/webpack/InsightsCloudSync/Components/InsightsSettings/InsightsSettingsActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { insightsCloudUrl } from '../../InsightsCloudSyncHelpers';
 import {

--- a/webpack/InsightsCloudSync/Components/InsightsSettings/__tests__/InsightsSettingsActions.test.js
+++ b/webpack/InsightsCloudSync/Components/InsightsSettings/__tests__/InsightsSettingsActions.test.js
@@ -1,5 +1,5 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import {
   getInsightsSyncSettings,
   setInsightsSyncEnabled,
@@ -10,7 +10,7 @@ const serverMock = {
   data: { insightsSyncEnabled: true },
 };
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.get.mockImplementation(() => serverMock);
 API.patch.mockImplementation(() => serverMock);
 

--- a/webpack/InsightsCloudSync/InsightsCloudSyncActions.js
+++ b/webpack/InsightsCloudSync/InsightsCloudSyncActions.js
@@ -1,6 +1,5 @@
 import { push } from 'connected-react-router';
-import API from 'foremanReact/API';
-import { get } from 'foremanReact/redux/API';
+import { API, get } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { stringifyParams } from 'foremanReact/common/urlHelpers';
 import { insightsCloudUrl } from './InsightsCloudSyncHelpers';

--- a/webpack/InsightsHostDetailsTab/InsightsTabActions.js
+++ b/webpack/InsightsHostDetailsTab/InsightsTabActions.js
@@ -1,4 +1,4 @@
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/redux/actions/toasts';
 import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
 import {

--- a/webpack/InsightsHostDetailsTab/__tests__/InsightsTabActions.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/InsightsTabActions.test.js
@@ -1,9 +1,9 @@
 import { testActionSnapshotWithFixtures } from '@theforeman/test';
-import API from 'foremanReact/API';
+import { API } from 'foremanReact/redux/API';
 import { fetchHits } from '../InsightsTabActions';
 import { hostID, hits } from './InsightsTab.fixtures';
 
-jest.mock('foremanReact/API');
+jest.mock('foremanReact/redux/API');
 API.get.mockImplementation(async () => ({ data: { hits } }));
 
 const fixtures = {

--- a/webpack/__mocks__/foremanReact/redux/API.js
+++ b/webpack/__mocks__/foremanReact/redux/API.js
@@ -1,4 +1,4 @@
-export default {
+export const API = {
   get: jest.fn(),
   put: jest.fn(),
   post: jest.fn(),


### PR DESCRIPTION
`'foremanReact/API'` is deprecated since foreman 1.24