### PR TITLE
use a space after `>=` for better parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "url": "http://projects.theforeman.org/projects/foreman_rh_cloud/issues"
   },
   "peerDependencies": {
-    "@theforeman/vendor": ">=8.16.0"
+    "@theforeman/vendor": ">= 8.16.0"
   },
   "devDependencies": {
     "@babel/core": "~7.7.0",
-    "@theforeman/builder": ">=8.16.0",
-    "@theforeman/stories": ">=8.16.0",
-    "@theforeman/test": ">=8.16.0",
-    "@theforeman/eslint-plugin-foreman": ">=8.16.0",
+    "@theforeman/builder": ">= 8.16.0",
+    "@theforeman/stories": ">= 8.16.0",
+    "@theforeman/test": ">= 8.16.0",
+    "@theforeman/eslint-plugin-foreman": ">= 8.16.0",
     "babel-eslint": "~10.0.0",
     "eslint": "~6.7.2",
     "eslint-plugin-spellcheck": "~0.0.17",


### PR DESCRIPTION
rpm doesn't like the modifier not to be separated from the version without a space