### PR TITLE
Add support for LEAPP data downloads

### DIFF
--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -71,6 +71,12 @@ module ForemanRhCloud
           ssl_client_cert: OpenSSL::X509::Certificate.new(certs[:cert]),
           ssl_client_key: OpenSSL::PKey::RSA.new(certs[:key]),
         }
+      when pes_request?
+        {
+          url: ForemanRhCloud.cert_base_url + request_path,
+          ssl_client_cert: OpenSSL::X509::Certificate.new(certs[:cert]),
+          ssl_client_key: OpenSSL::PKey::RSA.new(certs[:key]),
+        }
       else # Legacy insights API
         {
           url: ForemanRhCloud.legacy_insights_url + request_path.sub('/redhat_access/r/insights', '/r/insights'),
@@ -97,6 +103,10 @@ module ForemanRhCloud
 
     def connection_test_request?
       ->(request_path) { request_path =~ /redhat_access\/r\/insights\/?$/ }
+    end
+
+    def pes_request?
+      ->(request_path) { request_path =~ /api\/pes\// }
     end
 
     def prepare_forward_cloud_url(base_url, request_path)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,10 @@ Rails.application.routes.draw do
 
   # API routes
 
+  scope :module => :'insights_cloud/api', :path => '/api/pes' do
+    match '(/*path)(/)', to: 'machine_telemetries#forward_request', via: [:get]
+  end
+
   namespace :api, :defaults => {:format => 'json'} do
     scope '(:apiv)', :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       resources :organizations, :only => [:show] do

--- a/test/unit/services/foreman_rh_cloud/cloud_request_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/cloud_request_forwarder_test.rb
@@ -22,6 +22,7 @@ class CloudRequestForwarderTest < ActiveSupport::TestCase
       "/redhat_access/r/insights/platform/ingress/v1/upload" => "https://cert.cloud.example.com/api/ingress/v1/upload",
       "/redhat_access/r/insights/uploads/67200803-132b-474b-a6f9-37be74185df4" => "https://cert-api.access.example.com/r/insights/uploads/67200803-132b-474b-a6f9-37be74185df4",
       "/redhat_access/r/insights/" => "https://cert.cloud.example.com/api/apicast-tests/ping",
+      "/api/pes/repomap.json" => "https://cert.cloud.example.com/api/pes/repomap.json",
     }
 
     paths.each do |key, value|


### PR DESCRIPTION
LEAPP upgrade tool needs to download files from the cloud, so they need support for forwarding their requests through the server similar to insights-client.