### PR TITLE
Cloud connector button shows job pending

### DIFF
--- a/app/controllers/foreman_inventory_upload/accounts_controller.rb
+++ b/app/controllers/foreman_inventory_upload/accounts_controller.rb
@@ -27,10 +27,18 @@ module ForemanInventoryUpload
         cloudToken: Setting[:rh_cloud_token],
         excludePackages: Setting[:exclude_installed_packages],
         accounts: accounts,
+        CloudConnectorStatus: cloud_connector_status,
       }, status: :ok
     end
 
     private
+
+    def cloud_connector_status
+      cloud_connector = ForemanRhCloud::CloudConnector.new
+      job = cloud_connector&.latest_job
+      return nil unless job
+      { id: job.id, task: ForemanTasks::Task.where(:id => job.task_id).first }
+    end
 
     def status_for(label, job_class)
       label = job_class.output_label(label)

--- a/app/controllers/foreman_inventory_upload/uploads_controller.rb
+++ b/app/controllers/foreman_inventory_upload/uploads_controller.rb
@@ -32,7 +32,7 @@ module ForemanInventoryUpload
     def cloud_connector_status
       cloud_connector = ForemanRhCloud::CloudConnector.new
       task_id = cloud_connector.latest_job&.task_id
-      render json: ForemanTasks::Task.where(:id => task_id).first
+      render json: { id: cloud_connector.latest_job.id, task: ForemanTasks::Task.where(:id => task_id).first }
     end
 
     def auto_upload

--- a/app/controllers/foreman_inventory_upload/uploads_controller.rb
+++ b/app/controllers/foreman_inventory_upload/uploads_controller.rb
@@ -29,12 +29,6 @@ module ForemanInventoryUpload
       render json: cloud_connector.install.to_json
     end
 
-    def cloud_connector_status
-      cloud_connector = ForemanRhCloud::CloudConnector.new
-      job = cloud_connector.latest_job
-      render json: { id: job.id, task: ForemanTasks::Task.where(:id => job&.task_id).first }
-    end
-
     def auto_upload
       Setting[:allow_auto_inventory_upload] = auto_upload_params
       render_setting(:autoUploadEnabled, :allow_auto_inventory_upload)

--- a/app/controllers/foreman_inventory_upload/uploads_controller.rb
+++ b/app/controllers/foreman_inventory_upload/uploads_controller.rb
@@ -31,8 +31,8 @@ module ForemanInventoryUpload
 
     def cloud_connector_status
       cloud_connector = ForemanRhCloud::CloudConnector.new
-      task_id = cloud_connector.latest_job&.task_id
-      render json: { id: cloud_connector.latest_job.id, task: ForemanTasks::Task.where(:id => task_id).first }
+      job = cloud_connector.latest_job
+      render json: { id: job.id, task: ForemanTasks::Task.where(:id => job&.task_id).first }
     end
 
     def auto_upload

--- a/app/services/foreman_rh_cloud/cloud_connector.rb
+++ b/app/services/foreman_rh_cloud/cloud_connector.rb
@@ -20,7 +20,8 @@ module ForemanRhCloud
     end
 
     def latest_job
-      feature_id = RemoteExecutionFeature.find_by_label(CLOUD_CONNECTOR_FEATURE).id
+      feature_id = RemoteExecutionFeature.find_by_label(CLOUD_CONNECTOR_FEATURE)&.id
+      return nil unless feature_id
       JobInvocation.where(:remote_execution_feature_id => feature_id).includes(:task).reorder('foreman_tasks_tasks.started_at DESC').first
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,6 @@ Rails.application.routes.draw do
     post 'installed_packages_inclusion', to: 'uploads#installed_packages_inclusion'
     post 'ips_obfuscation', to: 'uploads#ips_obfuscation'
 
-    get 'cloud_connector', to: 'uploads#cloud_connector_status'
     post 'cloud_connector', to: 'uploads#enable_cloud_connector'
 
     resources :tasks, only: [:create]

--- a/webpack/ForemanInventoryUpload/Components/AccountList/AccountList.fixtures.js
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/AccountList.fixtures.js
@@ -42,6 +42,11 @@ export const cloudToken = 'some-cloud-token';
 
 export const excludePackages = false;
 
+export const CloudConnectorStatus = {
+  id: 7,
+  task: { id: 11 },
+};
+
 export const props = {
   accounts,
   fetchAccountsStatus: noop,
@@ -57,6 +62,7 @@ export const pollingResponse = {
   ipsObfuscationEnabled,
   cloudToken,
   excludePackages,
+  CloudConnectorStatus,
 };
 
 export const fetchAccountsStatusResponse = {

--- a/webpack/ForemanInventoryUpload/Components/AccountList/AccountListReducer.js
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/AccountListReducer.js
@@ -29,6 +29,7 @@ export default (state = initialState, action) => {
       ipsObfuscationEnabled,
       cloudToken,
       excludePackages,
+      CloudConnectorStatus,
     } = {},
   } = action;
 
@@ -42,6 +43,7 @@ export default (state = initialState, action) => {
         ipsObfuscationEnabled,
         cloudToken,
         excludePackages,
+        CloudConnectorStatus,
         error: null,
       });
     case INVENTORY_ACCOUNT_STATUS_POLLING_ERROR:

--- a/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/__snapshots__/AccountListActions.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/__snapshots__/AccountListActions.test.js.snap
@@ -5,6 +5,12 @@ Array [
   Array [
     Object {
       "payload": Object {
+        "CloudConnectorStatus": Object {
+          "id": 7,
+          "task": Object {
+            "id": 11,
+          },
+        },
         "accounts": Object {
           "Account1": Object {
             "generate_report_status": "running",

--- a/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/__snapshots__/AccountListReducer.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/__tests__/__snapshots__/AccountListReducer.test.js.snap
@@ -20,6 +20,12 @@ Object {
 
 exports[`AccountList reducer should handle INVENTORY_ACCOUNT_STATUS_POLLING 1`] = `
 Object {
+  "CloudConnectorStatus": Object {
+    "id": 7,
+    "task": Object {
+      "id": 11,
+    },
+  },
   "accounts": Object {
     "Account1": Object {
       "generate_report_status": "running",

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorActions.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorActions.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { get, post } from 'foremanReact/redux/API';
+import { post } from 'foremanReact/redux/API';
 import { CONFIGURE_CLOUD_CONNECTOR } from './CloudConnectorConstants';
 import { inventoryUrl } from '../../../../ForemanInventoryHelpers';
 import { foremanUrl } from '../../../../../ForemanRhCloudHelpers';
@@ -18,10 +18,4 @@ export const configureCloudConnector = () =>
       </span>
     ),
     errorToast: error => `${__('Cloud connector setup has failed: ')} ${error}`,
-  });
-
-export const getCloudConnector = () =>
-  get({
-    key: CONFIGURE_CLOUD_CONNECTOR,
-    url: inventoryUrl('cloud_connector'),
   });

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorButton.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorButton.js
@@ -1,27 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Spinner, Button, Popover } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { CONNECTOR_STATUS } from './CloudConnectorConstants';
 
 export const CloudConnectorButton = ({ status, onClick, jobLink }) => {
+  const [isPopoverVisible, setIsPopoverVisible] = useState(false);
   if (status === CONNECTOR_STATUS.PENDING) {
     return (
       <Popover
+        isVisible={isPopoverVisible}
+        shouldClose={() => setIsPopoverVisible(false)}
         bodyContent={
           <div>
-            {__('Cloud connector setup is in progress now: ')}
+            {__('Cloud connector setup has started: ')}
             <a href={jobLink} target="_blank" rel="noopener noreferrer">
-              {__('Cloud connector job link')}
+              {__('view the job in progress')}
             </a>
           </div>
         }
         aria-label="Popover with Link to cloud connector job"
         closeBtnAriaLabel="Close cloud connector Popover"
       >
-        <Button variant="secondary">
-          <Spinner size="sm" /> {__('Cloud Connector is in progress')}
-        </Button>
+        <div
+          classnmae="cloud-connector-pending-button"
+          onMouseEnter={() => setIsPopoverVisible(true)}
+        >
+          <Button variant="secondary" isDisabled>
+            <Spinner size="sm" /> {__('Cloud Connector is in progress')}
+          </Button>
+        </div>
       </Popover>
     );
   }

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorButton.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorButton.js
@@ -10,9 +10,9 @@ export const CloudConnectorButton = ({ status, onClick, jobLink }) => {
       <Popover
         bodyContent={
           <div>
-            {__('Cloud connector job is still running, you can view it here:')}
+            {__('Cloud connector setup is in progress now: ')}
             <a href={jobLink} target="_blank" rel="noopener noreferrer">
-              {__('Open job')}
+              {__('Cloud connector job link')}
             </a>
           </div>
         }
@@ -20,7 +20,7 @@ export const CloudConnectorButton = ({ status, onClick, jobLink }) => {
         closeBtnAriaLabel="Close cloud connector Popover"
       >
         <Button variant="secondary">
-          <Spinner size="sm" /> {__('Cloud Connector in progress')}
+          <Spinner size="sm" /> {__('Cloud Connector is in progress')}
         </Button>
       </Popover>
     );
@@ -28,8 +28,8 @@ export const CloudConnectorButton = ({ status, onClick, jobLink }) => {
 
   if (status === CONNECTOR_STATUS.RESOLVED) {
     return (
-      <Button variant="secondary" isDisabled>
-        {__('Cloud Connector is configured')}
+      <Button variant="secondary" onClick={onClick}>
+        {__('Reconfigure Cloud Connector')}
       </Button>
     );
   }

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorButton.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorButton.js
@@ -23,7 +23,7 @@ export const CloudConnectorButton = ({ status, onClick, jobLink }) => {
         closeBtnAriaLabel="Close cloud connector Popover"
       >
         <div
-          classnmae="cloud-connector-pending-button"
+          className="cloud-connector-pending-button"
           onMouseEnter={() => setIsPopoverVisible(true)}
         >
           <Button variant="secondary" isDisabled>

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorSelectors.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorSelectors.js
@@ -1,14 +1,20 @@
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
+import { foremanUrl } from '../../../../../ForemanRhCloudHelpers';
 
 import {
   CONFIGURE_CLOUD_CONNECTOR,
   CONNECTOR_STATUS,
 } from './CloudConnectorConstants';
 
-export const selectStatus = state =>
-  selectAPIResponse(state, CONFIGURE_CLOUD_CONNECTOR)?.result === 'success'
-    ? CONNECTOR_STATUS.RESOLVED
-    : CONNECTOR_STATUS.NOT_RESOLVED;
+export const selectStatus = state => {
+  const { task } = selectAPIResponse(state, CONFIGURE_CLOUD_CONNECTOR);
+  if (!task) return CONNECTOR_STATUS.NOT_RESOLVED;
+  if (task.state === 'running') return CONNECTOR_STATUS.PENDING;
+  if (task.result === 'success') return CONNECTOR_STATUS.RESOLVED;
+  return CONNECTOR_STATUS.NOT_RESOLVED;
+};
 
-export const selectJobLink = state =>
-  selectAPIResponse(state, CONFIGURE_CLOUD_CONNECTOR).job_link || '';
+export const selectJobLink = state => {
+  const { id } = selectAPIResponse(state, CONFIGURE_CLOUD_CONNECTOR);
+  return id ? foremanUrl(`/job_invocations/${id}`) : '';
+};

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorSelectors.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorSelectors.js
@@ -1,21 +1,19 @@
-import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import { foremanUrl } from '../../../../../ForemanRhCloudHelpers';
+import { selectAccountsList } from '../../../AccountList/AccountListSelectors';
+import { CONNECTOR_STATUS } from './CloudConnectorConstants';
 
-import {
-  CONFIGURE_CLOUD_CONNECTOR,
-  CONNECTOR_STATUS,
-} from './CloudConnectorConstants';
+export const SelectCloudConnectorStatus = state =>
+  selectAccountsList(state).CloudConnectorStatus || {};
 
 export const selectStatus = state => {
-  const { task } = selectAPIResponse(state, CONFIGURE_CLOUD_CONNECTOR);
+  const { task } = SelectCloudConnectorStatus(state);
   if (!task) return CONNECTOR_STATUS.NOT_RESOLVED;
-  if (task.result === 'running' || task.result === 'pending')
-    return CONNECTOR_STATUS.PENDING;
+  if (task.result === 'pending') return CONNECTOR_STATUS.PENDING;
   if (task.result === 'success') return CONNECTOR_STATUS.RESOLVED;
   return CONNECTOR_STATUS.NOT_RESOLVED;
 };
 
 export const selectJobLink = state => {
-  const { id } = selectAPIResponse(state, CONFIGURE_CLOUD_CONNECTOR);
+  const { id } = SelectCloudConnectorStatus(state);
   return id ? foremanUrl(`/job_invocations/${id}`) : '';
 };

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorSelectors.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/CloudConnectorSelectors.js
@@ -9,7 +9,8 @@ import {
 export const selectStatus = state => {
   const { task } = selectAPIResponse(state, CONFIGURE_CLOUD_CONNECTOR);
   if (!task) return CONNECTOR_STATUS.NOT_RESOLVED;
-  if (task.state === 'running') return CONNECTOR_STATUS.PENDING;
+  if (task.result === 'running' || task.result === 'pending')
+    return CONNECTOR_STATUS.PENDING;
   if (task.result === 'success') return CONNECTOR_STATUS.RESOLVED;
   return CONNECTOR_STATUS.NOT_RESOLVED;
 };

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/__tests__/__snapshots__/CloudConnectorButton.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/__tests__/__snapshots__/CloudConnectorButton.test.js.snap
@@ -29,7 +29,7 @@ exports[`CloudConnectorButton render pending connector 1`] = `
   shouldClose={[Function]}
 >
   <div
-    classnmae="cloud-connector-pending-button"
+    className="cloud-connector-pending-button"
     onMouseEnter={[Function]}
   >
     <Button

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/__tests__/__snapshots__/CloudConnectorButton.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/__tests__/__snapshots__/CloudConnectorButton.test.js.snap
@@ -14,27 +14,35 @@ exports[`CloudConnectorButton render pending connector 1`] = `
   aria-label="Popover with Link to cloud connector job"
   bodyContent={
     <div>
-      Cloud connector setup is in progress now: 
+      Cloud connector setup has started: 
       <a
         href="/job-link"
         rel="noopener noreferrer"
         target="_blank"
       >
-        Cloud connector job link
+        view the job in progress
       </a>
     </div>
   }
   closeBtnAriaLabel="Close cloud connector Popover"
+  isVisible={false}
+  shouldClose={[Function]}
 >
-  <Button
-    variant="secondary"
+  <div
+    classnmae="cloud-connector-pending-button"
+    onMouseEnter={[Function]}
   >
-    <Spinner
-      size="sm"
-    />
-     
-    Cloud Connector is in progress
-  </Button>
+    <Button
+      isDisabled={true}
+      variant="secondary"
+    >
+      <Spinner
+        size="sm"
+      />
+       
+      Cloud Connector is in progress
+    </Button>
+  </div>
 </Popover>
 `;
 

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/__tests__/__snapshots__/CloudConnectorButton.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/__tests__/__snapshots__/CloudConnectorButton.test.js.snap
@@ -14,13 +14,13 @@ exports[`CloudConnectorButton render pending connector 1`] = `
   aria-label="Popover with Link to cloud connector job"
   bodyContent={
     <div>
-      Cloud connector job is still running, you can view it here:
+      Cloud connector setup is in progress now: 
       <a
         href="/job-link"
         rel="noopener noreferrer"
         target="_blank"
       >
-        Open job
+        Cloud connector job link
       </a>
     </div>
   }
@@ -33,16 +33,16 @@ exports[`CloudConnectorButton render pending connector 1`] = `
       size="sm"
     />
      
-    Cloud Connector in progress
+    Cloud Connector is in progress
   </Button>
 </Popover>
 `;
 
 exports[`CloudConnectorButton render resolved cloud connector 1`] = `
 <Button
-  isDisabled={true}
+  onClick={[MockFunction]}
   variant="secondary"
 >
-  Cloud Connector is configured
+  Reconfigure Cloud Connector
 </Button>
 `;

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/index.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/CloudConnectorButton/index.js
@@ -1,10 +1,7 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { CloudConnectorButton } from './CloudConnectorButton';
-import {
-  configureCloudConnector,
-  getCloudConnector,
-} from './CloudConnectorActions';
+import { configureCloudConnector } from './CloudConnectorActions';
 import { selectStatus, selectJobLink } from './CloudConnectorSelectors';
 
 const ConnectedCloudConnectorButton = () => {
@@ -12,9 +9,6 @@ const ConnectedCloudConnectorButton = () => {
   const jobLink = useSelector(selectJobLink);
   const dispatch = useDispatch();
 
-  useEffect(() => {
-    dispatch(getCloudConnector());
-  }, [dispatch]);
   return (
     <CloudConnectorButton
       status={status}

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/toolbarButtons.scss
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/ToolbarButtons/toolbarButtons.scss
@@ -8,4 +8,8 @@
   .sync_button .spinner {
     margin: 3px 5px 0 -3px;
   }
+
+  .cloud-connector-pending-button {
+    display: inline-block;
+  }
 }


### PR DESCRIPTION
Changed the wording for the pending button to match the success toast.
Used the buttons pending state.
User can now reconfigure the cloud connector instead the button being disabled when the cloud connector is configured. 