### PR TITLE
Add Hybrid Cloud rake task

### DIFF
--- a/lib/tasks/fedramp.rake
+++ b/lib/tasks/fedramp.rake
@@ -1,0 +1,58 @@
+require 'io/console'
+
+namespace :rh_cloud do |args|
+  desc 'Register Satellite Organization with Hybrid Cloud API. \
+        Specify org_id=x replace your organization ID with x. \
+        Specify SATELLITE_RH_CLOUD_URL=https://x with the Hybrid Cloud endpoint you are connecting to.'
+  task hybridcloud_register: [:environment] do
+    include ::ForemanRhCloud::CertAuth
+    include ::InsightsCloud::CandlepinCache
+    
+    def logger
+      @logger ||= Logger.new(STDOUT)
+    end
+
+    def registrations_url
+      logger.warn("Custom url is not set, using the default one: #{ForemanRhCloud.base_url}") if ENV['SATELLITE_RH_CLOUD_URL'].empty?
+      ForemanRhCloud.base_url + '/api/identity/certificate/registrations'
+    end
+
+    if ENV['org_id'].nil?
+      logger.error('ERROR: org_id needs to be specified.')
+      exit(1)
+    end
+    
+    organization = Organization.find_by(id: ENV['org_id'].to_i) # saw this coming in as a string, so making sure it gets passed as an integer.
+    
+    @uid = cp_owner_id(organization)
+    logger.error('Organization provided does not have a manifest imported.') + exit(1) if @uid.nil?
+
+    puts 'Paste your token, output will be hidden.'
+    @token = STDIN.noecho(&:gets).chomp
+    logger.error('Token was not entered.') + exit(1) if @token.empty?
+
+    def headers
+      {
+        Authorization: "Bearer #{@token}"
+      }
+    end
+
+    def payload
+      {
+        "uid": @uid
+      }
+    end
+
+    def method
+      :post
+    end
+
+    execute_cloud_request(
+      organization: organization,
+      method: method,
+      url: registrations_url,
+      headers: headers,
+      payload: payload.to_json
+    )
+  end
+end


### PR DESCRIPTION
@ShimShtein

Here is the rake task, I am waiting on getting a token to test with but did confirm with the Insights team that they are seeing the response correctly when I pass in a fake token(foo)

I added the suggestion you wanted with having the ability to override the URL.

Output showing it's connecting:
```bash
Paste your token, output will be hidden.
D, [2023-03-01T19:11:01.337382 #8667] DEBUG -- : Failed response with code 500 headers for request url https://ephem-tls.outsrights.cc/api/identity/certificate/registrations are: {:x_amzn_requestid=>"5d07f3bd-6705-4087-b8e3-80f9713ed861", :x_amzn_remapped_content_length=>"174", :set_cookie=>["d7bca3c18ed4c32d59cbf3a6abaf73d6=ad4a508fae5d7b11119e1ca8af7e53df; path=/; HttpOnly; Secure; SameSite=None"], :x_amz_apigw_id=>"BHZy3GGCoAMFTeA=", :x_amzn_remapped_server=>"openresty", :x_content_type_options=>"nosniff", :x_amzn_remapped_date=>"Wed, 01 Mar 2023 19:11:01 GMT", :content_type=>"text/html", :content_length=>"174", :date=>"Wed, 01 Mar 2023 19:11:01 GMT"} and body: <html>
<head><title>500 Internal Server Error</title></head>
<body>
<center><h1>500 Internal Server Error</h1></center>
<hr><center>openresty</center>
</body>
</html>
 
rake aborted!
RestClient::InternalServerError: 500 Internal Server Error
```