### PR TITLE
Add a zeitwerk inflection

### DIFF
--- a/config/initializer/inflections.rb
+++ b/config/initializer/inflections.rb
@@ -1,0 +1,7 @@
+# Be sure to restart your server when you modify this file.
+Rails.autoloaders.each do |autoloader|
+  autoloader.inflector.inflect(
+ 'url_remediations_retriever' => 'URLRemediationsRetriever'    
+  )
+end
+


### PR DESCRIPTION
to handle this error
```
/home/vagrant/foreman/.vendor/ruby/3.0.0/gems/zeitwerk-2.6.18/lib/zeitwerk/loader/callbacks.rb:32:in `on_file_autoloaded': expected file /home/vagrant/foreman_rh_cloud/app/services/foreman_rh_cloud/url_remediations_retriever.rb to define constant ForemanRhCloud::URLRemediationsRetriever, but didn't (Zeitwerk::NameError)
```