### PR TITLE
SAT-27221 - Separate inventory upload for host into a new param

### DIFF
--- a/db/seeds.d/189_add_host_inventory_param.rb
+++ b/db/seeds.d/189_add_host_inventory_param.rb
@@ -1,0 +1,7 @@
+CommonParameter.without_auditing do
+  params = [
+    { name: "host_registration_insights_inventory", key_type: "boolean", value: true },
+  ]
+
+  params.each { |param| CommonParameter.find_or_create_by(param) }
+end

--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -44,7 +44,7 @@ module ForemanInventoryUpload
 
       def self.for_slice(base)
         base
-          .search_for("not params.#{InsightsCloud.enable_client_param} = f")
+          .search_for("not params.#{InsightsCloud.enable_client_param_inventory} = f")
           .joins(:subscription_facet)
           .preload(
             :interfaces,

--- a/lib/insights_cloud.rb
+++ b/lib/insights_cloud.rb
@@ -29,6 +29,10 @@ module InsightsCloud
     'host_registration_insights'
   end
 
+  def self.enable_client_param_inventory
+    'host_registration_insights_inventory'
+  end
+
   def self.enable_cloud_remediations_param
     'enable_cloud_remediations'
   end


### PR DESCRIPTION
* Added a new param in Foreman called `host_registraton_insights_inventory`
* Defined that param `host_registraton_insights_inventory` and switched the generator to look for that for a host instead of `enable_client_param`
* Updated a test that looked for that param
* Added a new test for the new param

Testing results:
With host_registraton_insights_inventory off
```bash
[vagrant@ip-10-0-168-88 done]$ tar -xvf report_for_1.tar.xz 
./
./metadata.json
```

With host_registraton_insights_inventory on
```bash
[vagrant@ip-10-0-168-88 done]$ tar -xvf report_for_1.tar.xz 
./
./metadata.json
./a70f324e-2497-40f4-8a41-f48d7861bf86.json
```