### PR TITLE
Set default autoupload value to true

### DIFF
--- a/app/models/setting/rh_cloud.rb
+++ b/app/models/setting/rh_cloud.rb
@@ -1,11 +1,20 @@
 class Setting::RhCloud < Setting
   ::Setting::BLANK_ATTRS.concat %w{rh_cloud_token}
 
+  def self.load_defaults
+    return false unless table_exists?
+    transaction do
+      # If the user had auto_upload default setting, we will not surprise him, and force the value to false
+      # for new users, the default will be set to true and the value will remain nil
+      Setting.where(name: 'allow_auto_inventory_upload', value: nil).where("settings.default LIKE '%false%'").update_all(value: "--- false\n...")
+      super
+    end
+  end
+
   def self.default_settings
     return unless ActiveRecord::Base.connection.table_exists?('settings')
-    return unless super
     [
-      set('allow_auto_inventory_upload', N_('Allow automatic upload of the host inventory to the Red Hat cloud'), false, N_('Allow automatic inventory uploads')),
+      set('allow_auto_inventory_upload', N_('Allow automatic upload of the host inventory to the Red Hat cloud'), true, N_('Allow automatic inventory uploads')),
       set('allow_auto_insights_sync', N_('Allow recommendations synchronization from Red Hat cloud'), false, N_('Allow recommendations synchronization')),
       set('obfuscate_inventory_hostnames', N_('Obfuscate host names sent to Red Hat cloud'), false, N_('Obfuscate host names')),
       set('obfuscate_inventory_ips', N_('Obfuscate ip addresses sent to Red Hat cloud'), false, N_('Obfuscate IPs')),


### PR DESCRIPTION
@ezr-ondrej, does it look like a valid solution?

The behaviour I am looking for is for new users set the default to `true`.
For users that are upgrading from previous versions and were relying on the fact that the default was `false`, I want to set the value to `false` explicitly.