### PR TITLE
Avoid host base including RhCloudHost module

### DIFF
--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -81,7 +81,6 @@ module ForemanRhCloud
       ::Katello::UINotifications::Subscriptions::ManifestImportSuccess.include ForemanInventoryUpload::Notifications::ManifestImportSuccessNotificationOverride if defined?(Katello)
 
       ::Host::Managed.include RhCloudHost
-      ::Host::Base.include RhCloudHost
     end
 
     initializer "foreman_rh_cloud.set_dynflow.config.on_init", :before => :finisher_hook do |_app|


### PR DESCRIPTION
There are some errors related to the fact we want to use the managed host and not the base host.