### PR TITLE
[CP 2.3] Omit malformed bios_uuid values (#551)

### DIFF
--- a/lib/foreman_inventory_upload/generators/fact_helpers.rb
+++ b/lib/foreman_inventory_upload/generators/fact_helpers.rb
@@ -10,6 +10,8 @@ module ForemanInventoryUpload
       CLOUD_AZURE = 'azure'
       CLOUD_ALIBABA = 'alibaba'
 
+      UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
       def fact_value(host, fact_name)
         value_record = host.fact_values.find do |fact_value|
           fact_value.fact_name_id == ForemanInventoryUpload::Generators::Queries.fact_names[fact_name]
@@ -103,6 +105,23 @@ module ForemanInventoryUpload
 
       def obfuscate_ip(ip, ips_dict)
         "10.230.230.#{ips_dict.count + 1}"
+      end
+
+      def bios_uuid(host)
+        value = fact_value(host, 'dmi::system::uuid') || ''
+        uuid_value(value)
+      end
+
+      def uuid_value(value)
+        uuid_match = UUID_REGEX.match(value)
+        uuid_match&.to_s
+      end
+
+      def uuid_value!(value)
+        uuid = uuid_value(value)
+        raise Foreman::Exception.new(N_('Value %{value} is not a valid UUID') % {value: value}) if value && uuid.empty?
+
+        uuid
       end
     end
   end

--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -25,7 +25,7 @@ module ForemanInventoryUpload
 
       def report_slice(hosts_batch)
         @stream.object do
-          @stream.simple_field('report_slice_id', @slice_id)
+          @stream.simple_field('report_slice_id', uuid_value!(@slice_id))
           @stream.array_field('hosts', :last) do
             first = true
             hosts_batch.each do |host|
@@ -45,10 +45,10 @@ module ForemanInventoryUpload
         @stream.object do
           @stream.simple_field('fqdn', fqdn(host))
           @stream.simple_field('account', account_id(host.organization).to_s)
-          @stream.simple_field('subscription_manager_id', host.subscription_facet&.uuid)
-          @stream.simple_field('satellite_id', host.subscription_facet&.uuid)
-          @stream.simple_field('bios_uuid', fact_value(host, 'dmi::system::uuid'))
-          @stream.simple_field('vm_uuid', fact_value(host, 'virt::uuid'))
+          @stream.simple_field('subscription_manager_id', uuid_value!(host.subscription_facet&.uuid))
+          @stream.simple_field('satellite_id', uuid_value!(host.subscription_facet&.uuid))
+          @stream.simple_field('bios_uuid', bios_uuid(host))
+          @stream.simple_field('vm_uuid', uuid_value(fact_value(host, 'virt::uuid')))
           report_ip_addresses(host, host_ips_cache)
           report_mac_addresses(host)
           @stream.object_field('system_profile') do

--- a/test/factories/inventory_upload_factories.rb
+++ b/test/factories/inventory_upload_factories.rb
@@ -49,7 +49,7 @@ end
 
 FactoryBot.define do
   factory :katello_subscription_facets, :aliases => [:subscription_facet], :class => ::Katello::Host::SubscriptionFacet do
-    sequence(:uuid) { |n| "uuid-#{n}-#{rand(500)}" }
+    sequence(:uuid) { |n| "00000000-%<n>04d-%<r>04d-0000-000000000000" % {n: n, r: rand(500)} }
     facts { { 'memory.memtotal' => "12 GB" } }
   end
 end

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -71,7 +71,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_nil actual_host['ip_addresses']
     assert_nil actual_host['mac_addresses']
@@ -102,7 +102,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_system_profile = actual_host['system_profile'])
     assert_equal 4, actual_system_profile['number_of_cpus']
@@ -120,7 +120,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal @host.interfaces.where.not(ip: nil).first.ip, actual_host['ip_addresses'].first
     assert_equal @host.interfaces.where.not(mac: nil).first.mac, actual_host['mac_addresses'].first
@@ -142,7 +142,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal @host.interfaces.where.not(ip: nil).first.ip, actual_host['ip_addresses'].first
     assert_equal @host.interfaces.where.not(mac: nil).first.mac, actual_host['mac_addresses'].first
@@ -172,7 +172,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal @host.interfaces.where.not(ip: nil).first.ip, actual_host['ip_addresses'].first
     assert_equal @host.interfaces.where.not(mac: nil).first.mac, actual_host['mac_addresses'].first
@@ -191,7 +191,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal '10.230.230.1', actual_host['ip_addresses'].first
     assert_not_nil(actual_system_profile = actual_host['system_profile'])
@@ -221,7 +221,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal '10.230.230.100', actual_host['ip_addresses'].first
     assert_not_nil(actual_system_profile = actual_host['system_profile'])
@@ -243,7 +243,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal 'obfuscated_name', actual_host['fqdn']
     assert_equal '1234', actual_host['account']
@@ -263,7 +263,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
 
     obfuscated_fqdn = Digest::SHA1.hexdigest(@host.fqdn) + '.example.com'
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal obfuscated_fqdn, actual_host['fqdn']
     assert_equal '1234', actual_host['account']
@@ -282,7 +282,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal @host.fqdn, actual_host['fqdn']
     assert_equal '1234', actual_host['account']
@@ -346,7 +346,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal @host.fqdn, actual_host['fqdn']
     assert_not_nil(host_facts = actual_host['facts']&.first)
@@ -368,7 +368,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal @host.fqdn, actual_host['fqdn']
     assert_not_nil(host_facts = actual_host['facts']&.first)
@@ -388,7 +388,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal @host.fqdn, actual_host['fqdn']
     assert_equal '1234', actual_host['account']
@@ -408,7 +408,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_equal @host.fqdn, actual_host['fqdn']
     assert_equal '1234', actual_host['account']
@@ -427,7 +427,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_equal 1, generator.hosts_count
   end
 
@@ -440,7 +440,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 1024, actual_profile['system_memory_bytes']
@@ -466,7 +466,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_host['account'])
     assert_not_empty(actual_host['account'])
@@ -483,7 +483,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 'Red Hat Test Linux 7.1 (TestId)', actual_profile['os_release']
@@ -498,7 +498,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 'virtual', actual_profile['infrastructure_type']
@@ -513,7 +513,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 'physical', actual_profile['infrastructure_type']
@@ -528,7 +528,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 'aws', actual_profile['cloud_provider']
@@ -543,7 +543,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 'google', actual_profile['cloud_provider']
@@ -558,7 +558,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 'azure', actual_profile['cloud_provider']
@@ -573,7 +573,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 'alibaba', actual_profile['cloud_provider']
@@ -588,7 +588,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_equal 'alibaba', actual_profile['cloud_provider']
@@ -614,15 +614,43 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     json_str = generator.render
     actual = JSON.parse(json_str.join("\n"))
 
-    assert_equal 'slice_123', actual['report_slice_id']
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
     assert_not_nil(actual_host = actual['hosts'].first)
     assert_not_nil(actual_profile = actual_host['system_profile'])
     assert_not_nil(actual_profile['installed_packages'])
   end
 
+  test 'omits malformed bios_uuid field' do
+    FactoryBot.create(:fact_value, fact_name: fact_names['dmi::system::uuid'], value: 'test value', host: @host)
+
+    batch = Host.where(id: @host.id).in_batches.first
+    generator = create_generator(batch)
+
+    json_str = generator.render
+    actual = JSON.parse(json_str.join("\n"))
+
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
+    assert_not_nil(actual_host = actual['hosts'].first)
+    assert_nil actual_host['bios_uuid']
+  end
+
+  test 'passes valid bios_uuid field' do
+    FactoryBot.create(:fact_value, fact_name: fact_names['dmi::system::uuid'], value: 'D30B0B42-7824-2635-C62D-491394DE43F7', host: @host)
+
+    batch = Host.where(id: @host.id).in_batches.first
+    generator = create_generator(batch)
+
+    json_str = generator.render
+    actual = JSON.parse(json_str.join("\n"))
+
+    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
+    assert_not_nil(actual_host = actual['hosts'].first)
+    assert_not_nil actual_host['bios_uuid']
+  end
+
   private
 
-  def create_generator(batch, name = 'slice_123')
+  def create_generator(batch, name = '00000000-0000-0000-0000-000000000000')
     generator = ForemanInventoryUpload::Generators::Slice.new(batch, [], name)
     if block_given?
       yield(generator)


### PR DESCRIPTION
* Omit malformed bios_uuid values

* Add exceptions to UUID fields