### PR TITLE
[CP 2.5] Handle duplicate InsightsFacets with upsert (#662)

### DIFF
--- a/lib/inventory_sync/async/host_result.rb
+++ b/lib/inventory_sync/async/host_result.rb
@@ -17,7 +17,6 @@ module InventorySync
         @sub_ids.map do |sub_id|
           host_id = host_id(sub_id)
           if host_id
-            touched << host_id
             {
               host_id: host_id,
               status: InventorySync::InventoryStatus::SYNC,
@@ -26,10 +25,6 @@ module InventorySync
             }
           end
         end.compact
-      end
-
-      def touched
-        @touched ||= []
       end
 
       def host_id(sub_id)

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -14,11 +14,7 @@ module InventorySync
       end
 
       def setup_statuses
-        @subscribed_hosts_ids = Set.new(
-          ForemanInventoryUpload::Generators::Queries.for_slice(
-            Host.unscoped.where(organization: input[:organization_id])
-          ).pluck(:id)
-        )
+        @subscribed_hosts_ids = Set.new(affected_host_ids)
 
         InventorySync::InventoryStatus.transaction do
           InventorySync::InventoryStatus.where(host_id: @subscribed_hosts_ids).delete_all
@@ -35,8 +31,10 @@ module InventorySync
       def update_statuses_batch
         results = yield
 
-        update_hosts_status(results.status_hashes, results.touched)
-        host_statuses[:sync] += results.touched.size
+        existing_hosts = results.status_hashes.select { |hash| @subscribed_hosts_ids.include?(hash[:host_id]) }
+
+        update_hosts_status(existing_hosts)
+        host_statuses[:sync] += existing_hosts.size
       end
 
       def rescue_strategy_for_self
@@ -45,9 +43,10 @@ module InventorySync
 
       private
 
-      def update_hosts_status(status_hashes, touched)
+      def update_hosts_status(status_hashes)
         InventorySync::InventoryStatus.create(status_hashes)
-        @subscribed_hosts_ids.subtract(touched)
+        updated_ids = status_hashes.map { |hash| hash[:host_id] }
+        @subscribed_hosts_ids.subtract(updated_ids)
       end
 
       def add_missing_hosts_statuses(hosts_ids)
@@ -67,6 +66,12 @@ module InventorySync
           sync: 0,
           disconnect: 0,
         }
+      end
+
+      def affected_host_ids
+        ForemanInventoryUpload::Generators::Queries.for_slice(
+          Host.unscoped.where(organization: input[:organization_id])
+        ).pluck(:id)
       end
     end
   end

--- a/lib/inventory_sync/async/inventory_hosts_sync.rb
+++ b/lib/inventory_sync/async/inventory_hosts_sync.rb
@@ -35,18 +35,14 @@ module InventorySync
       private
 
       def add_missing_insights_facets(uuids_hash)
-        existing_facets = InsightsFacet.where(host_id: uuids_hash.keys).pluck(:host_id, :uuid)
-        missing_facets = uuids_hash.except(*existing_facets.map(&:first)).map do |host_id, uuid|
+        all_facets = uuids_hash.map do |host_id, uuid|
           {
             host_id: host_id,
             uuid: uuid,
           }
         end
-        InsightsFacet.create(missing_facets)
 
-        existing_facets.select { |host_id, uuid| uuid.empty? }.each do |host_id, _uuid|
-          InsightsFacet.where(host_id: host_id).update_all(uuid: uuids_hash[host_id])
-        end
+        InsightsFacet.upsert_all(all_facets, unique_by: :host_id) unless all_facets.empty?
       end
 
       def plan_self_host_sync

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -37,6 +37,18 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
     @host2.subscription_facet.pools << pool
     @host2_inventory_id = '4536bf5c-ff03-4154-a8c9-32ff4b40e40c'
 
+    # this host would pass our plugin queries, so it could be uploaded to the cloud.
+    @host3 = FactoryBot.create(
+      :host,
+      :with_subscription,
+      :with_content,
+      content_view: cv.first,
+      lifecycle_environment: env,
+      organization: env.organization
+    )
+
+    @host3.subscription_facet.pools << pool
+
     ForemanInventoryUpload::Generators::Queries.instance_variable_set(:@fact_names, nil)
 
     inventory_json = <<-INVENTORY_JSON
@@ -151,7 +163,7 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
         {
           "insights_id": "b533848e-465f-4f1a-9b2b-b71cb2d5239d",
           "rhel_machine_id": null,
-          "subscription_manager_id": "d29bde40-348e-437c-8acf-8fa98320fc1b",
+          "subscription_manager_id": "#{@host3.subscription_facet.uuid}",
           "satellite_id": "d29bde40-348e-437c-8acf-8fa98320fc1b",
           "bios_uuid": "3cd5d972-cfb5-451a-8314-fd2f56629d7c",
           "ip_addresses": [
@@ -159,7 +171,7 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
             "fd6e:2298:736e::857",
             "fd6e:2298:736e:0:2c66:6101:9cc6:2b23"
           ],
-          "fqdn": "rhel8-demo.oss-lab.net",
+          "fqdn": "#{@host3.fqdn}",
           "mac_addresses": [
             "6e:66:a6:fe:fc:07",
             "00:00:00:00:00:00"
@@ -270,5 +282,19 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
     InventorySync::Async::InventoryFullSync.any_instance.expects(:plan_self).never
 
     ForemanTasks.sync_task(InventorySync::Async::InventoryFullSync, @host1.organization)
+  end
+
+  test 'Should skip hosts that are not returned in query' do
+    assert_nil InventorySync::InventoryStatus.where(host_id: @host3.id).first
+
+    Setting[:rh_cloud_token] = 'TEST TOKEN'
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:affected_host_ids).returns([@host1.id, @host2.id])
+    FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
+
+    ForemanTasks.sync_task(InventorySync::Async::InventoryFullSync, @host1.organization)
+    @host2.reload
+
+    assert_nil InventorySync::InventoryStatus.where(host_id: @host3.id).first
   end
 end

--- a/test/jobs/inventory_hosts_sync_test.rb
+++ b/test/jobs/inventory_hosts_sync_test.rb
@@ -265,4 +265,19 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
 
     assert_equal @host2_inventory_id, @host2.insights.uuid
   end
+
+  test 'Inventory should sync empty facets list' do
+    empty_inventory = @inventory.deep_clone
+    empty_inventory['results'] = []
+    InventorySync::Async::InventoryHostsSync.any_instance.expects(:query_inventory).returns(empty_inventory)
+    InventorySync::Async::InventoryHostsSync.any_instance.expects(:plan_self_host_sync)
+
+    assert_nil @host2.insights
+
+    ForemanTasks.sync_task(InventorySync::Async::InventoryHostsSync)
+
+    @host2.reload
+
+    assert_nil @host2.insights
+  end
 end


### PR DESCRIPTION
* Use upsert to update inventory facets

* Fix InventoryFullSync statuses

* Fix empty response