### PR TITLE
Refs #33010 - fix slot's id

### DIFF
--- a/webpack/ForemanRhCloudFills.js
+++ b/webpack/ForemanRhCloudFills.js
@@ -18,7 +18,7 @@ const fills = [
     weight: 400,
   },
   {
-    slot: 'details-cards',
+    slot: 'host-overview-cards',
     name: 'insights-total-risk-chart',
     component: props => <InsightsTotalRiskCard {...props} />,
     weight: 1100,


### PR DESCRIPTION
Fixing the overview tab cards slot's id, once we add the new details tab, the `details-cards` id is too ambiguous.

 blocked by https://github.com/theforeman/foreman/pull/9054