### PR TITLE
Update ruby_tests.yml to use Foreman3_9 container

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/theforeman/tfm_plugin_test:foreman_3_7
+      image: ghcr.io/theforeman/tfm_plugin_test:foreman_3_9
 
     services:
       postgres:


### PR DESCRIPTION
@ShimShtein can this get a review, Ewoud's translations pr because of `Foreman::PluginRequirementError: ERF72-3740 [Foreman::PluginRequirementError]: foreman_rh_cloud plugin requires Foreman >= 3.7 but current is 3.6.2`