### PR TITLE
allow babel/core 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@theforeman/vendor": ">= 10.1.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.7.0",
+    "@babel/core": "^7.7.0",
     "@theforeman/builder": ">= 10.1.1",
     "@theforeman/test": ">= 10.1.1",
     "@theforeman/eslint-plugin-foreman": ">= 10.1.1",


### PR DESCRIPTION
We currently use 7.23 in Foreman and this works fine. Reflect it in package.json