### PR TITLE
update inventory filter only on initial load

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/InventoryFilter/InventoryFilter.js
+++ b/webpack/ForemanInventoryUpload/Components/InventoryFilter/InventoryFilter.js
@@ -18,7 +18,7 @@ const InventoryFilter = ({
     const initialTerm =
       organization === __(ANY_ORGANIZATION) ? '' : organization;
     handleFilterChange(initialTerm);
-  }, [organization]);
+  }, []);
 
   return (
     <form id="inventory_filter_form">


### PR DESCRIPTION
dropping the filter update after taxonomy changes,
as the page will reload anyway and it just feels like a bug when it updates for a second and then the page refreshes...