### PR TITLE
Add css overflow to terminal text

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/Terminal/terminal.scss
+++ b/webpack/ForemanInventoryUpload/Components/Terminal/terminal.scss
@@ -10,6 +10,7 @@
     font-family: monospace;
     font-size: 16px;
     color: #22da26;
+    overflow-wrap: anywhere;
 
     &.terminal_error {
       color: #f00;


### PR DESCRIPTION
When a user opens the accordion the page "jumps" and gets bigger because the terminal didn't wrap at the correct place and a horizontal scroll was added.

before:
![Screenshot from 2021-01-18 18-48-09](https://user-images.githubusercontent.com/30431079/104943167-ffc93700-59bd-11eb-9d89-2f997b3ecc48.png)
after:
![Screenshot from 2021-01-18 18-48-00](https://user-images.githubusercontent.com/30431079/104943169-0061cd80-59be-11eb-908b-c15f8301409d.png)
 