### PR TITLE
Replace "Satellite" with "Foreman" in user-facing strings.

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
@@ -8,19 +8,19 @@ export const PageDescription = () => (
   <div id="inventory_page_description">
     <Text>
       {__(
-        'The Red Hat Hybrid Cloud Console provides a set of cloud services, including Red Hat Insights and Subscriptions, that provide predictive analysis, remediation of issues, and unified subscription reporting for this Satellite instance.'
+        'The Red Hat Hybrid Cloud Console provides a set of cloud services, including Red Hat Insights and Subscriptions, that provide predictive analysis, remediation of issues, and unified subscription reporting for this Foreman instance.'
       )}
     </Text>
     <Text>
       {__(
-        'The Satellite inventory upload plugin automatically uploads Satellite host inventory data to the Inventory service of Insights, where it can also be used by the Subscriptions service for subscription reporting. If you use the Subscriptions service, enabling inventory uploads is required.'
+        'The Foreman inventory upload plugin automatically uploads Foreman host inventory data to the Inventory service of Insights, where it can also be used by the Subscriptions service for subscription reporting. If you use the Subscriptions service, enabling inventory uploads is required.'
       )}
     </Text>
     <Text>
       <FormattedMessage
         id="enable-upload-hint"
         defaultMessage={__(
-          'To enable this reporting for all Satellite organizations, set {uploadButtonName} to on. The data will be reported automatically once per day.'
+          'To enable this reporting for all Foreman organizations, set {uploadButtonName} to on. The data will be reported automatically once per day.'
         )}
         values={{
           uploadButtonName: <strong>{__('Automatic inventory upload')}</strong>,

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/__tests__/__snapshots__/PageDescription.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/__tests__/__snapshots__/PageDescription.test.js.snap
@@ -5,14 +5,14 @@ exports[`PageDescription rendering render without Props 1`] = `
   id="inventory_page_description"
 >
   <Text>
-    The Red Hat Hybrid Cloud Console provides a set of cloud services, including Red Hat Insights and Subscriptions, that provide predictive analysis, remediation of issues, and unified subscription reporting for this Satellite instance.
+    The Red Hat Hybrid Cloud Console provides a set of cloud services, including Red Hat Insights and Subscriptions, that provide predictive analysis, remediation of issues, and unified subscription reporting for this Foreman instance.
   </Text>
   <Text>
-    The Satellite inventory upload plugin automatically uploads Satellite host inventory data to the Inventory service of Insights, where it can also be used by the Subscriptions service for subscription reporting. If you use the Subscriptions service, enabling inventory uploads is required.
+    The Foreman inventory upload plugin automatically uploads Foreman host inventory data to the Inventory service of Insights, where it can also be used by the Subscriptions service for subscription reporting. If you use the Subscriptions service, enabling inventory uploads is required.
   </Text>
   <Text>
     <FormattedMessage
-      defaultMessage="To enable this reporting for all Satellite organizations, set {uploadButtonName} to on. The data will be reported automatically once per day."
+      defaultMessage="To enable this reporting for all Foreman organizations, set {uploadButtonName} to on. The data will be reported automatically once per day."
       id="enable-upload-hint"
       values={
         Object {

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -37,7 +37,7 @@ const NewHostDetailsTab = ({ hostName, router }) => {
 
   const dropdownItems = [
     <DropdownItem key="insights-link" ouiaId="insights-link">
-      <a onClick={onSatInsightsClick}>{__('Go to Satellite Insights page')}</a>
+      <a onClick={onSatInsightsClick}>{__('Go to Foreman Insights page')}</a>
     </DropdownItem>,
   ];
 


### PR DESCRIPTION
This PR provides a starting point for un-branding this plugin.

Only user-facing strings are un-branded right now. Un-branding environment variables or hash-keys would either break existing usages or create a bit of a mess. I am not sure that would be worth the trouble...

Using `foreman_theme_satellite` in conjunction with this plugin re-applies the branding. 