### PR TITLE
only return response from Exceptions that have it

### DIFF
--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -17,7 +17,7 @@ module ForemanRhCloud
       logger.debug("Sending request to: #{request_opts[:url]}")
 
       execute_cloud_request(request_opts)
-    rescue RestClient::Exception => error_response
+    rescue RestClient::ExceptionWithResponse => error_response
       error_response.response
     end
 


### PR DESCRIPTION
Only RestClient::ExceptionWithResponse has .response, while a "normal"
RestClient::Exception does not.
But by catching RestClient::Exception we might swallow errors that would
be useful for users in the logs, like
RestClient::SSLCertificateNotVerified
