### PR TITLE
Add select all to url in insights

### DIFF
--- a/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTable.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTable.js
@@ -61,7 +61,7 @@ const InsightsTable = ({
         className="recommendations-table"
         aria-label="Recommendations Table"
         onSelect={(_event, isSelected, rowId) =>
-          onTableSelect(_event, isSelected, rowId, rows, selectedIds)
+          onTableSelect(isSelected, rowId, rows, selectedIds)
         }
         canSelectAll
         sortBy={{ index: getSortColumnIndex(sortBy), direction: sortOrder }}

--- a/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTableSelectors.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTableSelectors.js
@@ -32,6 +32,7 @@ export const selectQueryParams = state => ({
   query: selectSearch(state),
   sortBy: selectSortBy(state),
   sortOrder: selectSortOrder(state),
+  isSelectAll: selectIsAllSelectedQuery(state),
 });
 
 export const selectStatus = state =>
@@ -63,6 +64,9 @@ export const selectSelectedIds = state =>
 
 export const selectIsAllSelected = state =>
   selectInsightsCloudTable(state).isAllSelected || false;
+
+export const selectIsAllSelectedQuery = state =>
+  selectQuery(state).select_all === 'true';
 
 export const selectShowSelectAllAlert = state =>
   selectInsightsCloudTable(state).showSelectAllAlert || false;

--- a/webpack/InsightsCloudSync/Components/InsightsTable/SelectAllAlert.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/SelectAllAlert.js
@@ -18,10 +18,7 @@ const SelectAllAlert = ({
       <Alert
         isInline
         variant="info"
-        title={sprintf(
-          'All %s recommendations on this page are selected.',
-          selectedCount
-        )}
+        title={sprintf('Recommendations selected: %s.', selectedCount)}
         actionLinks={
           <AlertActionLink onClick={selectAll}>
             {__('Select recommendations from all pages')}

--- a/webpack/InsightsCloudSync/Components/InsightsTable/__tests__/InsightsTableActions.test.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/__tests__/InsightsTableActions.test.js
@@ -1,0 +1,48 @@
+import { testActionSnapshotWithFixtures } from '@theforeman/test';
+import API from 'foremanReact/redux/API';
+import {
+  fetchInsights,
+  setSelectAllAlert,
+  selectByIds,
+  setSelectAll,
+  selectAll,
+  clearAllSelection,
+} from '../InsightsTableActions';
+import { hits } from './fixtures';
+
+jest.mock('foremanReact/redux/API', () => jest.fn());
+API.get = jest.fn(({ handleSuccess, ...action }) => {
+  handleSuccess({ data: { hits } });
+  return { type: 'get', ...action };
+});
+
+const runWithGetState = (state, action, params) => dispatch => {
+  const getState = () => ({
+    router: {
+      location: {
+        query: {
+          page: '1',
+          per_page: '7',
+          search: '',
+          sort_by: '',
+          sort_order: '',
+          select_all: 'true',
+        },
+      },
+    },
+  });
+  action(params)(dispatch, getState);
+};
+
+const fixtures = {
+  'should fetchInsights': () =>
+    runWithGetState({}, fetchInsights, { page: 2, perPage: 7 }),
+  'should setSelectAllAlert true': () => setSelectAllAlert(true),
+  'should selectByIds': () => selectByIds({ 1: true, 5: true }),
+  'should setSelectAll false': () => setSelectAll(false),
+  'should selectAll': () => selectAll(),
+  'should clearAllSelection': () => clearAllSelection(),
+};
+
+describe('insights table actions', () =>
+  testActionSnapshotWithFixtures(fixtures));

--- a/webpack/InsightsCloudSync/Components/InsightsTable/__tests__/__snapshots__/InsightsTableActions.test.js.snap
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/__tests__/__snapshots__/InsightsTableActions.test.js.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`insights table actions should clearAllSelection 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "selectedIds": Object {},
+      },
+      "type": "INSIGHTS_SET_SELECTED_IDS",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "showSelectAllAlert": false,
+      },
+      "type": "INSIGHTS_SET_SELECT_ALL_ALERT",
+    },
+  ],
+  Array [
+    [Function],
+  ],
+]
+`;
+
+exports[`insights table actions should fetchInsights 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "selectedIds": Object {
+          "16": true,
+          "17": true,
+        },
+      },
+      "type": "INSIGHTS_SET_SELECTED_IDS",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "showSelectAllAlert": true,
+      },
+      "type": "INSIGHTS_SET_SELECT_ALL_ALERT",
+    },
+  ],
+  Array [
+    [Function],
+  ],
+  Array [
+    Object {
+      "key": "INSIGHTS_HITS",
+      "params": Object {
+        "order": " ",
+        "page": 2,
+        "per_page": 7,
+        "search": "",
+      },
+      "type": "get",
+      "url": "/insights_cloud/hits",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "args": Array [
+          Object {
+            "pathname": "/foreman_rh_cloud/insights_cloud",
+            "search": "?page=2&per_page=7&search=&sort_by=&sort_order=&select_all=true",
+          },
+        ],
+        "method": "push",
+      },
+      "type": "@@router/CALL_HISTORY_METHOD",
+    },
+  ],
+]
+`;
+
+exports[`insights table actions should selectAll 1`] = `
+Array [
+  Array [
+    [Function],
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "isAllSelected": true,
+      },
+      "type": "INSIGHTS_SET_SELECT_ALL",
+    },
+  ],
+]
+`;
+
+exports[`insights table actions should selectByIds 1`] = `
+Object {
+  "payload": Object {
+    "selectedIds": Object {
+      "1": true,
+      "5": true,
+    },
+  },
+  "type": "INSIGHTS_SET_SELECTED_IDS",
+}
+`;
+
+exports[`insights table actions should setSelectAll false 1`] = `
+Array [
+  Array [
+    [Function],
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "isAllSelected": false,
+      },
+      "type": "INSIGHTS_SET_SELECT_ALL",
+    },
+  ],
+]
+`;
+
+exports[`insights table actions should setSelectAllAlert true 1`] = `
+Object {
+  "payload": Object {
+    "showSelectAllAlert": true,
+  },
+  "type": "INSIGHTS_SET_SELECT_ALL_ALERT",
+}
+`;

--- a/webpack/InsightsCloudSync/Components/InsightsTable/__tests__/__snapshots__/InsightsTableSelectors.test.js.snap
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/__tests__/__snapshots__/InsightsTableSelectors.test.js.snap
@@ -59,6 +59,7 @@ Object {
 
 exports[`InsightsTable selectors should return queryParams 1`] = `
 Object {
+  "isSelectAll": false,
   "page": 1,
   "perPage": 7,
   "query": "total_risk < 3",

--- a/webpack/InsightsCloudSync/Components/InsightsTable/__tests__/fixtures.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/__tests__/fixtures.js
@@ -1,7 +1,7 @@
 import Immutable from 'seamless-immutable';
 import { noop } from 'patternfly-react';
 
-const hits = Immutable([
+export const hits = Immutable([
   {
     id: 16,
     host_id: 1,

--- a/webpack/__mocks__/foremanReact/redux/API/index.js
+++ b/webpack/__mocks__/foremanReact/redux/API/index.js
@@ -2,6 +2,7 @@ export const get = data => ({ type: 'get-some-type', ...data });
 export const put = data => ({ type: 'put-some-type', ...data });
 export const post = data => ({ type: 'post-some-type', ...data });
 export const patch = data => ({ type: 'patch-some-type', ...data });
+
 export const API = {
   get: jest.fn(),
   put: jest.fn(),


### PR DESCRIPTION
Insights table will be opened with selectAll= true from the navigation.
un-selecting all/one of the hosts will set selectAll =false in the url.
url params can't be boolean so the selector is ```isSelectAll === true ||  isSelectAll === 'true'; ``` because `!!'false' === true`.
Missing action tests. 