### PR TITLE
[CP 2.3] Convert all reported tag values to string (#553)

### DIFF
--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -85,7 +85,7 @@ module ForemanInventoryUpload
         @stream.object do
           @stream.simple_field('namespace', namespace)
           @stream.simple_field('key', key)
-          @stream.simple_field('value', value, :last)
+          @stream.simple_field('value', value.to_s, :last)
         end
         @stream.comma unless last
       end

--- a/test/jobs/insights_full_sync_test.rb
+++ b/test/jobs/insights_full_sync_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'foreman_tasks/test_helpers'
 
 class InsightsFullSyncTest < ActiveSupport::TestCase
+  include ForemanTasks::TestHelpers::WithInThreadExecutor
+
   setup do
     InsightsCloud::Async::InsightsFullSync.any_instance.stubs(:plan_rules_sync)
     InsightsCloud::Async::InsightsFullSync.any_instance.stubs(:plan_notifications)

--- a/test/jobs/insights_resolutions_sync_test.rb
+++ b/test/jobs/insights_resolutions_sync_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'foreman_tasks/test_helpers'
 
 class InsightsResolutionsSyncTest < ActiveSupport::TestCase
+  include ForemanTasks::TestHelpers::WithInThreadExecutor
+
   setup do
     @resolutions = {
       "advisor:ansible_deprecated_repo|ANSIBLE_DEPRECATED_REPO" => {

--- a/test/jobs/insights_rules_sync_test.rb
+++ b/test/jobs/insights_rules_sync_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'foreman_tasks/test_helpers'
 
 class InsightsRulesSyncTest < ActiveSupport::TestCase
+  include ForemanTasks::TestHelpers::WithInThreadExecutor
+
   setup do
     rules_json = <<-'RULES_JSON'
     {

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -1,6 +1,9 @@
 require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
 
 class InventoryFullSyncTest < ActiveSupport::TestCase
+  include ForemanTasks::TestHelpers::WithInThreadExecutor
+
   setup do
     User.current = User.find_by(login: 'secret_admin')
 


### PR DESCRIPTION
* Fix tests that require tasks executor

* Convert all reported tag values to string