### PR TITLE
Add host searching based on insights statuses

### DIFF
--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -11,5 +11,15 @@ module RhCloudHost
 
     has_many :insights_hits, through: :insights, source: :hits
     scoped_search :relation => :insights, :on => :hits_count, :only_explicit => true, :rename => :insights_recommendations_count
+
+    has_one :insights_client_report_status_object, :class_name => '::InsightsClientReportStatus', :foreign_key => 'host_id'
+    scoped_search :relation => :insights_client_report_status_object, :on => :status, :rename => :insights_client_report_status,
+                  :complete_value => { :reporting => ::InsightsClientReportStatus::REPORTING,
+                                       :no_report => ::InsightsClientReportStatus::NO_REPORT }
+
+    has_one :inventory_sync_status_object, :class_name => '::InventorySync::InventoryStatus', :foreign_key => 'host_id'
+    scoped_search :relation => :inventory_sync_status_object, :on => :status, :rename => :insights_inventory_sync_status,
+                  :complete_value => { :disconnect => ::InventorySync::InventoryStatus::DISCONNECT,
+                                       :sync => ::InventorySync::InventoryStatus::SYNC }
   end
 end


### PR DESCRIPTION
This is adding missing search definitions which were forgotten when the statuses were introduced.