### PR TITLE
Remove subscription label from report slice

### DIFF
--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -126,7 +126,6 @@ module ForemanInventoryUpload
         ) { |v| os_release_value(*v) }
         @stream.simple_field('os_kernel_version', fact_value(host, 'uname::release'))
         @stream.simple_field('arch', host.architecture&.name)
-        @stream.simple_field('subscription_status', host.subscription_status_label)
         @stream.simple_field('katello_agent_running', false)
         @stream.simple_field(
           'infrastructure_type',


### PR DESCRIPTION
With SCA being the default, this is now longer needed and has been removed from Katello so it throws an error in our tests