### PR TITLE
Add additional fields for convert2RHEL

### DIFF
--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -28,6 +28,16 @@ module ForemanInventoryUpload
               'insights_client::hostname',
               'insights_client::ips',
               'insights_id',
+              'conversions::activity',
+              'conversions::packages::0::nevra',
+              'conversions::packages::0::signature',
+              'conversions::activity_started',
+              'conversions::activity_ended',
+              'conversions::success',
+              'conversions::source_os::name',
+              'conversions::source_os::version',
+              'conversions::target_os::name',
+              'conversions::target_os::version',
             ]).pluck(:name, :id)
           ]
       end

--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -40,6 +40,16 @@ module ForemanInventoryUpload
         end
       end
 
+      def report_conversions(host)
+        @stream.simple_field('convert2rhel_through_foreman', host.subscription_facet&.convert2rhel_through_foreman)
+        @stream.simple_field('activity', fact_value(host, 'conversions::activity'))
+        @stream.simple_field('packages_0_nevra', fact_value(host, 'conversions::packages::0::nevra'))
+        @stream.simple_field('packages_0_signature', fact_value(host, 'conversions::packages::0::signature'))
+        @stream.simple_field('activity_started', fact_value(host, 'conversions::activity_started'))
+        @stream.simple_field('activity_ended', fact_value(host, 'conversions::activity_ended'))
+        @stream.simple_field('success', fact_value(host, 'conversions::success') || false, :last)
+      end
+
       def report_host(host)
         host_ips_cache = host_ips(host)
         @stream.object do
@@ -47,7 +57,19 @@ module ForemanInventoryUpload
           @stream.simple_field('account', account_id(host.organization).to_s)
           @stream.simple_field('subscription_manager_id', uuid_value!(host.subscription_facet&.uuid))
           @stream.simple_field('satellite_id', uuid_value!(host.subscription_facet&.uuid))
-          @stream.simple_field('convert2rhel_through_foreman', host.subscription_facet&.convert2rhel_through_foreman)
+          if host.subscription_facet&.convert2rhel_through_foreman.present?
+            @stream.object_field('conversions') do
+              @stream.object_field('source_os') do
+                @stream.simple_field('name', fact_value(host, 'conversions::source_os::name'))
+                @stream.simple_field('version', fact_value(host, 'conversions::source_os::version') || 'Unknown - Fact not reported', :last)
+              end
+              @stream.object_field('target_os') do
+                @stream.simple_field('name', fact_value(host, 'conversions::target_os::name'))
+                @stream.simple_field('version', fact_value(host, 'conversions::target_os::version') || 'Unknown - Fact not reported', :last)
+              end
+              report_conversions(host)
+            end
+          end
           @stream.simple_field('bios_uuid', bios_uuid(host))
           @stream.simple_field('vm_uuid', uuid_value(fact_value(host, 'virt::uuid')))
           @stream.simple_field('insights_id', uuid_value(fact_value(host, 'insights_id')))


### PR DESCRIPTION
This adds several convert2RHEL fields to the generated report:

```
"conversions": {
        "source_os": {
          "name": "AlmaLinux",
          "version": "8.10"
        },
        "target_os": {
          "name": "Red Hat Enterprise Linux",
          "version": "8.10"
        },
        "convert2rhel_through_foreman": 1,
        "activity": "conversion",
        "packages_0_nevra": "convert2rhel-0:2.0.0-1.el8.noarch",
        "packages_0_signature": "RSA/SHA256, Thu May 30 13:31:33 2024, Key ID 199e2f91fd431d51",
        "activity_started": "2024-07-11T17:28:54.281664Z",
        "activity_ended": "2024-07-11T17:48:47.026664Z",
        "success": "true"
      },
```

I had to learn several things the hard way here:

1. For some reason, RH Cloud seems to have _its own JSON generator_ in `lib/foreman_inventory_upload/generators/json_stream.rb`. !!??
2. In order to use the `simple_field` and `object_field` methods of this JSON generator properly, you must pass a second argument, `last`. If you don't pass `last`, and your field happens to be the last field in a object, the stream will include an extra comma and thus stop being valid JSON.
3. In order to be able to use the `fact_values` method, you have to add the fact names to `self.fact_names` in `lib/foreman_inventory_upload/generators/queries.rb`. If a fact name returns nil, `simple_field` will just return and skip that line. This causes problems with no. 2 above, because you never know for sure if a field will be the last field. (I'm guessing this is the reason for the `comma` method.

### Testing
see the instructions on https://github.com/theforeman/foreman_rh_cloud/pull/896
Make sure to test with different types of hosts (insights-enabled, insights-disabled)

Pipe your report output through `jq` (that's also a handy way to know if it's valid JSON) and make sure all the new values show up.



