### PR TITLE
Fix host deletion task call

### DIFF
--- a/lib/inventory_sync/async/inventory_scheduled_sync.rb
+++ b/lib/inventory_sync/async/inventory_scheduled_sync.rb
@@ -19,7 +19,7 @@ module InventorySync
             Organization.unscoped.each do |org|
               sequence do
                 plan_org_sync(org)
-                plan_remove_insights_hosts(org) if Setting[:allow_auto_insights_mismatch_delete]
+                plan_remove_insights_hosts(org.id) if Setting[:allow_auto_insights_mismatch_delete]
               end
             end
           end
@@ -30,9 +30,9 @@ module InventorySync
         plan_action InventoryFullSync, org
       end
 
-      def plan_remove_insights_hosts
+      def plan_remove_insights_hosts(org_id)
         # plan a remove hosts action with search set to empty (all records)
-        plan_action(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, '', org.id)
+        plan_action(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, '', org_id)
       end
 
       def logger


### PR DESCRIPTION
@chris1984 @jameerpathan111 I think this should fix our deletion task.

Also: the deletion is done only with the scheduled task, so if you want to test it, you have to run it manually from the console:

```
[2] pry(main)> ENV['SATELLITE_RH_CLOUD_REQUESTS_DELAY'] = '0'
=> "0"
[3] pry(main)> ForemanTasks.sync_task(InventorySync::Async::InventoryScheduledSync)
```

This will invoke the scheduled update task immediately.