### PR TITLE
Sync rh_cloud tags with branch_info

### DIFF
--- a/app/services/foreman_rh_cloud/branch_info.rb
+++ b/app/services/foreman_rh_cloud/branch_info.rb
@@ -38,20 +38,9 @@ module ForemanRhCloud
     end
 
     def host_labels(host)
-      labels = [new_label('Organization', host.organization.name, 'Satellite')]
-      labels += labels_from_items(host.location.title.split('/'), 'Satellite', ->(item) { 'Location' }) if host.location
-      labels += labels_from_items(host.hostgroup.title.split('/'), 'Satellite', ->(item) { 'Host Group' }) if host.hostgroup
-      labels += labels_from_items(host.host_collections, 'Satellite', ->(item) { 'Host Collection' }, :name)
-
-      if Setting[:include_parameter_tags]
-        labels += labels_from_items(
-          host.host_inherited_params_objects,
-          'SatelliteParameter',
-          ->(item) { item.name },
-          :value)
-      end
-
-      labels
+      tags_generator = ForemanInventoryUpload::Generators::Tags.new(host)
+      tags_generator.generate.map { |key, value| new_label(key, value, ForemanInventoryUpload::Generators::Slice::SATELLITE_NAMESPACE) } +
+        tags_generator.generate_parameters.map { |key, value| new_label(key, value, ForemanInventoryUpload::Generators::Slice::SATELLITE_PARAMS_NAMESPACE) }
     end
   end
 end

--- a/lib/foreman_inventory_upload/generators/tags.rb
+++ b/lib/foreman_inventory_upload/generators/tags.rb
@@ -1,0 +1,59 @@
+module ForemanInventoryUpload
+  module Generators
+    class Tags
+      def initialize(host)
+        @host = host
+      end
+
+      def generate
+        locations +
+        hostgroups +
+        host_collections +
+        organizations +
+        content_data +
+        satellite_server_data
+      end
+
+      def generate_parameters
+        return [] unless Setting[:include_parameter_tags]
+
+        (@host.host_inherited_params_objects || []).map { |item| [item.name, item.value] }
+      end
+
+      private
+
+      def locations
+        return [] unless @host.location
+        @host.location.title.split('/').map { |item| ['location', item] }.push(['location', @host.location.title])
+      end
+
+      def hostgroups
+        return [] unless @host.hostgroup
+        @host.hostgroup.title.split('/').map { |item| ['hostgroup', item] }.push(['hostgroup', @host.hostgroup.title])
+      end
+
+      def host_collections
+        (@host.host_collections || []).map { |item| ['host collection', item.name] }
+      end
+
+      def organizations
+        [['organization', @host.organization.name]]
+      end
+
+      def content_data
+        [
+          ['lifecycle_environment', @host.lifecycle_environment&.name],
+          ['content_view', @host.content_view&.name],
+        ] +
+        (@host.activation_keys || []).map { |item| ['activation_key', item.name] }
+      end
+
+      def satellite_server_data
+        [
+          ['satellite_instance_id', Foreman.instance_id],
+          ['organization_id', @host.organization_id.to_s],
+        ]
+      end
+    end
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -24,3 +24,16 @@ module FolderIsolation
     end
   end
 end
+
+module KatelloLocationFix
+  extend ActiveSupport::Concern
+
+  included do
+    setup do
+      FactoryBot.create(:setting, name: 'default_location_subscribed_hosts')
+      FactoryBot.create(:setting, name: 'default_location_puppet_content')
+      Setting[:default_location_subscribed_hosts] = Location.first.title
+      Setting[:default_location_puppet_content] = Location.first.title
+    end
+  end
+end

--- a/test/unit/services/foreman_rh_cloud/branch_info_test.rb
+++ b/test/unit/services/foreman_rh_cloud/branch_info_test.rb
@@ -46,15 +46,15 @@ class BranchInfoTest < ActiveSupport::TestCase
 
     labels = ::ForemanRhCloud::BranchInfo.new.generate('a1', @host, 'branch', 'foo')[:labels]
 
-    org_label = labels.find { |label| label[:key] == 'Organization' }
-    loc_label = labels.find { |label| label[:key] == 'Location' }
+    org_label = labels.find { |label| label[:key] == 'organization' }
+    loc_label = labels.find { |label| label[:key] == 'location' }
     assert_equal @host.organization.title, org_label[:value]
     assert_equal @host.location.title, loc_label[:value]
 
-    hg_label = labels.find { |label| label[:key] == 'Host Group' }
-    host_colections = labels.select { |label| label[:key] == 'Host Collection' }
+    hg_label = labels.find { |label| label[:key] == 'hostgroup' }
+    host_colections = labels.select { |label| label[:key] == 'host collection' }
     assert_equal @host.hostgroup.name, hg_label[:value]
     assert_equal 2, host_colections.count
-    refute_empty labels.select { |label| label[:namespace] == 'SatelliteParameter' }
+    refute_empty labels.select { |label| label[:namespace] == 'satellite_parameter' }
   end
 end

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -1,11 +1,15 @@
 require 'test_plugin_helper'
 
 class SliceGeneratorTest < ActiveSupport::TestCase
+  include KatelloLocationFix
+
   setup do
     User.current = User.find_by(login: 'secret_admin')
 
     env = FactoryBot.create(:katello_k_t_environment)
     cv = env.content_views << FactoryBot.create(:katello_content_view, organization: env.organization)
+
+    location = FactoryBot.create(:location)
 
     @host = FactoryBot.create(
       :host,
@@ -14,7 +18,8 @@ class SliceGeneratorTest < ActiveSupport::TestCase
       :with_content,
       content_view: cv.first,
       lifecycle_environment: env,
-      organization: env.organization
+      organization: env.organization,
+      location: location
     )
 
     @host.organization.pools << FactoryBot.create(:katello_pool, account_number: '1234', cp_id: 1)

--- a/test/unit/tags_generator_test.rb
+++ b/test/unit/tags_generator_test.rb
@@ -1,0 +1,60 @@
+require 'test_plugin_helper'
+
+class TagsGeneratorTest < ActiveSupport::TestCase
+  include KatelloLocationFix
+
+  setup do
+    User.current = User.find_by(login: 'secret_admin')
+
+    env = FactoryBot.create(:katello_k_t_environment)
+    cv = env.content_views << FactoryBot.create(:katello_content_view, organization: env.organization)
+
+    @location1 = FactoryBot.create(:location)
+    @location2 = FactoryBot.create(:location, parent: @location1)
+
+    @hostgroup1 = FactoryBot.create(:hostgroup)
+    @hostgroup2 = FactoryBot.create(:hostgroup, parent: @hostgroup1)
+
+    @host = FactoryBot.create(
+      :host,
+      :redhat,
+      :with_subscription,
+      :with_content,
+      content_view: cv.first,
+      lifecycle_environment: env,
+      organization: env.organization,
+      location: @location2,
+      hostgroup: @hostgroup2
+    )
+
+    @host.organization.pools << FactoryBot.create(:katello_pool, account_number: '1234', cp_id: 1)
+    @host.interfaces.first.identifier = 'test_nic1'
+    @host.save!
+  end
+
+  test 'generates tags for a single host' do
+    generator = create_generator
+
+    actual = generator.generate.group_by { |key, value| key }
+
+    locations = actual['location']
+    assert_equal 3, locations.length
+
+    hostgroups = actual['hostgroup']
+    assert_equal 3, hostgroups.length
+
+    assert_nil actual['host collection']
+
+    assert_equal @host.organization.name, actual['organization'].first.last
+    assert_equal @host.lifecycle_environment.name, actual['lifecycle_environment'].first.last
+    assert_equal @host.content_view.name, actual['content_view'].first.last
+    assert_equal Foreman.instance_id, actual['satellite_instance_id'].first.last
+    assert_equal @host.organization_id.to_s, actual['organization_id'].first.last
+  end
+
+  private
+
+  def create_generator
+    ForemanInventoryUpload::Generators::Tags.new(@host)
+  end
+end


### PR DESCRIPTION
Now the tags that are reported by rh_cloud are identical to those reported by insights-client (via the `branch_info` method)