### PR TITLE
Inject deprecation warning to old plugin

### DIFF
--- a/app/helpers/foreman_insights_deprecations_helper.rb
+++ b/app/helpers/foreman_insights_deprecations_helper.rb
@@ -1,0 +1,9 @@
+module ForemanInsightsDeprecationsHelper
+  def old_plugin_deprecation_warning
+    alert(
+      class: 'alert-warning',
+      close: false,
+      text: _('redhat_access plugin is deprecated and will be removed in Satellite 6.10. You can find recommendations for your hosts on hosts index and details pages.')
+    )
+  end
+end

--- a/app/overrides/old_plugin_deprecation.rb
+++ b/app/overrides/old_plugin_deprecation.rb
@@ -1,0 +1,20 @@
+Deface::Override.new(
+  virtual_path: 'redhat_access/analytics_dashboard/welcome',
+  name: 'deprecation_warning',
+  insert_before: 'div#welcome',
+  text: '<%= old_plugin_deprecation_warning %>'
+)
+
+Deface::Override.new(
+  virtual_path: 'redhat_access/analytics_dashboard/index',
+  name: 'deprecation_warning_index_not_met',
+  insert_before: 'article#content',
+  text: '<%= old_plugin_deprecation_warning %>'
+)
+
+Deface::Override.new(
+  virtual_path: 'redhat_access/analytics_dashboard/index',
+  name: 'deprecation_warning_index_met',
+  insert_before: 'div.main-content',
+  text: '<%= old_plugin_deprecation_warning %>'
+)


### PR DESCRIPTION
Now on all pages you should see the same deprecation:

![image](https://user-images.githubusercontent.com/10046168/124562443-b1163900-de47-11eb-916e-54357026fc89.png)

@MariSvirik Does it makes sense to you?