### PR TITLE
[CP 2.3] BZ 1967138 - remediation modal vertical nav overlap (#607)

### DIFF
--- a/webpack/InsightsCloudSync/Components/RemediationModal/RemediationModal.scss
+++ b/webpack/InsightsCloudSync/Components/RemediationModal/RemediationModal.scss
@@ -6,4 +6,18 @@
       margin-top: 5px;
     }
   }
+
+  // applies to the backdrop parent of the modal
+  @at-root .pf-c-backdrop {
+    width: calc(100% - 200px) !important;
+    left: 200px !important;
+  }
+
+  // where the vertical nav breaks: https://github.com/theforeman/foreman/blob/3347fa49d500964f0209122d8d36c920d1feafcc/webpack/assets/javascripts/react_app/components/Layout/components/Toolbar/HeaderToolbar.scss#L26
+  @media (max-width: 768px) {
+    @at-root .pf-c-backdrop {
+      width: 100% !important;
+      left: 0 !important;
+    }
+  }
 }


### PR DESCRIPTION
the remediation modal is not visible properly in reduced browser window.