### PR TITLE
SAT-25518 - Change removed URI.escape to CGI.escape w Ruby3

### DIFF
--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -75,7 +75,7 @@ module ForemanInventoryUpload
   end
 
   def self.inventory_export_url
-    tags = URI.encode("satellite/satellite_instance_id=#{Foreman.instance_id}")
+    tags = CGI.escape("satellite/satellite_instance_id=#{Foreman.instance_id}")
     inventory_base_url + "?tags=#{tags}"
   end
 


### PR DESCRIPTION
With the switch to Ruby3 we are getting the following traceback with inventory sync:

```ruby
13:07:08 rails.1   | 2024-06-13T13:07:08 [W|bac|9b31bf0e] undefined method `encode' for URI:Module (NoMethodError)
13:07:08 rails.1   |  9b31bf0e | /home/vagrant/foreman_rh_cloud/lib/foreman_inventory_upload.rb:78:in `inventory_export_url'
13:07:08 rails.1   |  9b31bf0e | /home/vagrant/foreman_rh_cloud/lib/inventory_sync/async/query_inventory_job.rb:74:in `request_url'
13:07:08 rails.1   |  9b31bf0e | /home/vagrant/foreman_rh_cloud/lib/inventory_sync/async/query_inventory_job.rb:57:in `query_inventory'
```

According to Stack Overflow Ruby3 got rid of `URI.escape` and suggest using `CGI.escape`
https://stackoverflow.com/questions/68635238/undefined-method-encode-for-urimodule-with-gem-rspotify
https://stackoverflow.com/questions/68174351/undefined-method-escape-for-urimodule

After PR, sync runs fine.

I looked in the code and this was the only instance I could find of `URI.escape`