### PR TITLE
Add convert2rhel fact to host report

### DIFF
--- a/foreman_rh_cloud.gemspec
+++ b/foreman_rh_cloud.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'foreman_ansible'
   s.add_dependency 'foreman-tasks'
-  s.add_dependency 'katello'
+  s.add_runtime_dependency 'katello', '>= 4.14.0.rc1.1'
 
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'

--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -47,6 +47,7 @@ module ForemanInventoryUpload
           @stream.simple_field('account', account_id(host.organization).to_s)
           @stream.simple_field('subscription_manager_id', uuid_value!(host.subscription_facet&.uuid))
           @stream.simple_field('satellite_id', uuid_value!(host.subscription_facet&.uuid))
+          @stream.simple_field('convert2rhel_through_foreman', host.subscription_facet&.convert2rhel_through_foreman)
           @stream.simple_field('bios_uuid', bios_uuid(host))
           @stream.simple_field('vm_uuid', uuid_value(fact_value(host, 'virt::uuid')))
           @stream.simple_field('insights_id', uuid_value(fact_value(host, 'insights_id')))

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -107,8 +107,8 @@ module InsightsCloud::Api
 
     context '#branch_info' do
       setup do
+        UpstreamOnlySettingsTestHelper.set_if_available('allow_multiple_content_views')
         User.current = User.find_by(login: 'secret_admin')
-        Setting[:allow_multiple_content_views] = true
 
         @env = FactoryBot.create(:katello_k_t_environment)
         @env2 = FactoryBot.create(:katello_k_t_environment, organization: @env.organization)

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -108,6 +108,7 @@ module InsightsCloud::Api
     context '#branch_info' do
       setup do
         User.current = User.find_by(login: 'secret_admin')
+        Setting[:allow_multiple_content_views] = true
 
         @env = FactoryBot.create(:katello_k_t_environment)
         @env2 = FactoryBot.create(:katello_k_t_environment, organization: @env.organization)

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -117,3 +117,11 @@ module CandlepinIsolation
     end
   end
 end
+
+module UpstreamOnlySettingsTestHelper
+  def self.set_if_available(setting_name, value: true)
+    Setting[setting_name] = value
+  rescue Foreman::Exception
+    skip "Setting #{setting_name} is not available in Foreman"
+  end
+end

--- a/test/unit/tags_generator_test.rb
+++ b/test/unit/tags_generator_test.rb
@@ -5,8 +5,8 @@ class TagsGeneratorTest < ActiveSupport::TestCase
   include CandlepinIsolation
 
   setup do
+    UpstreamOnlySettingsTestHelper.set_if_available('allow_multiple_content_views')
     User.current = User.find_by(login: 'secret_admin')
-    Setting[:allow_multiple_content_views] = true
 
     env = FactoryBot.create(:katello_k_t_environment)
     env2 = FactoryBot.create(:katello_k_t_environment, organization: env.organization)

--- a/test/unit/tags_generator_test.rb
+++ b/test/unit/tags_generator_test.rb
@@ -6,6 +6,7 @@ class TagsGeneratorTest < ActiveSupport::TestCase
 
   setup do
     User.current = User.find_by(login: 'secret_admin')
+    Setting[:allow_multiple_content_views] = true
 
     env = FactoryBot.create(:katello_k_t_environment)
     env2 = FactoryBot.create(:katello_k_t_environment, organization: env.organization)


### PR DESCRIPTION
To test:

#### Setup

On a registered host, create a custom fact file that includes `conversions.env.CONVERT2RHEL_THROUGH_FOREMAN`:

```
[root@toledo8 ~]# cat /etc/rhsm/facts/convert2rhel.facts {
"conversions.version": "1",
"conversions.activity": "conversion",
"conversions.packages.0.nevra": "convert2rhel-0:2.0.0-1.el8.noarch",
"conversions.packages.0.signature": "RSA/SHA256, Thu May 30 13:31:33 2024, Key ID 199e2f91fd431d51",
"conversions.executed": "/usr/bin/convert2rhel",
"conversions.success": true,
"conversions.activity_started": "2024-07-11T17:28:54.281664Z",
"conversions.activity_ended": "2024-07-11T17:48:47.026664Z",
"conversions.source_os.id": "Cerulean Leopard",
"conversions.source_os.name": "AlmaLinux",
"conversions.source_os.version": "8.10",
"conversions.target_os.id": "Ootpa",
"conversions.target_os.name": "Red Hat Enterprise Linux",
"conversions.target_os.version": "8.10",
"conversions.env.CONVERT2RHEL_THROUGH_FOREMAN": "1",
"conversions.run_id": "null"
}
```

Update facts:
```
subscription-manager facts --update
```

Verify that the host's `subscription_facet_attributes` have `convert2rhel_through_foreman: 1`

#### Test

Ensure that the host's `host_registration_insights` parameter is set to true
On the Inventory Upload page, click 'Sync inventory status' and wait for the sync to complete

On the host, run
```
organization_id=1 target=/var/lib/foreman/red_hat_inventory/generated_reports/ bundle exec rake rh_cloud_inventory:report:generate
```

You should see, at the end of the output, something like 
```
Successfully generated /tmp/d20240827-17482-t377is/report_for_1.tar.xz for organization id 1
```

CD into that directory, then run
```
$ tar -vxf report_for_1.tar.xz
./
./metadata.json
./d5f5c08b-7903-4c58-8c08-53d1f37c753c.json
```

All files except `metadata.json` will be about individual hosts. Find your host and verify its json contains `convert2rhel_through_foreman`:

```
$ cat d5f5c08b-7903-4c58-8c08-53d1f37c753c.json | jq
{
  "report_slice_id": "d5f5c08b-7903-4c58-8c08-53d1f37c753c",
  "hosts": [
    {
      "fqdn": "rhel9b.fedora.example.com",
      "account": "1212729",
      "subscription_manager_id": "8cea8fa3-c2c1-463a-953c-ae29386ca7b5",
      "satellite_id": "8cea8fa3-c2c1-463a-953c-ae29386ca7b5",
      "convert2rhel_through_foreman": 1,
...
```
