### PR TITLE
Ignore adding branch_id to compliance policies requests

### DIFF
--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -52,7 +52,9 @@ module ForemanRhCloud
 
     def prepare_forward_params(original_request, branch_id)
       forward_params = original_request.query_parameters
-      if original_request.user_agent && !original_request.user_agent.include?('redhat_access_cfme')
+      compliance_request = original_request.path.match?(/compliance\/v2(\/.*)?/)
+      user_agent = original_request.user_agent.present? && !original_request.user_agent.include?('redhat_access_cfme')
+      if user_agent && !compliance_request
         forward_params = forward_params.merge(:branch_id => branch_id)
       end
 


### PR DESCRIPTION
The following route does not like a branch_id `/redhat_access/r/insights/platform/compliance/v2/systems/<id>/policies` 

This pr makes sure that branch_id is not forwarded for compliance policy requests