### PR TITLE
Cast success to boolean in inventory report

### DIFF
--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -47,7 +47,7 @@ module ForemanInventoryUpload
         @stream.simple_field('packages_0_signature', fact_value(host, 'conversions::packages::0::signature'))
         @stream.simple_field('activity_started', fact_value(host, 'conversions::activity_started'))
         @stream.simple_field('activity_ended', fact_value(host, 'conversions::activity_ended'))
-        @stream.simple_field('success', fact_value(host, 'conversions::success') || false, :last)
+        @stream.simple_field('success', ActiveModel::Type::Boolean.new.cast(fact_value(host, 'conversions::success')), :last)
       end
 
       def report_host(host)


### PR DESCRIPTION
The `success` fact (along with other Boolean RHSM facts, apparently) gets converted to a string at some point during Foreman/Katello processing. This caused problems for the Insights folks, so I'm raising this to ensure that it's cast back to a boolean value in the rh_cloud inventory report. This should produce reports that look like this:


```
{
  "report_slice_id": "c2e1020a-5722-47cb-9573-043291265985",
  "hosts": [
    {
      "fqdn": "rhel9b.fedora.example.com",
      "account": "0000000",
      "subscription_manager_id": "45d3d61a-b76e-404d-98ed-3475a06c7611",
      "satellite_id": "45d3d61a-b76e-404d-98ed-3475a06c7611",
      "conversions": {
        "source_os": {
          "name": "AlmaLinux",
          "version": "Unknown - Fact not reported"
        },
        "target_os": {
          "name": "Red Hat Enterprise Linux",
          "version": "Unknown - Fact not reported"
        },
        "convert2rhel_through_foreman": 1,
        "activity": "conversion",
        "packages_0_nevra": "convert2rhel-0:2.0.0-1.el8.noarch",
        "packages_0_signature": "RSA/SHA256, Thu May 30 13:31:33 2024, Key ID 199e2f91fd431d51",
        "activity_started": "2024-07-11T17:28:54.281664Z",
        "activity_ended": "2024-07-11T17:48:47.026664Z",
        "success": true
      },
...
```

One other note - For source_os version and target_os version, if for some reason the host does not report that fact, I have a default value as `"Unknown - Fact not reported"`. (I needed to have a key/value pair there rather than omitting it entirely, because of some quirks about rh_cloud JSON which are discussed in https://github.com/theforeman/foreman_rh_cloud/pull/914 but really you probably don't want to know ;) Since that's also a string, I believe it should still comply with the schema outlined in https://github.com/RedHatInsights/inventory-schemas/pull/142/files. Let me know if that's a problem.