### PR TITLE
Fix missing to_status method.

### DIFF
--- a/app/models/inventory_sync/inventory_status.rb
+++ b/app/models/inventory_sync/inventory_status.rb
@@ -26,5 +26,11 @@ module InventorySync
           N_('Successfully uploaded to your RH cloud inventory')
       end
     end
+
+    def to_status(options = {})
+      # this method used to calculate status.
+      # Since the calculation is done externally we should return the previously calculated status
+      status
+    end
   end
 end


### PR DESCRIPTION
It causes https://github.com/theforeman/foreman/blob/f5bfce8bc5cab43fa66c362d40ee843e0783fe72/app/models/host/managed.rb#L856 to fail.