### PR TITLE
Change compression algo for reports to xz

### DIFF
--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -48,7 +48,7 @@ module ForemanInventoryUpload
   end
 
   def self.facts_archive_name(organization)
-    "report_for_#{organization}.tar.gz"
+    "report_for_#{organization}.tar.xz"
   end
 
   def self.upload_url

--- a/lib/foreman_inventory_upload/generators/archived_report.rb
+++ b/lib/foreman_inventory_upload/generators/archived_report.rb
@@ -28,7 +28,7 @@ module ForemanInventoryUpload
 
           @logger.info 'Archiving generated report'
           # success = system('tar', '-zcvf', @target, '-C', tmpdir, '.')
-          Open3.popen2e('tar', '-zcvf', @target, '-C', tmpdir, '.') do |_in, out, wait_thr|
+          Open3.popen2e('tar', '-Jcvf', @target, '-C', tmpdir, '.') do |_in, out, wait_thr|
             @logger.info("tar: #{out.read}")
 
             if wait_thr.value.success?


### PR DESCRIPTION
the default gzip files become too large, let's change it to xz that should compress the files much more efficiently.

This can go in once https://github.com/quipucords/yupana/pull/336 goes in.