### PR TITLE
Make remediation modal handle empty state correctly

### DIFF
--- a/webpack/InsightsCloudSync/Components/RemediationModal/RemediationModal.js
+++ b/webpack/InsightsCloudSync/Components/RemediationModal/RemediationModal.js
@@ -74,7 +74,11 @@ const RemediationModal = ({
           <TableHeader />
           <TableBody />
         </Table>
-        <TableEmptyState status={status} error={error} />
+        <TableEmptyState
+          status={status}
+          error={error}
+          rowsLength={rows.length}
+        />
       </Modal>
     </React.Fragment>
   );


### PR DESCRIPTION
Previously the Remediations modal would show a fake empty state even when remediations were correctly selected

![image](https://github.com/user-attachments/assets/497c3e79-e704-4724-b542-d21f294b2426)

This PR fixes that by correctly passing the rowsLength attribute

#### Testing Steps


- Create a host with vulnerabilities. Example I used 
```bash
$ sed -i 's/#ClientAliveInterval 0/ClientAliveInterval 1000/g' /etc/ssh/sshd_config &&     sed -i 's/#ClientAliveCountMax 3/ClientAliveCountMax 3/g' /etc/ssh/sshd_config
$ insights-client
```
- Go to Hosts => insights (hopefully you should see some remediations)
- Select one of the remediations
- Click  Remediate

##### Before PR
-  ![image](https://github.com/user-attachments/assets/497c3e79-e704-4724-b542-d21f294b2426)

##### After PR
- ![image](https://github.com/user-attachments/assets/5d329048-218f-4761-ba5e-a0ba3b3ce85e)
