### PR TITLE
update theforeman npm packages to 4.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,27 +22,26 @@
     "url": "http://projects.theforeman.org/projects/foreman_rh_cloud/issues"
   },
   "peerDependencies": {
-    "@theforeman/vendor": ">= 4.0.2"
+    "@theforeman/vendor": "~4.14.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.7.0",
-    "@theforeman/builder": "^4.0.2",
-    "@theforeman/stories": "^4.0.2",
-    "@theforeman/test": "^4.0.2",
-    "@theforeman/vendor-dev": "^4.0.2",
-    "@theforeman/eslint-plugin-foreman": "^4.0.2",
-    "babel-eslint": "^10.0.0",
-    "eslint": "^6.7.2",
-    "eslint-plugin-spellcheck": "^0.0.17",
-    "prettier": "^1.13.5",
-    "raf": "^3.4.0",
-    "stylelint": "^9.3.0",
-    "stylelint-config-standard": "^18.0.0",
-    "surge": "^0.20.3",
-    "redux-mock-store": "^1.2.2"
+    "@babel/core": "~7.7.0",
+    "@theforeman/builder": "~4.14.0",
+    "@theforeman/stories": "~4.14.0",
+    "@theforeman/test": "~4.14.0",
+    "@theforeman/vendor-dev": "~4.14.0",
+    "@theforeman/eslint-plugin-foreman": "~4.14.0",
+    "babel-eslint": "~10.0.0",
+    "eslint": "~6.7.2",
+    "eslint-plugin-spellcheck": "~0.0.17",
+    "prettier": "~1.19.1",
+    "stylelint": "~9.3.0",
+    "stylelint-config-standard": "~18.0.0",
+    "surge": "~0.20.3",
+    "redux-mock-store": "~1.2.2"
   },
   "dependencies": {
-    "jed": "^1.1.1",
-    "react-intl": "^2.8.0"
+    "jed": "~1.1.1",
+    "react-intl": "~2.8.0"
   }
 }


### PR DESCRIPTION
Matching foreman 2.3 packages.
vendor 4.0 doesn't have pf4, 4.14 has pf4 
* updated prettier to match foreman 
* Removed unused package raf