### PR TITLE
Correct the capitalization of URLRemediationsRetriever

### DIFF
--- a/app/services/foreman_rh_cloud/template_renderer_helper.rb
+++ b/app/services/foreman_rh_cloud/template_renderer_helper.rb
@@ -25,7 +25,7 @@ module ForemanRhCloud
       returns String, desc: 'Playbook downloaded from the cloud'
     end
     def download_rh_playbook(playbook_url, organization_id)
-      retriever = ForemanRhCloud::UrlRemediationsRetriever.new(url: playbook_url, organization_id: organization_id, logger: template_logger)
+      retriever = ForemanRhCloud::URLRemediationsRetriever.new(url: playbook_url, organization_id: organization_id, logger: template_logger)
 
       cached("rh_playbook_#{playbook_url}") do
         retriever.create_playbook


### PR DESCRIPTION
This should fix
```
Failed rendering template: error during rendering: uninitialized constant ForemanRhCloud::UrlRemediationsRetriever Did you mean? ForemanRhCloud::URLRemediationsRetriever
```

Probably missed during the Zeitwerk refactorings.