### PR TITLE
don't pin cosmiconfig-typescript-loader anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@theforeman/test": ">= 10.1.1",
     "@theforeman/eslint-plugin-foreman": ">= 10.1.1",
     "babel-eslint": "~10.0.0",
-    "cosmiconfig-typescript-loader": "~4.3.0",
     "eslint": "~6.7.2",
     "eslint-plugin-spellcheck": "~0.0.17",
     "jed": "~1.1.1",


### PR DESCRIPTION
We pinned that in cc0511a7 to fix tests, but do not depend on it
ourself. Let's unpin and see if tests are green again.
