### PR TITLE
Fixes tags_generator_test

### DIFF
--- a/test/unit/tags_generator_test.rb
+++ b/test/unit/tags_generator_test.rb
@@ -46,6 +46,9 @@ class TagsGeneratorTest < ActiveSupport::TestCase
   end
 
   test 'generates tags for a single host' do
+    instance_id = Foreman.uuid
+    Foreman.stubs(:instance_id).returns(instance_id)
+
     generator = create_generator
 
     actual = generator.generate.group_by { |key, value| key }


### PR DESCRIPTION
Added explicit mock for `Foreman.instance_id`