### PR TITLE
WIP - Add ability to generate report without uploading

### DIFF
--- a/app/controllers/concerns/inventory_upload/report_actions.rb
+++ b/app/controllers/concerns/inventory_upload/report_actions.rb
@@ -10,7 +10,7 @@ module InventoryUpload
       end
     end
 
-    def start_report_generation(organization_id)
+    def start_report_generation(organization_id, disconnected)
       ForemanTasks.async_task(ForemanInventoryUpload::Async::GenerateReportJob, ForemanInventoryUpload.generated_reports_folder, organization_id)
     end
 

--- a/app/controllers/foreman_inventory_upload/reports_controller.rb
+++ b/app/controllers/foreman_inventory_upload/reports_controller.rb
@@ -21,8 +21,9 @@ module ForemanInventoryUpload
 
     def generate
       organization_id = params[:organization_id]
+      disconnected = params[:disconnected]
 
-      start_report_generation(organization_id)
+      start_report_generation(organization_id, disconnected)
 
       render json: {
         action_status: 'success',

--- a/lib/foreman_inventory_upload/async/generate_report_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_report_job.rb
@@ -5,7 +5,7 @@ module ForemanInventoryUpload
         "report_for_#{label}"
       end
 
-      def plan(base_folder, organization_id)
+      def plan(base_folder, organization_id, disconnected)
         sequence do
           super(
             GenerateReportJob.output_label(organization_id),
@@ -18,7 +18,7 @@ module ForemanInventoryUpload
             base_folder,
             ForemanInventoryUpload.facts_archive_name(organization_id),
             organization_id
-          )
+          ) unless disconnected
         end
       end
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@theforeman/test": ">= 10.1.1",
     "@theforeman/eslint-plugin-foreman": ">= 10.1.1",
     "babel-eslint": "~10.0.0",
-    "cosmiconfig-typescript-loader": "~4.3.0",
+    "cosmiconfig-typescript-loader": "^4.0.0",
     "eslint": "~6.7.2",
     "eslint-plugin-spellcheck": "~0.0.17",
     "jed": "~1.1.1",

--- a/webpack/ForemanInventoryUpload/Components/AccountList/AccountListActions.js
+++ b/webpack/ForemanInventoryUpload/Components/AccountList/AccountListActions.js
@@ -40,6 +40,40 @@ export const stopAccountStatusPolling = pollingProcessID => dispatch => {
   });
 };
 
+export const restartDisconnected = (accountID, activeTab) => async dispatch => {
+  let processController = null;
+  let processStatusName = null;
+  let disconnected = true
+
+  if (activeTab === 'uploading') {
+    processController = 'uploads';
+    processStatusName = 'upload_report_status';
+  } else {
+    processController = 'reports';
+    processStatusName = 'generate_report_status';
+  }
+
+  try {
+    await API.post(inventoryUrl(`${accountID}/${processController}`));
+    dispatch({
+      type: INVENTORY_PROCESS_RESTART,
+      payload: {
+        accountID,
+        disconnected,
+        processStatusName,
+      },
+    });
+  } catch (error) {
+    dispatch(
+      addToast({
+        sticky: true,
+        type: 'error',
+        message: error.message,
+      })
+    );
+  }
+};
+
 export const restartProcess = (accountID, activeTab) => async dispatch => {
   let processController = null;
   let processStatusName = null;

--- a/webpack/ForemanInventoryUpload/Components/Dashboard/index.js
+++ b/webpack/ForemanInventoryUpload/Components/Dashboard/index.js
@@ -2,7 +2,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import * as actions from './DashboardActions';
-import { restartProcess } from '../AccountList/AccountListActions';
+import { restartProcess, restartDisconnected } from '../AccountList/AccountListActions';
 import reducer from './DashboardReducer';
 
 import Dashboard from './Dashboard';
@@ -25,7 +25,7 @@ const mapStateToProps = (state, { accountID }) => ({
 
 // map action dispatchers to props
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ ...actions, restartProcess }, dispatch);
+  bindActionCreators({ ...actions, restartProcess, restartDisconnected }, dispatch);
 
 // export reducers
 export const reducers = { dashboard: reducer };

--- a/webpack/ForemanInventoryUpload/Components/ReportGenerate/ReportGenerate.fixtures.js
+++ b/webpack/ForemanInventoryUpload/Components/ReportGenerate/ReportGenerate.fixtures.js
@@ -4,6 +4,7 @@ export const exitCode = 'exit 0';
 export const logs = ['No running process'];
 export const completed = 0;
 export const restartProcess = noop;
+export const restartDisconnected = noop;
 export const error = null;
 export const scheduled = '2019-08-21T16:14:16.520+03:00';
 export const props = {
@@ -11,6 +12,7 @@ export const props = {
   logs,
   completed,
   restartProcess,
+  restartDisconnected,
   error,
   scheduled,
 };

--- a/webpack/ForemanInventoryUpload/Components/ReportGenerate/ReportGenerate.js
+++ b/webpack/ForemanInventoryUpload/Components/ReportGenerate/ReportGenerate.js
@@ -12,6 +12,7 @@ const ReportGenerate = ({
   completed,
   error,
   restartProcess,
+  restartDisconnected,
   toggleFullScreen,
   scheduled,
 }) => (
@@ -19,6 +20,7 @@ const ReportGenerate = ({
     <TabHeader
       exitCode={exitCode}
       onRestart={restartProcess}
+      restartDisconnected={restartDisconnected}
       toggleFullScreen={toggleFullScreen}
     />
     <TabBody
@@ -39,6 +41,7 @@ ReportGenerate.propTypes = {
   ]),
   completed: PropTypes.number,
   error: PropTypes.string,
+  restartDisconnected: PropTypes.func,
   restartProcess: PropTypes.func,
   toggleFullScreen: PropTypes.func,
   scheduled: PropTypes.string,
@@ -50,6 +53,7 @@ ReportGenerate.defaultProps = {
   completed: 0,
   error: null,
   restartProcess: noop,
+  restartDisconnected: noop,
   toggleFullScreen: noop,
   scheduled: null,
 };

--- a/webpack/ForemanInventoryUpload/Components/ReportUpload/ReportUpload.fixtures.js
+++ b/webpack/ForemanInventoryUpload/Components/ReportUpload/ReportUpload.fixtures.js
@@ -5,6 +5,7 @@ export const exitCode = 'exit 0';
 export const logs = ['No running process'];
 export const completed = 0;
 export const restartProcess = noop;
+export const restartDisconnected = noop;
 export const downloadReports = noop;
 export const error = null;
 export const props = {
@@ -13,6 +14,7 @@ export const props = {
   logs,
   completed,
   restartProcess,
+  restartDisconnected,
   downloadReports,
   error,
 };

--- a/webpack/ForemanInventoryUpload/Components/TabHeader/TabHeader.js
+++ b/webpack/ForemanInventoryUpload/Components/TabHeader/TabHeader.js
@@ -1,12 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Button, Icon } from 'patternfly-react';
+import { Grid, Button, Icon, DropdownItem, Dropdown, DropdownToggle, DropdownToggleAction } from 'patternfly-react';
 import { noop } from 'foremanReact/common/helpers';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { isExitCodeLoading } from '../../ForemanInventoryHelpers';
 import './tabHeader.scss';
 
-const TabHeader = ({ exitCode, onRestart, onDownload, toggleFullScreen }) => (
+const onActionToggle = () => {
+  setIsActionOpen(prev => !prev);
+};
+
+const dropdownItems = [
+  <DropdownItem
+    aria-label="restart_disconnected"
+    ouiaId="restart_disconnected"
+    key="restart_disconnected"
+    component="button"
+    onClick={restartDisconnected}
+    isDisabled={isExitCodeLoading(exitCode)}
+  >
+    {__('Restart without uploading')}
+  </DropdownItem>,
+];
+
+const TabHeader = ({ exitCode, onRestart, onDownload, restartDisconnected, toggleFullScreen }) => (
   <Grid.Row className="tab-header">
     <Grid.Col sm={6}>
       <p>{sprintf(__('Exit Code: %s'), exitCode)}</p>
@@ -14,13 +31,27 @@ const TabHeader = ({ exitCode, onRestart, onDownload, toggleFullScreen }) => (
     <Grid.Col sm={6}>
       <div className="tab-action-buttons">
         {onRestart ? (
-          <Button
-            bsStyle="primary"
-            onClick={onRestart}
-            disabled={isExitCodeLoading(exitCode)}
-          >
-            {__('Restart')}
-          </Button>
+          <Dropdown
+          aria-label="restart_dropdown"
+          ouiaId="restart_dropdown"
+          toggle={
+            <DropdownToggle
+              aria-label="restart_report_toggle"
+              ouiaId="restart_report_toggle"
+              splitButtonItems={[
+                <DropdownToggleAction key="action" aria-label="bulk_actions" onClick={onRestart}>
+                  {__('Restart')}
+                </DropdownToggleAction>,
+              ]}
+              splitButtonVariant="action"
+              toggleVariant="primary"
+              onToggle={onActionToggle}
+              isDisabled={isExitCodeLoading(exitCode)}
+            />
+        }
+          isOpen={isActionOpen}
+          dropdownItems={dropdownItems}
+        />
         ) : null}
         {onDownload ? (
           <Button onClick={onDownload}>


### PR DESCRIPTION
Need to figure out why i'm getting
```javascript
TabHeader.js:19  Uncaught ReferenceError: restartDisconnected is not defined
at Object.<anonymous> (TabHeader.js:19:14)
```

And also update the JS snapshots so tests will pass.

@ShimShtein let me know if the backend change looks fine, I sent a link to this pr to @Ron-Lavi  so he can help with the JS stuff

Looks like the JS tests GitHub action is failing to even start with our favorite thing
```javascript
npm ERR! cipm can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm ERR! 
npm ERR! 
npm ERR! Invalid: lock file's cosmiconfig-typescript-loader@4.0.0 does not satisfy cosmiconfig-typescript-loader@~4.3.0
npm ERR! 
```