### PR TITLE
SAT-30393 - Skip recurring logic tasks if on prem is enabled

### DIFF
--- a/lib/foreman_inventory_upload/async/generate_all_reports_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_all_reports_job.rb
@@ -13,20 +13,28 @@ module ForemanInventoryUpload
           return
         end
 
-        after_delay do
-          organizations = Organization.unscoped.all
+        if ForemanRhCloud.with_local_advisor_engine?
+          plan_self # so that 'run' runs
+        else
+          after_delay do
+            organizations = Organization.unscoped.all
 
-          organizations.map do |organization|
-            total_hosts = ForemanInventoryUpload::Generators::Queries.for_org(organization.id, use_batches: false).count
+            organizations.map do |organization|
+              total_hosts = ForemanInventoryUpload::Generators::Queries.for_org(organization.id, use_batches: false).count
 
-            if total_hosts <= ForemanInventoryUpload.max_org_size
-              disconnected = false
-              plan_generate_report(ForemanInventoryUpload.generated_reports_folder, organization, disconnected)
-            else
-              logger.info("Skipping automatic uploads for organization #{organization.name}, too many hosts (#{total_hosts}/#{ForemanInventoryUpload.max_org_size})")
-            end
-          end.compact
+              if total_hosts <= ForemanInventoryUpload.max_org_size
+                disconnected = false
+                plan_generate_report(ForemanInventoryUpload.generated_reports_folder, organization, disconnected)
+              else
+                logger.info("Skipping automatic uploads for organization #{organization.name}, too many hosts (#{total_hosts}/#{ForemanInventoryUpload.max_org_size})")
+              end
+            end.compact
+          end
         end
+      end
+
+      def run
+        output[:status] = _('The scheduled process is disabled because this Foreman is configured with the use_local_advisor_engine option.') if ForemanRhCloud.with_local_advisor_engine?
       end
 
       def rescue_strategy_for_self

--- a/lib/insights_cloud/async/insights_scheduled_sync.rb
+++ b/lib/insights_cloud/async/insights_scheduled_sync.rb
@@ -13,9 +13,17 @@ module InsightsCloud
           return
         end
 
-        after_delay do
-          plan_full_sync
+        if ForemanRhCloud.with_local_advisor_engine?
+          plan_self
+        else
+          after_delay do
+            plan_full_sync # so that 'run' runs
+          end
         end
+      end
+
+      def run
+        output[:status] = _('The scheduled process is disabled because this Foreman is configured with the use_local_advisor_engine option.') if ForemanRhCloud.with_local_advisor_engine?
       end
 
       def plan_full_sync

--- a/test/jobs/inventory_scheduled_sync_test.rb
+++ b/test/jobs/inventory_scheduled_sync_test.rb
@@ -14,6 +14,16 @@ class InventoryScheduledSyncTest < ActiveSupport::TestCase
     ForemanTasks.sync_task(InventorySync::Async::InventoryScheduledSync)
   end
 
+  test 'Skips execution if with_local_advisor_engine? is true' do
+    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(true)
+
+    InventorySync::Async::InventoryScheduledSync.any_instance.expects(:plan_org_sync).never
+
+    task = ForemanTasks.sync_task(InventorySync::Async::InventoryScheduledSync)
+    status = task.output[:status].to_s
+    assert_match(/Foreman is configured with the use_local_advisor_engine option/, status)
+  end
+
   test 'Skips execution if auto upload is disabled' do
     Setting[:allow_auto_inventory_upload] = false
 


### PR DESCRIPTION
This PR adds a skip to inventory/insights/generate report scheduled sync tasks if on_prem is enabled. This includes a change @jeremylenz has in his pr, once that is merged, I will remove it from here. 