### PR TITLE
Fix redhat-cloud-services/frontend-components scss import

### DIFF
--- a/webpack/InsightsCloudSync/Components/InsightsTable/table.scss
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/table.scss
@@ -1,5 +1,3 @@
-@import '~@redhat-cloud-services/frontend-components/index.css';
-
 .rh-cloud-recommendations-table {
   .pf-c-table__check {
     input:disabled {


### PR DESCRIPTION
@redhat-cloud-services/frontend-components/index.css will be exported to Foreman via https://github.com/theforeman/foreman-js/pull/387