### PR TITLE
Explicitly include CA file when making calls to advisor engine

### DIFF
--- a/app/services/foreman_rh_cloud/cloud_request.rb
+++ b/app/services/foreman_rh_cloud/cloud_request.rb
@@ -8,6 +8,10 @@ module ForemanRhCloud
         proxy: ForemanRhCloud.transformed_http_proxy_string,
       }.deep_merge(params)
 
+      if ForemanRhCloud.with_local_advisor_engine?
+        final_params[:ssl_ca_file] ||= ForemanRhCloud.ca_cert
+      end
+
       response = RestClient::Request.execute(final_params)
 
       logger.debug("Response headers for request url #{final_params[:url]} are: #{response.headers}")

--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -34,7 +34,13 @@ module ForemanRhCloud
         ),
       }
       requested_url = original_request.original_fullpath.end_with?('/') ? original_request.path + '/' : original_request.path
-      base_params.merge(path_params(requested_url, certs))
+      params = path_params(requested_url, certs)
+
+      if ForemanRhCloud.with_local_advisor_engine?
+        params[:ssl_ca_file] = ForemanRhCloud.ca_cert
+      end
+
+      base_params.merge(params)
     end
 
     def prepare_forward_payload(original_request, controller_name)

--- a/app/services/foreman_rh_cloud/rules_ingester.rb
+++ b/app/services/foreman_rh_cloud/rules_ingester.rb
@@ -13,7 +13,18 @@ module ForemanRhCloud
 
     def fetch_rules_data
       advisor_url = "#{ForemanRhCloud.on_premise_url}/r/insights/v1/static/release/content.json"
-      JSON.parse(Net::HTTP.get(URI.parse(advisor_url)), symbolize_names: true)
+      uri = URI.parse(advisor_url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+
+      # Set CA certificate
+      http.ca_file = ForemanRhCloud.ca_cert
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+      request = Net::HTTP::Get.new(uri.request_uri)
+
+      response = http.request(request)
+      JSON.parse(response.body, symbolize_names: true)
     end
 
     def fetch_rules_and_resolutions

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -212,4 +212,15 @@ module ForemanRhCloud
   def self.with_local_advisor_engine?
     SETTINGS.dig(:foreman_rh_cloud, :use_local_advisor_engine) || false
   end
+
+  def self.ca_cert
+    # The reference to candlepin ca_cert_file can be removed
+    # once the setting is dropped. Foreman 3.15 introduces
+    # a single CA file that bundles all CAs.
+    if ::SETTINGS.dig(:katello, :candlepin, :ca_cert_file)
+      ::SETTINGS[:katello][:candlepin][:ca_cert_file]
+    else
+      ::SETTINGS[:ssl_ca_file]
+    end
+  end
 end


### PR DESCRIPTION
When using custom certificates, calls to the advisor engine will fail. 

The "server CA cert" is trusted at the system level by default. When non-custom certificates are installed, the server-ca is equal to the default CA and thus the system ends up trusting the CA certificate and everything works. Once custom certificates are involved, the default CA is not trusted by the system and failures occur.

We should not rely on the host to trust the CAs we need to use when making calls, and should rely on explicit configuration.