### PR TITLE
Keep existing trailing slash in URL when forwarding request to insights

### DIFF
--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -33,7 +33,8 @@ module ForemanRhCloud
           }
         ),
       }
-      base_params.merge(path_params(original_request.path, certs))
+      requested_url = original_request.original_fullpath.end_with?('/') ? original_request.path + '/' : original_request.path
+      base_params.merge(path_params(requested_url, certs))
     end
 
     def prepare_forward_payload(original_request, controller_name)


### PR DESCRIPTION
```
Started GET "/redhat_access/r/insights/platform/module-update-router/v1/channel?module=insights-core" for 10.0.167.131 at 2024-11-07 13:49:01 -0500
Started GET "/redhat_access/r/insights/v1/static/testing/insights-core.egg" for 10.0.167.131 at 2024-11-07 13:49:54 -0500
Started GET "/redhat_access/r/insights/v1/systems/327dd693-3204-460a-a398-526d14ebe243" for 10.0.167.131 at 2024-11-07 13:50:22 -0500
Started POST "/redhat_access/r/insights/uploads/327dd693-3204-460a-a398-526d14ebe243" for 10.0.167.131 at 2024-11-07 13:51:21 -0500
Started GET "/redhat_access/r/insights/platform/inventory/v1/hosts?insights_id=327dd693-3204-460a-a398-526d14ebe243" for 10.0.167.131 at 2024-11-07 13:51:45 -0500
Started GET "/redhat_access/r/insights/platform/insights/v1/system/5db40f5f-d099-4077-9d90-7337d0ef6ea5/reports/" for 10.0.167.131 at 2024-11-07 13:54:39 -0500
```
Among these requests forwarded to Insights, only reports has the trailing slash in the request URL.
To avoid a redirect in Insights, let's keep the trailing slash in the request URL.

`original_request.path` in this [line](https://github.com/theforeman/foreman_rh_cloud/blob/48f9d74ba8a671c74cec3a79b2646c38172a42a3/app/services/foreman_rh_cloud/cloud_request_forwarder.rb#L36) would remove a trailing stash if it exists.

Fixes https://github.com/theforeman/foreman_rh_cloud/issues/895