### PR TITLE
Remove icon from toolbar buttons on inventory page

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButton.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButton.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Spinner, Button } from '@patternfly/react-core';
-import { RedoIcon } from '@patternfly/react-icons';
 import { STATUS } from 'foremanReact/constants';
 import { SYNC_BUTTON_TEXT } from '../../../../ForemanInventoryConstants';
 
@@ -27,7 +26,7 @@ class SyncButton extends React.Component {
           isDisabled={status === STATUS.PENDING}
           variant="secondary"
         >
-          {status === STATUS.PENDING ? <Spinner size="sm" /> : <RedoIcon />}
+          {status === STATUS.PENDING && <Spinner size="sm" />}
           {SYNC_BUTTON_TEXT}
         </Button>
       </React.Fragment>

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/__tests__/__snapshots__/SyncButton.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/__tests__/__snapshots__/SyncButton.test.js.snap
@@ -9,11 +9,6 @@ exports[`SyncButton rendering render with Props 1`] = `
     size="lg"
     variant="secondary"
   >
-    <RedoIcon
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-    />
      Sync inventory status
   </Button>
 </Fragment>


### PR DESCRIPTION
@ShimShtein let me know how this looks, I was able to get a devel box installed with the plugin and I don't see the icon anymore.

I switched the logic up based on this:

https://stackoverflow.com/a/70337425