### PR TITLE
limit remediation to specific host even if all selected on new host page

### DIFF
--- a/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTableActions.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTableActions.js
@@ -8,8 +8,11 @@ import {
   INSIGHTS_SET_SELECTED_IDS,
   INSIGHTS_SET_SELECT_ALL_ALERT,
   INSIGHTS_SET_SELECT_ALL,
-  NEW_HOST_PATH,
 } from './InsightsTableConstants';
+import {
+  getServerQueryForHostname,
+  isNewHostPage,
+} from './InsightsTableHelpers';
 
 export const fetchInsights = (queryParams = {}) => (dispatch, getState) => {
   const state = getState();
@@ -34,13 +37,7 @@ export const fetchInsights = (queryParams = {}) => (dispatch, getState) => {
     dispatch(setSelectAllAlert(false));
   }
 
-  let search = query;
-  if (isNewHostPage(uri)) {
-    const hostname = uri.pathname().split('/new/hosts/')[1];
-    const hostQuery = `hostname = ${hostname}`;
-    const q = query?.trim();
-    search = q ? `${hostQuery} AND (${q})` : hostQuery;
-  }
+  const search = getServerQueryForHostname(query);
 
   return dispatch(
     get({
@@ -151,11 +148,9 @@ const setSelectAllUrl = selectAllValue => dispatch => {
 
 const updateUrl = (uri, dispatch) => {
   const nextUrlParams = { search: uri.search() };
-  if (isNewHostPage(uri)) {
+  if (isNewHostPage()) {
     // we need to keep the hash so the insights tab will remain selected in the new host details page.
     nextUrlParams.hash = '/Insights';
   }
   dispatch(push(nextUrlParams));
 };
-
-const isNewHostPage = uri => uri.pathname().includes(NEW_HOST_PATH);

--- a/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTableHelpers.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTableHelpers.js
@@ -1,4 +1,7 @@
 /* eslint-disable camelcase */
+import URI from 'urijs';
+import { NEW_HOST_PATH } from './InsightsTableConstants';
+
 export const modifySelectedRows = (
   hits,
   selectedIds,
@@ -53,4 +56,23 @@ export const getPerPageOptions = (urlPerPage, appPerPage) => {
   urlPerPage && initialValues.add(urlPerPage);
   const options = [...initialValues].sort((a, b) => a - b);
   return options.map(value => ({ title: value.toString(), value }));
+};
+
+export const isNewHostPage = () => {
+  const uri = new URI();
+  const pathname = uri.pathname();
+  const isIncluded = pathname.includes(NEW_HOST_PATH);
+  return isIncluded ? pathname.split('/new/hosts/')[1] : false; // return hostname or false
+};
+
+// return query or specific hostname with query if it's in the new host page.
+export const getServerQueryForHostname = query => {
+  const isNewHost = isNewHostPage();
+  let serverQuery = query;
+  if (isNewHost) {
+    const hostQuery = `hostname = ${isNewHost}`;
+    const q = query?.trim();
+    serverQuery = q ? `${hostQuery} AND (${q})` : hostQuery;
+  }
+  return serverQuery;
 };

--- a/webpack/InsightsCloudSync/Components/RemediationModal/RemediationActions.js
+++ b/webpack/InsightsCloudSync/Components/RemediationModal/RemediationActions.js
@@ -1,4 +1,5 @@
 import { get } from 'foremanReact/redux/API';
+import { getServerQueryForHostname } from '../InsightsTable/InsightsTableHelpers';
 import {
   REMEDIATIONS_API_KEY,
   REMEDIATIONS_PATH,
@@ -8,5 +9,9 @@ export const fetchRemediations = ({ selectedIds, isAllSelected, query }) =>
   get({
     key: REMEDIATIONS_API_KEY,
     url: REMEDIATIONS_PATH,
-    params: { ids: Object.keys(selectedIds), isAllSelected, query },
+    params: {
+      ids: Object.keys(selectedIds),
+      isAllSelected,
+      query: getServerQueryForHostname(query),
+    },
   });


### PR DESCRIPTION
at the moment, when the user selects all recommendations from all pages
all host's resolutions was shown.
when the user views the insights table from the host page,
we should limit it to that specific host.