### PR TITLE
Add org name and fqdn to Hybrid Cloud reg task

### DIFF
--- a/lib/tasks/hybrid_cloud.rake
+++ b/lib/tasks/hybrid_cloud.rake
@@ -22,9 +22,9 @@ namespace :rh_cloud do |args|
       exit(1)
     end
     
-    organization = Organization.find_by(id: ENV['org_id'].to_i) # saw this coming in as a string, so making sure it gets passed as an integer.
-    
-    @uid = cp_owner_id(organization)
+    @organization = Organization.find_by(id: ENV['org_id'].to_i) # saw this coming in as a string, so making sure it gets passed as an integer.
+    @uid = cp_owner_id(@organization)
+    @hostname = ForemanRhCloud.foreman_host_name
     logger.error('Organization provided does not have a manifest imported.') + exit(1) if @uid.nil?
 
     puts 'Paste your token, output will be hidden.'
@@ -39,7 +39,8 @@ namespace :rh_cloud do |args|
 
     def payload
       {
-        "uid": @uid
+        "uid": @uid,
+        "display_name": "#{@hostname}+#{@organization.label}"
       }
     end
 
@@ -49,7 +50,7 @@ namespace :rh_cloud do |args|
 
     begin
       response = execute_cloud_request(
-        organization: organization,
+        organization: @organization,
         method: method,
         url: registrations_url,
         headers: headers,


### PR DESCRIPTION
@ShimShtein 

Here is the output showing it is registering to the endpoint correctly with the new payload params:

```
Paste your token, output will be hidden.
D, [2023-03-14T19:15:58.185624 #5605] DEBUG -- : Response headers for request url https://ephem-tls.outsrights.cc/api/identity/certificate/registrations are: {:x_amzn_requestid=>"b9069776-0c8c-40a3-8832-5de1743a858b", :x_amzn_remapped_content_length=>"37", :set_cookie=>["d7bca3c18ed4c32d59cbf3a6abaf73d6=d7af00a91655d95a019b33ed9d0ecc6c; path=/; HttpOnly; Secure; SameSite=None"], :x_amz_apigw_id=>"ByQtQEFJoAMFUMg=", :x_amzn_remapped_server=>"openresty", :x_content_type_options=>"nosniff", :x_amzn_remapped_date=>"Tue, 14 Mar 2023 19:15:58 GMT", :content_type=>"text/plain; charset=utf-8", :content_length=>"37", :date=>"Tue, 14 Mar 2023 19:15:57 GMT"}
D, [2023-03-14T19:15:58.185796 #5605] DEBUG -- : {"message":"Successfully registered"}
```