### PR TITLE
Clear shell process log before restart

### DIFF
--- a/lib/foreman_inventory_upload/async/shell_process.rb
+++ b/lib/foreman_inventory_upload/async/shell_process.rb
@@ -7,6 +7,7 @@ module ForemanInventoryUpload
       include ::ForemanRhCloud::Async::ExponentialBackoff
 
       def plan(instance_label, more_inputs = {})
+        clear_task_output(instance_label)
         inputs = more_inputs.merge(instance_label: instance_label)
         plan_self(inputs)
       end
@@ -51,6 +52,11 @@ module ForemanInventoryUpload
 
       def rescue_strategy_for_self
         Dynflow::Action::Rescue::Fail
+      end
+
+      def clear_task_output(label)
+        TaskOutputLine.where(label: label).delete_all
+        TaskOutputStatus.where(label: label).delete_all
       end
 
       private


### PR DESCRIPTION
Report regeneration and upload tasks add a lot of logs Since we dont clear logs on every regeneration we have too much outdated logs. This commit wil change that and clear logs before running the report..


### Testing steps ###
On the console 
before PR
```ruby
> TaskOutputLine.count
=> 22092
```

After pr
click restart under RH Cloud -> Inventory Upload page
check the console

```ruby
> TaskOutputLine.count
=> 5523
```

