### PR TITLE
Hits uploaded doesn't fail if system has no hits

### DIFF
--- a/app/services/foreman_rh_cloud/hits_uploader.rb
+++ b/app/services/foreman_rh_cloud/hits_uploader.rb
@@ -28,21 +28,25 @@ module ForemanRhCloud
       facet.hits.delete_all
       hits = @payload[:hits]
       # rubocop:disable Rails/SkipsModelValidations
-      facet.hits.insert_all(hits)
+      facet.hits.insert_all(hits) if hits.present?
       # rubocop:enable Rails/SkipsModelValidations
       InsightsFacet.reset_counters(facet.id, :hits_count)
     end
 
     def update_rules_and_resolutions
+      return if @payload[:rules].blank?
       # rubocop:disable Rails/SkipsModelValidations
       ::InsightsRule.upsert_all(@payload[:rules], unique_by: :rule_id)
       rules = @payload[:rules].map { |rule| rule[:rule_id] }
+
+      return if @payload[:resolutions].blank?
       ::InsightsResolution.where(rule_id: rules).delete_all
       ::InsightsResolution.insert_all(@payload[:resolutions])
       # rubocop:enable Rails/SkipsModelValidations
     end
 
     def update_details
+      return if @payload[:details].blank?
       fact_name = FactName.where(name: "insights::hit_details", short_name: 'insights_details').first_or_create
       fact_value = @host.fact_values.where(fact_name: fact_name).first_or_create
       fact_value.update(value: @payload[:details])

--- a/test/unit/services/foreman_rh_cloud/hits_uploader_test.rb
+++ b/test/unit/services/foreman_rh_cloud/hits_uploader_test.rb
@@ -96,4 +96,25 @@ class HitsUploaderTest < ActiveSupport::TestCase
     refute_nil fact_value
     assert_equal PAYLOAD[:details], fact_value.value
   end
+
+  test "empty payload" do
+    payload = {
+      resolutions: [],
+      rules: [],
+      hits: [],
+      details: "",
+    }
+
+    @host = FactoryBot.create(:host)
+    @uuid = SecureRandom.uuid
+    uploader = ForemanRhCloud::HitsUploader.new(host: @host, payload: payload, uuid: @uuid)
+    uploader.upload!
+    @host.reload
+    assert_equal @uuid, @host.insights_facet.uuid
+    assert_empty @host.insights_facet.hits
+    assert_equal 0, @host.insights_facet.hits_count
+    fact_name = FactName.where(name: "insights::hit_details").first
+    fact_value = @host.fact_values.where(fact_name: fact_name).first
+    assert_nil fact_value
+  end
 end


### PR DESCRIPTION
So if the advisor engine did not have any hits for the host it would error saying _no data passed for insert all_.  We need to handle it correctly and not try insert_all if hit values are empty. 