### PR TITLE
fix infinite loop on total risk chart error

### DIFF
--- a/webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js
+++ b/webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js
@@ -25,7 +25,7 @@ const InsightsTotalRiskCard = ({ hostDetails: { id } }) => {
   } = useAPI('get', insightsCloudUrl(`hits/${id}`), API_OPTIONS);
 
   useEffect(() => {
-    if (status !== STATUS.PENDING) {
+    if (status === STATUS.RESOLVED) {
       const risks = getInitialRisks();
       hits.forEach(({ total_risk: risk }) => {
         risks[risk].value += 1;


### PR DESCRIPTION
found that when there's a network error or host without recommendation, it may cause an infinite loop in the use-effect.