### PR TITLE
Corrects the disconnected setting to use subscription_connection_enabled

### DIFF
--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -78,7 +78,7 @@ module ForemanInventoryUpload
       end
 
       def content_disconnected?
-        Setting[:content_disconnected]
+        !Setting[:subscription_connection_enabled]
       end
     end
   end


### PR DESCRIPTION
https://github.com/Katello/katello/pull/9812 basically removed the content_disconnected setting that rh cloud was still using to determine if content was actually disconnected.

Step:
- add this to your `/etc/hosts`
 `0.0.0.0 cert-api.access.redhat.com cert.cloud.redhat.com cloud.redhat.com console.redhat.com`
- Set subscription_connection_enabled to false
- Try generating and uploading report on inventory upload
Before PR
- Notice rh cloud still tries to upload the generated report.
```
 Trying 0.0.0.0:443...

* Connected to cert.cloud.redhat.com (127.0.0.1) port 443 (#0)

* ALPN, offering h2
```

After PR
- Upload should get ignored.
`Upload was stopped since disconnected mode setting is enabled for content on this instance.`