### PR TITLE
Fix inventory file download error handling

### DIFF
--- a/app/controllers/foreman_inventory_upload/uploads_controller.rb
+++ b/app/controllers/foreman_inventory_upload/uploads_controller.rb
@@ -14,14 +14,7 @@ module ForemanInventoryUpload
       files = Dir["{#{ForemanInventoryUpload.uploads_file_path(filename)},#{ForemanInventoryUpload.done_file_path(filename)}}"]
 
       return send_file files.first, disposition: 'attachment', filename: filename unless files.empty?
-      throw_flash_error "File doesn't exist"
-    end
-
-    def throw_flash_error(message)
-      process_error(
-        :redirect => foreman_inventory_upload_index_path,
-        :error_msg => message
-      )
+      raise ::Foreman::Exception.new("The report file doesn't exist")
     end
 
     def enable_cloud_connector

--- a/webpack/ForemanInventoryUpload/Components/Dashboard/DashboardActions.js
+++ b/webpack/ForemanInventoryUpload/Components/Dashboard/DashboardActions.js
@@ -67,7 +67,7 @@ export const setActiveTab = (accountID, tabName) => ({
 });
 
 export const downloadReports = accountID => {
-  window.location.href = inventoryUrl(`${accountID}/uploads/file`);
+  window.open(inventoryUrl(`${accountID}/uploads/file`), '_blank');
   return {
     type: INVENTORY_REPORTS_DOWNLOAD,
     payload: {

--- a/webpack/ForemanInventoryUpload/Components/Dashboard/__tests__/DashboardActions.test.js
+++ b/webpack/ForemanInventoryUpload/Components/Dashboard/__tests__/DashboardActions.test.js
@@ -36,15 +36,15 @@ const fixtures = {
 };
 
 describe('Dashboard actions', () => {
-  const { location } = window;
+  const { open } = window;
 
   beforeAll(() => {
-    delete window.location;
-    window.location = { href: jest.fn() };
+    delete window.open;
+    window.open = jest.fn();
   });
 
   afterAll(() => {
-    window.location = location;
+    window.open = open;
   });
 
   return testActionSnapshotWithFixtures(fixtures);


### PR DESCRIPTION
Since we moved to react-router pages, there is a problem to throw an error doing a full-page reload.
In this PR we will get the file and the error with a JSON request.