### PR TITLE
Fix rh_cloud_insights and rh_cloud_inventory rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In UI: Configure -> Insights -> Sync now
 
 From command-line:
 
-    /usr/sbin/foreman-rake rh_cloud_inventory:sync
+    /usr/sbin/foreman-rake rh_cloud_insights:sync
 
 #### Synchronize inventory status
 
@@ -51,11 +51,11 @@ In UI: Configure -> Inventory Upload -> Sync inventory status
 From command-line:
 
     # all organizations
-    /usr/sbin/foreman-rake rh_cloud_insights:sync
+    /usr/sbin/foreman-rake rh_cloud_inventory:sync
 
     # specific organization with id 1
     export organization_id=1
-    /usr/sbin/foreman-rake rh_cloud_insights:sync
+    /usr/sbin/foreman-rake rh_cloud_inventory:sync
 
 ## TODO
 

--- a/lib/tasks/insights.rake
+++ b/lib/tasks/insights.rake
@@ -1,15 +1,7 @@
 namespace :rh_cloud_insights do
-  desc "Synchronize Insights inventory"
-  task sync: :environment do
-    if ! ENV['organization_id'].nil?
-      organizations = [ Organization.where(:id => ENV['organization_id']).first ]
-    else
-      organizations = Organization.all
-    end
-
-    organizations.each do |organization|
-      ForemanTasks.async_task(InventorySync::Async::InventoryFullSync, organization)
-      puts "Synchronized inventory for organization '#{organization.name}'"
-    end
+  desc "Synchronize Insights hosts hits"
+  task sync: [:environment, 'dynflow:client'] do
+    ForemanTasks.sync_task(InsightsCloud::Async::InsightsFullSync)
+    puts "Synchronized Insights hosts hits data"
   end
 end

--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -52,9 +52,17 @@ namespace :rh_cloud_inventory do
     end
   end
 
-  desc "Synchronize Insights hosts hits"
-  task sync: :environment do
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsFullSync)
-    puts "Synchronized Insights hosts hits data"
+  desc "Synchronize Hosts inventory"
+  task sync: [:environment, 'dynflow:client'] do
+    if ! ENV['organization_id'].nil?
+      organizations = [ Organization.where(:id => ENV['organization_id']).first ]
+    else
+      organizations = Organization.all
+    end
+
+    organizations.each do |organization|
+      ForemanTasks.async_task(InventorySync::Async::InventoryFullSync, organization)
+      puts "Synchronized inventory for organization '#{organization.name}'"
+    end
   end
 end


### PR DESCRIPTION
PR to fix https://bugzilla.redhat.com/show_bug.cgi?id=1957186
I have also interchanged the functionality of `rh_cloud_insights:sync` and `rh_cloud_inventory:sync` rake commands.