### PR TITLE
Hide more things when using local advisor engine

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
     get 'settings', to: 'uploads_settings#index'
     post 'setting', to: 'uploads_settings#set_advanced_setting'
 
-    post 'cloud_connector', to: 'uploads#enable_cloud_connector'
+    unless ForemanRhCloud.with_local_advisor_engine?
+      post 'cloud_connector', to: 'uploads#enable_cloud_connector'
+    end
 
     resources :tasks, only: [:create, :show]
 
@@ -31,7 +33,9 @@ Rails.application.routes.draw do
   end
 
   namespace :foreman_rh_cloud do
-    get 'inventory_upload', to: '/react#index'
+    unless ForemanRhCloud.with_local_advisor_engine?
+      get 'inventory_upload', to: '/react#index'
+    end
     get 'insights_cloud', to: '/react#index' # Uses foreman's react controller
   end
 
@@ -61,8 +65,10 @@ Rails.application.routes.draw do
       end
 
       namespace 'rh_cloud' do
-        post 'enable_connector', to: 'inventory#enable_cloud_connector'
-        post 'cloud_request', to: 'cloud_request#update'
+        unless ForemanRhCloud.with_local_advisor_engine?
+          post 'enable_connector', to: 'inventory#enable_cloud_connector'
+          post 'cloud_request', to: 'cloud_request#update'
+        end
         get 'advisor_engine_config', to: 'advisor_engine_config#show'
       end
 

--- a/lib/tasks/insights.rake
+++ b/lib/tasks/insights.rake
@@ -24,13 +24,16 @@ namespace :rh_cloud_insights do
   desc "Re-announce all organizations into Sources on RH cloud."
   task announce_to_sources: [:environment] do
     logger = Logging::Logger.new(STDOUT)
-    Organization.unscoped.each do |org|
-      presence = ForemanRhCloud::CloudPresence.new(org, logger)
-      presence.announce_to_sources
-    rescue StandardError => ex
-      logger.warn(ex)
+    if ForemanRhCloud.with_local_advisor_engine?
+      logger.warn('Task announce_to_sources is not available when using local advisor engine')
+    else
+      Organization.unscoped.each do |org|
+        presence = ForemanRhCloud::CloudPresence.new(org, logger)
+        presence.announce_to_sources
+      rescue StandardError => ex
+        logger.warn(ex)
+      end
+      logger.info('Reannounced all organizations')
     end
-
-    logger.info('Reannounced all organizations')
   end
 end


### PR DESCRIPTION
When using local advisor engine,

1. Do not define routes in web UI if they depend on being connected
2. Pass `disconnected=true` to Dynflow tasks
3. make `rake rh_cloud_insights:announce_to_sources` a no-op
