### PR TITLE
SAT-28994 - Fix About subscription watch link on RH Cloud Inventory page

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
@@ -42,7 +42,7 @@ export const PageDescription = () => (
       {__('For more information about the Subscriptions service, see:')}
       &nbsp;
       <a
-        href="https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/assembly-about-subscriptionwatch"
+        href="https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/index"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/__tests__/__snapshots__/PageDescription.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/__tests__/__snapshots__/PageDescription.test.js.snap
@@ -40,7 +40,7 @@ exports[`PageDescription rendering render without Props 1`] = `
     For more information about the Subscriptions service, see:
      
     <a
-      href="https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/assembly-about-subscriptionwatch"
+      href="https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/index"
       rel="noopener noreferrer"
       target="_blank"
     >


### PR DESCRIPTION
**To test**

1. Go to Configure > RH Cloud > Inventory Upload page
2. Click on "About subscription watch" link.

The link should redirect to the document of Getting Started with the Subscriptions Service.