### PR TITLE
Fixes #919 - isNotRhelHost regex too restrictive

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
           "remediate",
           "remediations",
           "repo",
+          "rhc",
           "theforeman",
           "tooltip",
           "unmount",

--- a/webpack/ForemanRhCloudHelpers.js
+++ b/webpack/ForemanRhCloudHelpers.js
@@ -6,5 +6,8 @@
 export const foremanUrl = path => `${window.URL_PREFIX}${path}`;
 
 export const isNotRhelHost = ({ hostDetails }) =>
-  // eslint-disable-next-line camelcase
-  !new RegExp('red\\s?hat', 'i').test(hostDetails?.operatingsystem_name);
+  // This regex tries matches sane variations of "RedHat", "RHEL" and "RHCOS"
+  !new RegExp('red[\\s\\-]?hat|rh[\\s\\-]?el|rhc[\\s\\-]?os', 'i').test(
+    // eslint-disable-next-line camelcase
+    hostDetails?.operatingsystem_name
+  );

--- a/webpack/InsightsHostDetailsTab/InsightsTotalRiskChartWrapper.js
+++ b/webpack/InsightsHostDetailsTab/InsightsTotalRiskChartWrapper.js
@@ -6,7 +6,7 @@ import { isNotRhelHost } from '../ForemanRhCloudHelpers';
 export const InsightsTotalRiskChartWrapper = props => {
   if (props.status === 'RESOLVED') {
     return (
-      !isNotRhelHost(props.hostDetails) && <InsightsTotalRiskChart {...props} /> // check for RHEL hosts
+      !isNotRhelHost(props) && <InsightsTotalRiskChart {...props} /> // check for RHEL hosts
     );
   }
   return null;


### PR DESCRIPTION
This PR changes the regex used in the `isNotRhelHost` function, which was introduced in #911.
The regex now accepts variations of **RedHat**, **RHEL** and **RHCOS** as valid.

Additionally, the wrong parameter was passed to the function in `InsightsTotalRiskChartWrapper`. 


CC @chris1984 