### PR TITLE
BZ2069640 - prevent hits#show network errors

### DIFF
--- a/app/controllers/insights_cloud/hits_controller.rb
+++ b/app/controllers/insights_cloud/hits_controller.rb
@@ -14,9 +14,16 @@ module InsightsCloud
 
     def show
       host = Host.where(id: host_id_param).first
+      hits = host.insights&.hits
+
+      unless hits
+        return render json: {
+          error: 'No recommendations were found for this host',
+        }, status: :not_found
+      end
 
       render json: {
-        hits: host.insights.hits,
+        hits: hits,
       }, status: :ok
     end
 

--- a/webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js
+++ b/webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js
@@ -19,10 +19,11 @@ const InsightsTotalRiskCard = ({ hostDetails: { id } }) => {
   const dispatch = useDispatch();
   const API_KEY = `HOST_${id}_RECOMMENDATIONS`;
   const API_OPTIONS = useMemo(() => ({ key: API_KEY }), [API_KEY]);
+  const url = id && insightsCloudUrl(`hits/${id}`); // This will keep the API call from being triggered if there's no host id.
   const {
     status = STATUS.PENDING,
     response: { hits = [] },
-  } = useAPI('get', insightsCloudUrl(`hits/${id}`), API_OPTIONS);
+  } = useAPI('get', url, API_OPTIONS);
 
   useEffect(() => {
     if (status === STATUS.RESOLVED) {


### PR DESCRIPTION
When accessing the overview tab on the new host page,
there are two network error responses with a 500 status.
the first one which tries the endpoint `/insights_cloud/hits/3` is because that specific host doesn't have recommendations.

and the second which comes right after that is failing due to the path ends with `/insights_cloud/hits/undefined`

this doesn't cause errors to be seen on the UI,
but rather an API call that could be avoided.