### PR TITLE
Drop cdn_proxy settings

### DIFF
--- a/app/services/foreman_rh_cloud/cloud_connector.rb
+++ b/app/services/foreman_rh_cloud/cloud_connector.rb
@@ -17,7 +17,7 @@ module ForemanRhCloud
         :satellite_cloud_connector_password => token_value,
       }
 
-      if (http_proxy = ForemanRhCloud.proxy_setting(logger: Foreman::Logging.logger('app')))
+      if (http_proxy = ForemanRhCloud.proxy_setting)
         input[:satellite_cloud_connector_http_proxy] = http_proxy
       end
 

--- a/app/services/foreman_rh_cloud/cloud_request.rb
+++ b/app/services/foreman_rh_cloud/cloud_request.rb
@@ -5,7 +5,7 @@ module ForemanRhCloud
     def execute_cloud_request(params)
       final_params = {
         verify_ssl: ForemanRhCloud.verify_ssl_method,
-        proxy: ForemanRhCloud.transformed_http_proxy_string(logger: logger),
+        proxy: ForemanRhCloud.transformed_http_proxy_string,
       }.deep_merge(params)
 
       response = RestClient::Request.execute(final_params)

--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -51,7 +51,7 @@ module ForemanInventoryUpload
           'CER_PATH' => @cer_path
         )
 
-        http_proxy_string = ForemanRhCloud.http_proxy_string(logger: logger)
+        http_proxy_string = ForemanRhCloud.http_proxy_string
         if http_proxy_string
           env_vars['http_proxy'] = http_proxy_string
           env_vars['https_proxy'] = http_proxy_string

--- a/test/unit/rh_cloud_http_proxy_test.rb
+++ b/test/unit/rh_cloud_http_proxy_test.rb
@@ -4,29 +4,12 @@ class RhCloudHttpProxyTest < ActiveSupport::TestCase
   setup do
     @global_content_proxy_mock = 'http://global:content@localhost:80'
     @global_foreman_proxy_mock = 'http://global:foreman@localhost:80'
-    @katello_cdn_proxy_mock = {
-      host: 'localhost',
-      port: '80',
-      user: 'katello',
-      password: 'cdn',
-      scheme: 'http',
-    }
-    @katello_cdn_proxy_string_mock = 'http://katello:cdn@localhost:80'
   end
 
   test 'selects global content proxy' do
     setup_global_content_proxy
     setup_global_foreman_proxy
-    setup_cdn_proxy do
-      assert_equal @global_content_proxy_mock, ForemanRhCloud.proxy_setting
-    end
-  end
-
-  test 'selects cdn proxy' do
-    setup_global_foreman_proxy
-    setup_cdn_proxy do
-      assert_equal @katello_cdn_proxy_string_mock, ForemanRhCloud.proxy_setting
-    end
+    assert_equal @global_content_proxy_mock, ForemanRhCloud.proxy_setting
   end
 
   test 'selects global foreman proxy' do
@@ -42,14 +25,6 @@ class RhCloudHttpProxyTest < ActiveSupport::TestCase
 
   def setup_global_foreman_proxy
     Setting[:http_proxy] = @global_foreman_proxy_mock
-  end
-
-  def setup_cdn_proxy
-    old_cdn_setting = SETTINGS[:katello][:cdn_proxy]
-    SETTINGS[:katello][:cdn_proxy] = @katello_cdn_proxy_mock
-    yield
-  ensure
-    SETTINGS[:katello][:cdn_proxy] = old_cdn_setting
   end
 
   test 'transform proxy scheme test' do


### PR DESCRIPTION
Back in 2020 the last traces of this were removed from Katello so this can't have any affect anymore.

It may be better to look at some other proxy config, but I can't really judge that right now.

Link: https://github.com/Katello/katello/commit/d593923a18d445f853d61d8af9d9a86e6195c82c