### PR TITLE
Add tags to inventory_export_url

### DIFF
--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -62,6 +62,7 @@ module ForemanInventoryUpload
   end
 
   def self.inventory_export_url
-    ForemanRhCloud.base_url + '/api/inventory/v1/hosts'
+    tags = URI.encode("satellite/satellite_instance_id=#{Foreman.instance_id}")
+    ForemanRhCloud.base_url + "/api/inventory/v1/hosts?tags=#{tags}"
   end
 end


### PR DESCRIPTION
returning all of the hosts from c.r.c can take a lot of time,
we can filter to the specific hosts with the satellite instance tag