### PR TITLE
[CP 2.3] Handle duplicate InsightsFacets with upsert (#662)

### DIFF
--- a/lib/inventory_sync/async/host_result.rb
+++ b/lib/inventory_sync/async/host_result.rb
@@ -17,7 +17,6 @@ module InventorySync
         @sub_ids.map do |sub_id|
           host_id = host_id(sub_id)
           if host_id
-            touched << host_id
             {
               host_id: host_id,
               status: InventorySync::InventoryStatus::SYNC,
@@ -26,10 +25,6 @@ module InventorySync
             }
           end
         end.compact
-      end
-
-      def touched
-        @touched ||= []
       end
 
       def host_id(sub_id)

--- a/lib/inventory_sync/async/inventory_hosts_sync.rb
+++ b/lib/inventory_sync/async/inventory_hosts_sync.rb
@@ -31,18 +31,14 @@ module InventorySync
       private
 
       def add_missing_insights_facets(uuids_hash)
-        existing_facets = InsightsFacet.where(host_id: uuids_hash.keys).pluck(:host_id, :uuid)
-        missing_facets = uuids_hash.except(*existing_facets.map(&:first)).map do |host_id, uuid|
+        all_facets = uuids_hash.map do |host_id, uuid|
           {
             host_id: host_id,
             uuid: uuid,
           }
         end
-        InsightsFacet.create(missing_facets)
 
-        existing_facets.select { |host_id, uuid| uuid.empty? }.each do |host_id, _uuid|
-          InsightsFacet.where(host_id: host_id).update_all(uuid: uuids_hash[host_id])
-        end
+        InsightsFacet.upsert_all(all_facets, unique_by: :host_id) unless all_facets.empty?
       end
 
       def plan_self_host_sync

--- a/test/jobs/inventory_hosts_sync_test.rb
+++ b/test/jobs/inventory_hosts_sync_test.rb
@@ -265,4 +265,19 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
 
     assert_equal @host2_inventory_id, @host2.insights.uuid
   end
+
+  test 'Inventory should sync empty facets list' do
+    empty_inventory = @inventory.deep_clone
+    empty_inventory['results'] = []
+    InventorySync::Async::InventoryHostsSync.any_instance.expects(:query_inventory).returns(empty_inventory)
+    InventorySync::Async::InventoryHostsSync.any_instance.expects(:plan_self_host_sync)
+
+    assert_nil @host2.insights
+
+    ForemanTasks.sync_task(InventorySync::Async::InventoryHostsSync)
+
+    @host2.reload
+
+    assert_nil @host2.insights
+  end
 end


### PR DESCRIPTION
* Use upsert to update inventory facets

* Fix InventoryFullSync statuses

* Fix empty response