### PR TITLE
Ensure Configure Cloud Connector runs as root

### DIFF
--- a/app/views/job_templates/cloud_connector.erb
+++ b/app/views/job_templates/cloud_connector.erb
@@ -30,6 +30,7 @@ feature: ansible_configure_cloud_connector
 
 ---
 - hosts: all
+  become: true
   vars:
     satellite_cloud_connector_url: "<%= foreman_server_url %>"
   roles:


### PR DESCRIPTION
When a user has set the REX user as non-root, this task fails. Setting become to true means it will attempt to use sudo, which allows it to work in more cases.

Replacement of https://github.com/theforeman/foreman_rh_cloud/pull/791