### PR TITLE
Load all rules from advisor engine

### DIFF
--- a/app/services/foreman_rh_cloud/rules_ingester.rb
+++ b/app/services/foreman_rh_cloud/rules_ingester.rb
@@ -1,0 +1,61 @@
+module ForemanRhCloud
+  class RulesIngester
+    def ingest_rules_and_resolutions!
+      rules, resolutions = fetch_rules_and_resolutions
+      # rubocop:disable Rails/SkipsModelValidations
+      ::InsightsRule.upsert_all(rules, unique_by: :rule_id)
+      ::InsightsResolution.delete_all
+      ::InsightsResolution.insert_all(resolutions)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+
+    private
+
+    def fetch_rules_data
+      advisor_url = "#{ForemanRhCloud.on_premise_url}/r/insights/v1/static/release/content.json"
+      JSON.parse(Net::HTTP.get(URI.parse(advisor_url)), symbolize_names: true)
+    end
+
+    def fetch_rules_and_resolutions
+      rules = fetch_rules_data.values.map do |rule|
+        next unless rule[:active]
+        next if rule[:playbooks].blank?
+        rule.slice(:description, :category,
+          :impact_name, :summary, :generic, :reason,
+          :rec_likelihood, :rec_impact, :reboot_required,
+          :more_info, :rule_id, :playbooks)
+      end
+      rules.compact!
+
+      resolutions = rules.flat_map do |rule|
+        rule[:playbooks].map do |fix_type, playbook|
+          {
+            rule_id: rule[:rule_id],
+            description: playbook[:name],
+            needs_reboot: playbook[:reboot_required] == true,
+            resolution_risk: rule[:resolution_risk],
+            resolution_type: fix_type,
+          }
+        end
+      end
+
+      rules.map! do |rule|
+        {
+          rule_id: rule[:rule_id],
+          description: rule[:description],
+          category_name: rule[:category],
+          impact_name: rule[:impact_name],
+          summary: rule[:summary],
+          generic: rule[:generic],
+          reason: rule[:reason],
+          total_risk: ((rule[:rec_likelihood] + rule[:rec_impact]) / 2).to_i,
+          reboot_required: rule[:reboot_required] == true,
+          more_info: rule[:more_info],
+          rating: 0,
+        }
+      end
+
+      [rules, resolutions]
+    end
+  end
+end

--- a/test/unit/services/foreman_rh_cloud/rules_ingester_test.rb
+++ b/test/unit/services/foreman_rh_cloud/rules_ingester_test.rb
@@ -1,0 +1,60 @@
+require 'test_plugin_helper'
+
+class RulesIngesterTest < ActiveSupport::TestCase
+  PAYLOAD = {
+    non_active: {
+      rule_id: "non_active",
+      active: false,
+    },
+    no_playbooks: {
+      rule_id: "no_playbooks",
+      active: true,
+      playbooks: {},
+    },
+    R123: {
+      active: true,
+      rule_id: "R123",
+      description: "R123 failed.",
+      category: "Stability",
+      reboot_required: false,
+      impact_name: "R123 Failure",
+      rec_impact: 1,
+      rec_likelihood: 1,
+      playbooks: {
+        resolution1: {
+          name: "Update package to 100.9 or above",
+          reboot_required: false,
+        },
+        resolution2: {
+          name: "Update other package to 101.9 or above",
+          reboot_required: true,
+          text: "- name: Update package-102",
+        },
+      },
+    },
+  }.freeze
+
+  setup do
+    ForemanRhCloud::RulesIngester.any_instance.expects(:fetch_rules_data).returns(PAYLOAD)
+    ForemanRhCloud::RulesIngester.new.ingest_rules_and_resolutions!
+  end
+
+  test 'non active are ignored' do
+    refute InsightsRule.where(rule_id: "non_active").exists?
+  end
+
+  test 'non playbooks are ignored' do
+    refute InsightsRule.where(rule_id: "no_playbooks").exists?
+  end
+
+  test 'R123 exists' do
+    rule = InsightsRule.find_by(rule_id: "R123")
+    refute_nil rule
+    assert_equal "R123 Failure", rule.impact_name
+  end
+
+  test 'Resolutions exists' do
+    assert_equal 2, InsightsResolution.where(rule_id: "R123").count
+    assert InsightsResolution.where(rule_id: "R123", resolution_type: "resolution1").exists?
+  end
+end


### PR DESCRIPTION
The idea here is to load all the rules into the db in one go from insights advisor if the some rules are not in the database.

This will make the hits api more performant since it is not updating the db for the most expensive operations, i.e upserting rules and resolutions

To test this

1. Setup foreman with  advisor engine
2. Check out this pr
3. `rake console` - find the `InsightsRule.maximum(:id)` and `InsightsResolution.maximum(:id)` values. they may be nil if you dont have any rules .
4. register a host and introduce a vulnerability like `chmod 777 /etc/shadow`
5. run `insights-client` on the host
6. `rake console` - find the `InsightsRule.maximum(:id)` and `InsightsResolution.maximum(:id)` values. You should see around 900+ rules added in the db. Make a note of the maximum id
7. run `insights-client` on the host again
8. `rake console` - find the `InsightsRule.maximum(:id)` and `InsightsResolution.maximum(:id)` values. These values should not have changed.