### PR TITLE
SAT-30614 - Add rescue handling for crc and network timeouts

### DIFF
--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -26,6 +26,8 @@ module InsightsCloud::Api
         return render json: { error: e }, status: :gateway_timeout
       end
 
+      return render json: { message: @cloud_response.to_s }, status: :gateway_timeout if @cloud_response.is_a?(RestClient::Exceptions::OpenTimeout)
+
       if @cloud_response.code == 401
         return render json: {
           :message => 'Authentication to the Insights Service failed.',

--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -18,7 +18,7 @@ module ForemanRhCloud
 
       execute_cloud_request(request_opts)
     rescue RestClient::ExceptionWithResponse => error_response
-      error_response.response
+      error_response.response.presence || error_response.exception
     end
 
     def prepare_request_opts(original_request, forward_payload, forward_params, certs)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Added rescue handing in the `cloud_request_forwarder` to pass down the error correctly if the `.response` was `nil` or `empty` and `machine_telemetries_controller` to return the timeout correctly if we get a `RestClient::Exceptions::OpenTimeout`
* Added a unit test for the timeout

#### What are the testing steps for this pull request?
* On the Foreman server run the following commands to block access to `cloud.redhat.com` for some connections
```bash
iptables -I OUTPUT -d api.access.redhat.com -j DROP

iptables -I OUTPUT -d cert-api.access.redhat.com -j DROP
```
* On your client run `insights-client` and see after a while we get `undefined method .code` with a stacktrace
* Checkout PR
* Try `insights-client` again and watch the server logs and we should see a proper error with a 504 gateway timeout