### PR TITLE
job_finished_message should indicate overall playbook status

### DIFF
--- a/lib/insights_cloud/async/connector_playbook_execution_reporter_task.rb
+++ b/lib/insights_cloud/async/connector_playbook_execution_reporter_task.rb
@@ -137,6 +137,7 @@ module InsightsCloud
 
       def report_job_progress(invocation_status)
         generator = InsightsCloud::Generators::PlaybookProgressGenerator.new(correlation_id)
+        all_hosts_success = true
 
         invocation_status.each do |host_name, status|
           # skip host if the host already reported that it's finished
@@ -151,9 +152,10 @@ module InsightsCloud
           if status['state'] == 'stopped'
             generator.host_finished_message(host_name, status['exit_status'])
             status['report_done'] = true
+            all_hosts_success &&= status['exit_status'] == 0
           end
         end
-        generator.job_finished_message if done?(invocation_status)
+        generator.job_finished_message(all_hosts_success) if done?(invocation_status)
 
         send_report(generator.generate)
       end

--- a/lib/insights_cloud/generators/playbook_progress_generator.rb
+++ b/lib/insights_cloud/generators/playbook_progress_generator.rb
@@ -30,12 +30,12 @@ module InsightsCloud
         }
       end
 
-      def job_finished_message
+      def job_finished_message(success)
         @messages << {
           "type": "playbook_run_completed",
           "version": 3,
           "correlation_id": correlation_id,
-          "status": "success",
+          "status": success ? 'success' : 'failure',
         }
       end
 

--- a/test/unit/playbook_progress_generator_test.rb
+++ b/test/unit/playbook_progress_generator_test.rb
@@ -51,7 +51,7 @@ class PlaybookProgressGeneratorTest < ActiveSupport::TestCase
   end
 
   test 'Outputs job finished message' do
-    @generator.job_finished_message
+    @generator.job_finished_message(true)
 
     actual = @generator.generate
     actual_message = JSON.parse(actual)


### PR DESCRIPTION
consoleDot expects the `playbook_run_completed` status to indicate if the playbook succeeded for all hosts or indicate failure if at least one host failed.

@tahmidefaz @aleccohan -- could you verify this looks as you are expecting?