### PR TITLE
[CP 2.3] Add proxy parameter to insights forwarded requests (#547)

### DIFF
--- a/app/services/foreman_rh_cloud/cloud_auth.rb
+++ b/app/services/foreman_rh_cloud/cloud_auth.rb
@@ -2,6 +2,8 @@ module ForemanRhCloud
   module CloudAuth
     extend ActiveSupport::Concern
 
+    include CloudRequest
+
     def rh_credentials
       @rh_credentials ||= query_refresh_token
     end
@@ -23,6 +25,16 @@ module ForemanRhCloud
     rescue RestClient::ExceptionWithResponse => e
       Foreman::Logging.exception('Unable to authenticate using rh_cloud_token setting', e)
       raise ::Foreman::WrappedException.new(e, N_('Unable to authenticate using rh_cloud_token setting'))
+    end
+
+    def execute_cloud_request(params)
+      final_params = {
+        headers: {
+          Authorization: "Bearer #{rh_credentials}",
+        },
+      }.deep_merge(params)
+
+      super(final_params)
     end
   end
 end

--- a/app/services/foreman_rh_cloud/cloud_request.rb
+++ b/app/services/foreman_rh_cloud/cloud_request.rb
@@ -1,0 +1,14 @@
+module ForemanRhCloud
+  module CloudRequest
+    extend ActiveSupport::Concern
+
+    def execute_cloud_request(params)
+      final_params = {
+        verify_ssl: ForemanRhCloud.verify_ssl_method,
+        proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
+      }.deep_merge(params)
+
+      RestClient::Request.execute(final_params)
+    end
+  end
+end

--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -2,7 +2,7 @@ require 'rest-client'
 
 module ForemanRhCloud
   class CloudRequestForwarder
-    include ::ForemanRhCloud::CloudAuth
+    include ForemanRhCloud::CloudRequest
 
     def forward_request(original_request, controller_name, branch_id, certs)
       forward_params = prepare_forward_params(original_request, branch_id)
@@ -22,7 +22,6 @@ module ForemanRhCloud
     def prepare_request_opts(original_request, forward_payload, forward_params, certs)
       base_params = {
         method: original_request.method,
-        verify_ssl: ForemanRhCloud.verify_ssl_method,
         payload: forward_payload,
         headers: {
           params: forward_params,
@@ -31,10 +30,6 @@ module ForemanRhCloud
         },
       }
       base_params.merge(path_params(original_request.path, certs))
-    end
-
-    def execute_cloud_request(request_opts)
-      RestClient::Request.execute request_opts
     end
 
     def prepare_forward_payload(original_request, controller_name)

--- a/app/services/foreman_rh_cloud/remediations_retriever.rb
+++ b/app/services/foreman_rh_cloud/remediations_retriever.rb
@@ -62,14 +62,11 @@ module ForemanRhCloud
     end
 
     def query_playbook
-      RestClient::Request.execute(
+      execute_cloud_request(
         method: :post,
         url: InsightsCloud.playbook_url,
-        verify_ssl: ForemanRhCloud.verify_ssl_method,
-        proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
         headers: {
           content_type: :json,
-          Authorization: "Bearer #{rh_credentials}",
         },
         payload: playbook_request.to_json
       )

--- a/lib/insights_cloud/async/insights_full_sync.rb
+++ b/lib/insights_cloud/async/insights_full_sync.rb
@@ -50,28 +50,18 @@ module InsightsCloud
       end
 
       def query_insights_hits
-        hits_response = RestClient::Request.execute(
+        hits_response = execute_cloud_request(
           method: :get,
-          url: InsightsCloud.hits_export_url,
-          verify_ssl: ForemanRhCloud.verify_ssl_method,
-          proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
-          headers: {
-            Authorization: "Bearer #{rh_credentials}",
-          }
+          url: InsightsCloud.hits_export_url
         )
 
         JSON.parse(hits_response)
       end
 
       def query_insights_rules
-        rules_response = RestClient::Request.execute(
+        rules_response = execute_cloud_request(
           method: :get,
-          url: InsightsCloud.rules_url,
-          verify_ssl: ForemanRhCloud.verify_ssl_method,
-          proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
-          headers: {
-            Authorization: "Bearer #{rh_credentials}",
-          }
+          url: InsightsCloud.rules_url
         )
 
         JSON.parse(rules_response)

--- a/lib/insights_cloud/async/insights_resolutions_sync.rb
+++ b/lib/insights_cloud/async/insights_resolutions_sync.rb
@@ -22,14 +22,11 @@ module InsightsCloud
       private
 
       def query_insights_resolutions(rule_ids)
-        resolutions_response = RestClient::Request.execute(
+        resolutions_response = execute_cloud_request(
           method: :post,
           url: InsightsCloud.resolutions_url,
-          verify_ssl: ForemanRhCloud.verify_ssl_method,
-          proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
           headers: {
             content_type: :json,
-            Authorization: "Bearer #{rh_credentials}",
           },
           payload: {
             issues: rule_ids,

--- a/lib/insights_cloud/async/insights_rules_sync.rb
+++ b/lib/insights_cloud/async/insights_rules_sync.rb
@@ -37,14 +37,9 @@ module InsightsCloud
       private
 
       def query_insights_rules(offset)
-        rules_response = RestClient::Request.execute(
+        rules_response = execute_cloud_request(
           method: :get,
-          url: InsightsCloud.rules_url(offset: offset),
-          verify_ssl: ForemanRhCloud.verify_ssl_method,
-          proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
-          headers: {
-            Authorization: "Bearer #{rh_credentials}",
-          }
+          url: InsightsCloud.rules_url(offset: offset)
         )
 
         JSON.parse(rules_response)

--- a/lib/inventory_sync/async/query_inventory_job.rb
+++ b/lib/inventory_sync/async/query_inventory_job.rb
@@ -29,13 +29,10 @@ module InventorySync
       private
 
       def query_inventory(page = 1)
-        hosts_inventory_response = RestClient::Request.execute(
+        hosts_inventory_response = execute_cloud_request(
           method: :get,
           url: ForemanInventoryUpload.inventory_export_url,
-          verify_ssl: ForemanRhCloud.verify_ssl_method,
-          proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
           headers: {
-            Authorization: "Bearer #{rh_credentials}",
             params: {
               per_page: 100,
               page: page,


### PR DESCRIPTION
* Refactor RestClient requests to a single factory

* Fix tests that require tasks executor

* Refactor all RestClient calls to a single method

Now all requests will inherit the same basic properties.