### PR TITLE
Add Global params for host obfuscation and migrate off settings

### DIFF
--- a/app/controllers/foreman_inventory_upload/uploads_settings_controller.rb
+++ b/app/controllers/foreman_inventory_upload/uploads_settings_controller.rb
@@ -3,8 +3,6 @@ module ForemanInventoryUpload
     def index
       render json: {
         autoUploadEnabled: Setting[:allow_auto_inventory_upload],
-        hostObfuscationEnabled: Setting[:obfuscate_inventory_hostnames],
-        ipsObfuscationEnabled: Setting[:obfuscate_inventory_ips],
         excludePackagesEnabled: Setting[:exclude_installed_packages],
         allowAutoInsightsMismatchDelete: Setting[:allow_auto_insights_mismatch_delete],
         CloudConnectorStatus: ForemanInventoryUpload::UploadsSettingsController.cloud_connector_status,

--- a/db/migrate/20241108165827_convert_obfuscation_settings_to_params.rb
+++ b/db/migrate/20241108165827_convert_obfuscation_settings_to_params.rb
@@ -1,0 +1,22 @@
+class ConvertObfuscationSettingsToParams < ActiveRecord::Migration[6.1]
+  def change
+    # Create the common parameters if they don't exist and set the default values to false
+    CommonParameter.find_or_create_by!(name: 'obfuscate_inventory_hostnames', value: false)
+    CommonParameter.find_or_create_by!(name: 'obfuscate_inventory_ips', value: false)
+
+    # Copy the settings to the common parameters and remove the settings from the database
+    # rubocop:disable Style/GuardClause
+    if Setting.find_by(name: 'obfuscate_inventory_hostnames')&.value
+      hostname_setting = CommonParameter.find_by(name: 'obfuscate_inventory_hostnames')
+      hostname_setting.update!(value: Setting.find_by(name: 'obfuscate_inventory_hostnames')&.value)
+      Setting.find_by(name: 'obfuscate_inventory_hostnames').destroy_all
+    end
+
+    if Setting.find_by(name: 'obfuscate_inventory_ips')&.value
+      ip_setting = CommonParameter.find_by(name: 'obfuscate_inventory_ips')
+      ip_setting.update!(value: Setting.find_by(name: 'obfuscate_inventory_ips')&.value)
+      Setting.find_by(name: 'obfuscate_inventory_ips').destroy_all
+    end
+    # rubocop:enable Style/GuardClause
+  end
+end

--- a/lib/foreman_inventory_upload/generators/fact_helpers.rb
+++ b/lib/foreman_inventory_upload/generators/fact_helpers.rb
@@ -61,7 +61,7 @@ module ForemanInventoryUpload
         insights_client_setting = ActiveModel::Type::Boolean.new.cast(insights_client_setting)
         return insights_client_setting unless insights_client_setting.nil?
 
-        Setting[:obfuscate_inventory_hostnames]
+        CommonParameter.find_by(name: 'obfuscate_inventory_hostnames')&.value
       end
 
       def fqdn(host)
@@ -79,7 +79,7 @@ module ForemanInventoryUpload
         insights_client_setting = ActiveModel::Type::Boolean.new.cast(insights_client_setting)
         return insights_client_setting unless insights_client_setting.nil?
 
-        Setting[:obfuscate_inventory_ips]
+        CommonParameter.find_by(name: 'obfuscate_inventory_ips')&.value
       end
 
       def host_ips(host)
@@ -114,7 +114,7 @@ module ForemanInventoryUpload
         foreman_hostname = ForemanRhCloud.foreman_host&.name
         if bash_hostname == foreman_hostname
           fqdn(ForemanRhCloud.foreman_host)
-        elsif Setting[:obfuscate_inventory_hostnames]
+        elsif CommonParameter.find_by(name: 'obfuscate_inventory_hostnames')&.value
           obfuscate_fqdn(bash_hostname)
         else
           bash_hostname

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -44,8 +44,6 @@ module ForemanRhCloud
               setting('allow_auto_inventory_upload', type: :boolean, description: N_('Enable automatic upload of your host inventory to the Red Hat cloud'), default: true, full_name: N_('Automatic inventory upload'))
               setting('allow_auto_insights_sync', type: :boolean, description: N_('Enable automatic synchronization of Insights recommendations from the Red Hat cloud'), default: false, full_name: N_('Synchronize recommendations Automatically'))
               setting('allow_auto_insights_mismatch_delete', type: :boolean, description: N_('Enable automatic deletion of mismatched host records from the Red Hat cloud'), default: false, full_name: N_('Automatic mismatch deletion'))
-              setting('obfuscate_inventory_hostnames', type: :boolean, description: N_('Obfuscate host names sent to the Red Hat cloud'), default: false, full_name: N_('Obfuscate host names'))
-              setting('obfuscate_inventory_ips', type: :boolean, description: N_('Obfuscate ipv4 addresses sent to the Red Hat cloud'), default: false, full_name: N_('Obfuscate host ipv4 addresses'))
               setting('exclude_installed_packages', type: :boolean, description: N_('Exclude installed packages from being uploaded to the Red Hat cloud'), default: false, full_name: N_("Exclude installed Packages"))
               setting('include_parameter_tags', type: :boolean, description: N_('Should import include parameter tags from Foreman?'), default: false, full_name: N_('Include parameters in insights-client reports'))
               setting('rhc_instance_id', type: :string, description: N_('RHC daemon id'), default: nil, full_name: N_('ID of the RHC(Yggdrasil) daemon'))

--- a/test/unit/metadata_generator_test.rb
+++ b/test/unit/metadata_generator_test.rb
@@ -23,8 +23,8 @@ class MetadataGeneratorTest < ActiveSupport::TestCase
   end
 
   test 'generates an empty report with hidden hostname and ip' do
-    Setting[:obfuscate_inventory_hostnames] = true
-    Setting[:obfuscate_inventory_ips] = true
+    CommonParameter.find_or_create_by!(name: 'obfuscate_inventory_ips', value: true)
+    CommonParameter.find_or_create_by!(name: 'obfuscate_inventory_hostnames', value: true)
     @host = FactoryBot.create(:host, :managed)
     ForemanRhCloud.expects(:foreman_host_name).returns(@host.name)
     generator = ForemanInventoryUpload::Generators::Metadata.new

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -190,7 +190,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
   end
 
   test 'generates obfuscated ip_address fields without inisghts-client' do
-    Setting[:obfuscate_inventory_ips] = true
+    CommonParameter.find_or_create_by!(name: 'obfuscate_inventory_ips', value: true)
 
     @host.interfaces << FactoryBot.build(:nic_managed)
     batch = Host.where(id: @host.id).in_batches.first
@@ -261,7 +261,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
   end
 
   test 'obfuscates fqdn when setting set' do
-    Setting[:obfuscate_inventory_hostnames] = true
+    CommonParameter.find_or_create_by!(name: 'obfuscate_inventory_hostnames', value: true)
 
     batch = Host.where(id: @host.id).in_batches.first
     generator = create_generator(batch)

--- a/webpack/ForemanInventoryUpload/Components/InventorySettings/AdvancedSetting/AdvancedSettingsConstants.js
+++ b/webpack/ForemanInventoryUpload/Components/InventorySettings/AdvancedSetting/AdvancedSettingsConstants.js
@@ -8,16 +8,6 @@ export const settingsDict = {
       'Enable automatic upload of your hosts inventory to the Red Hat cloud'
     ),
   },
-  hostObfuscationEnabled: {
-    name: 'obfuscate_inventory_hostnames',
-    label: __('Obfuscate host names'),
-    tooltip: __('Obfuscate host names sent to the Red Hat cloud'),
-  },
-  ipsObfuscationEnabled: {
-    name: 'obfuscate_inventory_ips',
-    label: __('Obfuscate host ipv4 addresses'),
-    tooltip: __('Obfuscate ipv4 addresses sent to the Red Hat cloud'),
-  },
   excludePackagesEnabled: {
     name: 'exclude_installed_packages',
     label: __('Exclude installed Packages'),

--- a/webpack/ForemanInventoryUpload/Components/InventorySettings/__tests__/__snapshots__/InventorySettings.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/InventorySettings/__tests__/__snapshots__/InventorySettings.test.js.snap
@@ -12,14 +12,6 @@ exports[`InventorySettings rendering render without Props 1`] = `
     setting="autoUploadEnabled"
   />
   <AdvancedSetting
-    key="hostObfuscationEnabled"
-    setting="hostObfuscationEnabled"
-  />
-  <AdvancedSetting
-    key="ipsObfuscationEnabled"
-    setting="ipsObfuscationEnabled"
-  />
-  <AdvancedSetting
     key="excludePackagesEnabled"
     setting="excludePackagesEnabled"
   />


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Created a global parameter for `obfuscate_inventory_hostnames` and `obfuscate_inventory_ips` and set them to `false` which is the default value for `insights-client`
* Created a DB migration to set the values of the global parameters to the value of the settings for `obfuscate_inventory_hostnames` and `obfuscate_inventory_ips` and deletes the settings from the plugin and DB
* Removed the UI toggles
* Updated UI and JS tests to use the new parameters
* These parameters will be used for the REX job template for existing hosts to configure host obfuscation and for global registration. 