### PR TITLE
update URL of local advisor engine as it is deployed by the installer

### DIFF
--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -5,8 +5,8 @@ require 'uri'
 module ForemanRhCloud
   def self.on_premise_url
     return unless ForemanRhCloud.with_local_advisor_engine?
-    port = ENV['ADVISOR_ENGINE_PORT'] || "8000"
-    ENV['ADVISOR_ENGINE_URL'] || "http://#{ForemanRhCloud.foreman_host.fqdn || 'localhost'}:#{port}"
+    port = ENV['ADVISOR_ENGINE_PORT'] || "24443"
+    ENV['ADVISOR_ENGINE_URL'] || "https://localhost:#{port}"
   end
 
   def self.env_or_on_premise_url(env_var_name)

--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -124,7 +124,7 @@ module ForemanRhCloud
   end
 
   def self.legacy_insights_ca
-    "#{ForemanRhCloud::Engine.root}/config/rh_cert-api_chain.pem"
+    "#{ForemanRhCloud::Engine.root}/config/rh_cert-api_chain.pem" unless ForemanRhCloud.with_local_advisor_engine?
   end
 
   def self.cloud_url_validator


### PR DESCRIPTION
- **don't set legacy insights ca when local advisor engine is used**
- **update URL of local advisor engine as it is deployed by the installer**
