### PR TITLE
Add backend changes for missing hosts

### DIFF
--- a/app/controllers/api/v2/rh_cloud/inventory_controller.rb
+++ b/app/controllers/api/v2/rh_cloud/inventory_controller.rb
@@ -28,6 +28,29 @@ module Api
           }, status: :ok
         end
 
+        api :GET, "/organizations/:organization_id/rh_cloud/missing_hosts", N_("Grab hosts that are missing in RH Cloud")
+        param :organization_id, Integer, required: true, desc: N_("Set the current organization context for the request")
+        def get_hosts
+          organization_id = params[:organization_id]
+          payload = InsightsMissingHosts.where(organization_id: organization_id)
+
+          render :json => payload
+        end
+
+        api :POST, "/organizations/:organization_id/rh_cloud/missing_hosts", N_("Grab hosts that are missing in RH Cloud")
+        param :organization_id, Integer, required: true, desc: N_("Set the current organization context for the request")
+        param :search_term, String, required: true, desc: N_("Scoped search string for host removal")
+        def remove_hosts
+          organization_id = params[:organization_id]
+          search_term = params[:search_term]
+
+          task = ForemanTasks.async_task(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, search_term, organization_id)
+
+          render json: {
+            task: task,
+          }, status: :ok
+        end
+
         api :POST, "/organizations/:organization_id/rh_cloud/inventory_sync", N_("Start inventory synchronization")
         param :organization_id, Integer, required: true, desc: N_("Set the current organization context for the request")
         def sync_inventory_status

--- a/app/controllers/foreman_inventory_upload/missing_hosts_controller.rb
+++ b/app/controllers/foreman_inventory_upload/missing_hosts_controller.rb
@@ -1,0 +1,22 @@
+module ForemanInventoryUpload
+  class MissingHostsController < ::ApplicationController
+    def index
+      organizations = Organization.current || User.current.my_organizations
+      organization_id = organizations.pluck(:id)
+      payload = InsightsMissingHosts.where(organization_id: organization_id)
+
+      render :json => payload
+    end
+
+    def remove_hosts
+      organization_id = params[:organization_id]
+      search_term = params[:search_term]
+
+      task = ForemanTasks.async_task(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, search_term, organization_id)
+
+      render json: {
+        task: task,
+      }, status: :ok
+    end
+  end
+end

--- a/app/models/insights_missing_host.rb
+++ b/app/models/insights_missing_host.rb
@@ -2,4 +2,6 @@ class InsightsMissingHost < ApplicationRecord
   belongs_to :organization
 
   scoped_search on: [:name, :insights_id, :rhsm_id, :ip_address]
+  validates :organization_id, presence: true
+  validates :name, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     post ':organization_id/reports', to: 'reports#generate', constraints: { organization_id: %r{[^\/]+} }
     get ':organization_id/uploads/last', to: 'uploads#last', constraints: { organization_id: %r{[^\/]+} }
     get ':organization_id/uploads/file', to: 'uploads#download_file', constraints: { organization_id: %r{[^\/]+} }
+    get 'missing_hosts', to: 'missing_hosts#index'
     get 'accounts', to: 'accounts#index'
     get 'settings', to: 'uploads_settings#index'
     post 'setting', to: 'uploads_settings#set_advanced_setting'
@@ -50,10 +51,12 @@ Rails.application.routes.draw do
     scope '(:apiv)', :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       resources :organizations, :only => [:show] do
         namespace 'rh_cloud' do
+          get 'missing_hosts', to: 'inventory#get_hosts'
           get 'report', to: 'inventory#download_file'
           post 'report', to: 'inventory#generate_report'
 
           post 'inventory_sync', to: 'inventory#sync_inventory_status'
+          post 'missing_hosts', to: 'inventory#remove_hosts'
         end
       end
 

--- a/db/migrate/20230515140211_add_missing_hosts_table.foreman_rh_cloud.rb
+++ b/db/migrate/20230515140211_add_missing_hosts_table.foreman_rh_cloud.rb
@@ -3,8 +3,8 @@
 class AddMissingHostsTable < ActiveRecord::Migration[6.1]
   def change
     create_table :insights_missing_hosts do |t|
-      t.integer :organization_id
       t.string :name
+      t.integer :organization_id
       t.string :insights_id
       t.string :rhsm_id
       t.string :ip_address

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -52,9 +52,10 @@ module ForemanRhCloud
             :generate_foreman_rh_cloud,
             'foreman_inventory_upload/reports': [:generate],
             'foreman_inventory_upload/tasks': [:create],
-            'api/v2/rh_cloud/inventory': [:sync_inventory_status, :download_file, :generate_report, :enable_cloud_connector],
+            'api/v2/rh_cloud/inventory': [:get_hosts, :remove_hosts, :sync_inventory_status, :download_file, :generate_report, :enable_cloud_connector],
             'foreman_inventory_upload/uploads': [:enable_cloud_connector],
             'foreman_inventory_upload/uploads_settings': [:set_advanced_setting],
+            'foreman_inventory_upload/missing_hosts': [:remove_hosts],
             'insights_cloud/settings': [:update],
             'insights_cloud/tasks': [:create]
           )
@@ -66,6 +67,7 @@ module ForemanRhCloud
             'foreman_inventory_upload/tasks': [:show],
             'foreman_inventory_upload/cloud_status': [:index],
             'foreman_inventory_upload/uploads_settings': [:index],
+            'foreman_inventory_upload/missing_hosts': [:index],
             'react': [:index]
           )
           permission(


### PR DESCRIPTION
* Added route
* Added GET controller method for API
* Added new controller for UI with GET route
* Added permissions for routes
* Updated model with validations
* Fix model file name
* Fix migration (was not adding the `organization_id` column for some reason, this way it does)

Getting data back on get method :)
```ruby
19:21:52 rails.1   | 2023-05-19T19:21:52 [I|app|9d49580f] Started GET "/api/v2/organizations/3/rh_cloud/missing_hosts" for 192.168.196.1 at 2023-05-19 19:21:52 -0400
19:21:52 rails.1   | 2023-05-19T19:21:52 [I|app|9d49580f] Processing by Api::V2::RhCloud::InventoryController#get_hosts as JSON
19:21:52 rails.1   | 2023-05-19T19:21:52 [I|app|9d49580f]   Parameters: {"apiv"=>"v2", "organization_id"=>"3"}
19:21:52 rails.1   | 2023-05-19T19:21:52 [D|app|9d49580f] Body: {"id":1,"name":"foo.example.com","organization_id":3,"insights_id":"111-222","rhsm_id":"111-222","ip_address":"192.168.196.1"}
```