### PR TITLE
Forward exit code from curl to script

### DIFF
--- a/lib/foreman_inventory_upload/scripts/uploader.sh.erb
+++ b/lib/foreman_inventory_upload/scripts/uploader.sh.erb
@@ -37,9 +37,13 @@ mkdir -p $DONE_DIR
 for f in $FILES
 do
   curl -k -vvv -# --fail -F "file=@$f;type=application/vnd.redhat.qpc.tar+tgz" $DEST "$AUTH_KEY" "$AUTH_VAL"
-  if [ $? -eq 0 ]; then
+  status=$?
+  if [ $status -eq 0 ]; then
     mv $f $DONE_DIR
     echo "Done: $f"
   fi
 done
 echo "Uploaded files moved to done/ folder"
+
+# return the error code from the curl command
+exit $status


### PR DESCRIPTION
You have to delete `red_hat_inventory/uploads/uploader.sh` file to regenerate the uploader script.