### PR TITLE
Add self host sync task

### DIFF
--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -70,8 +70,16 @@ module ForemanInventoryUpload
     folder
   end
 
+  def self.inventory_base_url
+    ForemanRhCloud.base_url + "/api/inventory/v1/hosts"
+  end
+
   def self.inventory_export_url
     tags = URI.encode("satellite/satellite_instance_id=#{Foreman.instance_id}")
-    ForemanRhCloud.base_url + "/api/inventory/v1/hosts?tags=#{tags}"
+    inventory_base_url + "?tags=#{tags}"
+  end
+
+  def self.inventory_self_url
+    inventory_base_url + "?hostname_or_id=#{ForemanRhCloud.foreman_host.fqdn}"
   end
 end

--- a/lib/inventory_sync/async/host_result.rb
+++ b/lib/inventory_sync/async/host_result.rb
@@ -1,6 +1,8 @@
 module InventorySync
   module Async
     class HostResult
+      attr_reader :uuid_by_fqdn
+
       def initialize(result)
         @total = result['total']
         @count = result['count']
@@ -8,6 +10,7 @@ module InventorySync
         @per_page = result['per_page']
         @sub_ids = result["results"].map { |host| host['subscription_manager_id'] }
         @uuid_by_sub_id = Hash[result["results"].map { |host| [host['subscription_manager_id'], host['id']] }]
+        @uuid_by_fqdn = Hash[result["results"].map { |host| [host['fqdn'].downcase, host['id']] }]
       end
 
       def status_hashes

--- a/lib/inventory_sync/async/inventory_hosts_sync.rb
+++ b/lib/inventory_sync/async/inventory_hosts_sync.rb
@@ -4,6 +4,12 @@ module InventorySync
       set_callback :iteration, :around, :setup_facet_transaction
       set_callback :step, :around, :create_facets
 
+      def plan
+        # by default the tasks will be executed concurrently
+        plan_self
+        plan_self_host_sync
+      end
+
       def setup_facet_transaction
         InsightsFacet.transaction do
           yield
@@ -32,6 +38,10 @@ module InventorySync
         existing_facets.select { |host_id, uuid| uuid.empty? }.each do |host_id, _uuid|
           InsightsFacet.where(host_id: host_id).update_all(uuid: uuids_hash[host_id])
         end
+      end
+
+      def plan_self_host_sync
+        plan_action InventorySync::Async::InventorySelfHostSync
       end
     end
   end

--- a/lib/inventory_sync/async/inventory_self_host_sync.rb
+++ b/lib/inventory_sync/async/inventory_self_host_sync.rb
@@ -1,0 +1,30 @@
+module InventorySync
+  module Async
+    class InventorySelfHostSync < QueryInventoryJob
+      set_callback :step, :around, :create_facets
+
+      def create_facets
+        # get the results from the event
+        results = yield
+
+        add_missing_insights_facet(results.uuid_by_fqdn) unless results.uuid_by_fqdn.empty?
+        results
+      end
+
+      private
+
+      def add_missing_insights_facet(uuids_hash)
+        facet = InsightsFacet.find_or_create_by(host_id: ForemanRhCloud.foreman_host.id) do |facet|
+          facet.uuid = uuids_hash.values.first
+        end
+
+        # fix empty uuid in case the facet already exists
+        facet.update(uuid: uuids_hash.values.first) unless facet.uuid
+      end
+
+      def request_url
+        ForemanInventoryUpload.inventory_self_url
+      end
+    end
+  end
+end

--- a/lib/inventory_sync/async/query_inventory_job.rb
+++ b/lib/inventory_sync/async/query_inventory_job.rb
@@ -31,7 +31,7 @@ module InventorySync
       def query_inventory(page = 1)
         hosts_inventory_response = execute_cloud_request(
           method: :get,
-          url: ForemanInventoryUpload.inventory_export_url,
+          url: request_url,
           headers: {
             params: {
               per_page: 100,
@@ -45,6 +45,10 @@ module InventorySync
 
       def logger
         action_logger
+      end
+
+      def request_url
+        ForemanInventoryUpload.inventory_export_url
       end
     end
   end

--- a/test/jobs/inventory_hosts_sync_test.rb
+++ b/test/jobs/inventory_hosts_sync_test.rb
@@ -243,6 +243,7 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
 
   test 'Inventory should sync UUID for existing Insights Facets' do
     InventorySync::Async::InventoryHostsSync.any_instance.expects(:query_inventory).returns(@inventory)
+    InventorySync::Async::InventoryHostsSync.any_instance.expects(:plan_self_host_sync)
 
     @host2.build_insights.save
 
@@ -255,6 +256,7 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
 
   test 'Inventory should sync UUID for new Insights Facets' do
     InventorySync::Async::InventoryHostsSync.any_instance.expects(:query_inventory).returns(@inventory)
+    InventorySync::Async::InventoryHostsSync.any_instance.expects(:plan_self_host_sync)
 
     ForemanTasks.sync_task(InventorySync::Async::InventoryHostsSync)
 

--- a/test/jobs/inventory_self_host_sync_test.rb
+++ b/test/jobs/inventory_self_host_sync_test.rb
@@ -1,0 +1,103 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class InventorySelfHostSyncTest < ActiveSupport::TestCase
+  include ForemanTasks::TestHelpers::WithInThreadExecutor
+
+  setup do
+    User.current = User.find_by(login: 'secret_admin')
+
+    # this host would pass our plugin queries, so it could be uploaded to the cloud.
+    @host1 = FactoryBot.create(:host)
+    @host1_inventory_id = '3255d080-e6c1-44e2-8d72-b044b9a38d8f'
+
+    ForemanInventoryUpload::Generators::Queries.instance_variable_set(:@fact_names, nil)
+
+    ForemanRhCloud.stubs(:foreman_host).returns(@host1)
+
+    inventory_json = <<-INVENTORY_JSON
+    {
+      "total": 1,
+      "count": 1,
+      "page": 1,
+      "per_page": 1,
+      "results": [
+        {
+          "insights_id": "e0dc5144-d78e-43ed-97be-a7a21d1b6946",
+          "rhel_machine_id": null,
+          "subscription_manager_id": "0f97ee19-6862-4900-aea4-f121c8754776",
+          "satellite_id": "0f97ee19-6862-4900-aea4-f121c8754776",
+          "bios_uuid": "6a0b199a-8225-4ade-ae44-3b18cfc84a01",
+          "ip_addresses": [
+            "192.168.122.136"
+          ],
+          "fqdn": "#{@host1.fqdn}",
+          "mac_addresses": [
+            "52:54:00:02:d1:2a",
+            "00:00:00:00:00:00"
+          ],
+          "external_id": null,
+          "id": "#{@host1_inventory_id}",
+          "account": "1460290",
+          "display_name": "insights-rh8.example.com",
+          "ansible_host": null,
+          "facts": [
+            {
+              "namespace": "satellite",
+              "facts": {
+                "virtual_host_name": "virt-who-nobody.home-1",
+                "satellite_instance_id": "fc4d0cb0-a0b0-421e-b096-b028319b8e47",
+                "is_simple_content_access": false,
+                "distribution_version": "8.3",
+                "satellite_version": "6.8.4",
+                "organization_id": 1,
+                "is_hostname_obfuscated": false,
+                "virtual_host_uuid": "a90e6294-4766-420a-8dc0-3ec5b96d60ec"
+              }
+            },
+            {
+              "namespace": "yupana",
+              "facts": {
+                "report_platform_id": "d37afa50-08ce-4efb-a0e5-759c2a016661",
+                "report_slice_id": "5bf791d7-5e30-4a3c-929a-11dd9fa6eb72",
+                "source": "Satellite",
+                "yupana_host_id": "78c62486-0ac4-406c-a4c0-3a1f81112a2d",
+                "account": "1460290"
+              }
+            }
+          ],
+          "reporter": "puptoo",
+          "stale_timestamp": "2021-03-19T06:05:12.092136+00:00",
+          "stale_warning_timestamp": "2021-03-26T06:05:12.092136+00:00",
+          "culled_timestamp": "2021-04-02T06:05:12.092136+00:00",
+          "created": "2021-02-08T13:22:50.555671+00:00",
+          "updated": "2021-03-18T01:05:12.131847+00:00"
+        }
+      ]
+    }
+    INVENTORY_JSON
+    @inventory = JSON.parse(inventory_json)
+  end
+
+  test 'Inventory should sync UUID for existing Insights Facets' do
+    InventorySync::Async::InventorySelfHostSync.any_instance.expects(:query_inventory).returns(@inventory)
+
+    @host1.build_insights.save
+
+    ForemanTasks.sync_task(InventorySync::Async::InventorySelfHostSync)
+
+    @host1.reload
+
+    assert_equal @host1_inventory_id, @host1.insights.uuid
+  end
+
+  test 'Inventory should sync UUID for new Insights Facets' do
+    InventorySync::Async::InventorySelfHostSync.any_instance.expects(:query_inventory).returns(@inventory)
+
+    ForemanTasks.sync_task(InventorySync::Async::InventorySelfHostSync)
+
+    @host1.reload
+
+    assert_equal @host1_inventory_id, @host1.insights.uuid
+  end
+end


### PR DESCRIPTION
Since foreman host will not be registered to itself, it will not be synced using the regular hosts sync task. This is because hosts sync task assumes all hosts have subscription facet and on the cloud side they will be marked as managed by Satellite.