### PR TITLE
Schedule a random delay before execution

### DIFF
--- a/lib/foreman_inventory_upload/async/delayed_start.rb
+++ b/lib/foreman_inventory_upload/async/delayed_start.rb
@@ -1,0 +1,51 @@
+module ForemanInventoryUpload
+  module Async
+    module DelayedStart
+      extend ActiveSupport::Concern
+
+      START_WINDOW = 3.hours.seconds
+
+      def after_delay(delay = nil, logger: nil, &block)
+        logger ||= self.logger if respond_to? :logger
+        delay ||= ForemanRhCloud.requests_delay || Random.new.rand(START_WINDOW)
+        delay = delay.to_i
+
+        logger&.debug("planning a delay for #{delay} seconds before the rest of the execution")
+
+        sequence do
+          plan_action(ForemanInventoryUpload::Async::DelayAction, delay)
+          concurrence(&block)
+        end
+      end
+
+      def humanized_name
+        _('Wait and %s' % super)
+      end
+    end
+
+    class DelayAction < ::Actions::EntryAction
+      Wake = Algebrick.atom
+
+      def plan(delay)
+        plan_self(delay: delay)
+      end
+
+      def run(event = nil)
+        case event
+        when nil
+          action_logger.debug("Going to sleep for #{sleep_seconds} seconds")
+          plan_event(Wake, sleep_seconds)
+          suspend
+        when Wake
+          action_logger.debug('Waking up')
+        else
+          action_logger.debug("DelayAction received unknown event #{event}")
+        end
+      end
+
+      def sleep_seconds
+        input[:delay].to_i
+      end
+    end
+  end
+end

--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -120,4 +120,8 @@ module ForemanRhCloud
   def self.cloud_url_validator
     @cloud_url_validator ||= Regexp.new(ENV['SATELLITE_RH_CLOUD_VALIDATOR'] || 'redhat.com$')
   end
+
+  def self.requests_delay
+    @requests_delay ||= ENV['SATELLITE_RH_CLOUD_REQUESTS_DELAY']
+  end
 end

--- a/lib/insights_cloud/async/insights_scheduled_sync.rb
+++ b/lib/insights_cloud/async/insights_scheduled_sync.rb
@@ -2,6 +2,7 @@ module InsightsCloud
   module Async
     class InsightsScheduledSync < ::Actions::EntryAction
       include ::Actions::RecurringAction
+      include ForemanInventoryUpload::Async::DelayedStart
 
       def plan
         unless Setting[:allow_auto_insights_sync]
@@ -12,7 +13,9 @@ module InsightsCloud
           return
         end
 
-        plan_full_sync
+        after_delay do
+          plan_full_sync
+        end
       end
 
       def plan_full_sync

--- a/lib/inventory_sync/async/inventory_scheduled_sync.rb
+++ b/lib/inventory_sync/async/inventory_scheduled_sync.rb
@@ -2,6 +2,7 @@ module InventorySync
   module Async
     class InventoryScheduledSync < ::Actions::EntryAction
       include ::Actions::RecurringAction
+      include ForemanInventoryUpload::Async::DelayedStart
 
       def plan
         unless Setting[:allow_auto_inventory_upload]
@@ -12,8 +13,10 @@ module InventorySync
           return
         end
 
-        Organization.unscoped.each do |org|
-          plan_org_sync(org)
+        after_delay do
+          Organization.unscoped.each do |org|
+            plan_org_sync(org)
+          end
         end
       end
 


### PR DESCRIPTION
Adding another option for randomizing task schedule. 
This correlates  to option 1 in https://github.com/theforeman/foreman_rh_cloud/pull/781

The idea is to wait in the main task before starting the execution of the sub-tasks.