### PR TITLE
Fixes #910 - Insights tab displayed for non-RHEL hosts

### DIFF
--- a/webpack/ForemanRhCloudFills.js
+++ b/webpack/ForemanRhCloudFills.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';
 import InventoryAutoUploadSwitcher from './ForemanInventoryUpload/SubscriptionsPageExtension/InventoryAutoUpload';
 import NewHostDetailsTab from './InsightsHostDetailsTab/NewHostDetailsTab';
-import InsightsTotalRiskCard from './InsightsHostDetailsTab/InsightsTotalRiskChart';
+import { InsightsTotalRiskChartWrapper } from './InsightsHostDetailsTab/InsightsTotalRiskChartWrapper';
+import { isNotRhelHost } from './ForemanRhCloudHelpers';
 
 const fills = [
   {
@@ -16,22 +17,27 @@ const fills = [
     name: 'Insights',
     component: props => <NewHostDetailsTab {...props} />,
     weight: 400,
+    metadata: {
+      hideTab: isNotRhelHost,
+    },
   },
   {
     slot: 'host-overview-cards',
     name: 'insights-total-risk-chart',
-    component: props => <InsightsTotalRiskCard {...props} />,
+    component: props => <InsightsTotalRiskChartWrapper {...props} />,
     weight: 2800,
   },
 ];
 
 export const registerFills = () => {
-  fills.forEach(({ slot, name, component: Component, weight }, index) =>
-    addGlobalFill(
-      slot,
-      name,
-      <Component key={`rh-cloud-fill-${index}`} />,
-      weight
-    )
+  fills.forEach(
+    ({ slot, name, component: Component, weight, metadata }, index) =>
+      addGlobalFill(
+        slot,
+        name,
+        <Component key={`rh-cloud-fill-${index}`} />,
+        weight,
+        metadata
+      )
   );
 };

--- a/webpack/ForemanRhCloudHelpers.js
+++ b/webpack/ForemanRhCloudHelpers.js
@@ -4,3 +4,7 @@
  * should be imported once core moves it to the ReactApp folder.
  */
 export const foremanUrl = path => `${window.URL_PREFIX}${path}`;
+
+export const isNotRhelHost = ({ hostDetails }) =>
+  // eslint-disable-next-line camelcase
+  !new RegExp('red\\s?hat', 'i').test(hostDetails?.operatingsystem_name);

--- a/webpack/InsightsHostDetailsTab/InsightsTotalRiskChartWrapper.js
+++ b/webpack/InsightsHostDetailsTab/InsightsTotalRiskChartWrapper.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import InsightsTotalRiskChart from './InsightsTotalRiskChart';
+import { isNotRhelHost } from '../ForemanRhCloudHelpers';
+
+export const InsightsTotalRiskChartWrapper = props => {
+  if (props.status === 'RESOLVED') {
+    return (
+      !isNotRhelHost(props.hostDetails) && <InsightsTotalRiskChart {...props} /> // check for RHEL hosts
+    );
+  }
+  return null;
+};
+
+InsightsTotalRiskChartWrapper.propTypes = {
+  status: PropTypes.string,
+  hostDetails: PropTypes.object,
+};
+
+InsightsTotalRiskChartWrapper.defaultProps = {
+  status: 'PENDING',
+  hostDetails: {},
+};


### PR DESCRIPTION
Fixes #910 

## Changes made
- Add helper-function isNotRhelHost
- Hide insights tab based on host-OS by using "hideTab" fill-metadata field.
- Hide TotalRisk card based on host-OS by wrapping it.

The isNotRhelHost check is not the nicest but this is similar to how it is done in:
provisioning_templates/snippet/insights.erb:<% if @host.operatingsystem.name == 'RedHat' -%>