### PR TITLE
SAT-33134 - Allow minimal set of data collection for SWATCH

### DIFF
--- a/lib/foreman_inventory_upload/generators/fact_helpers.rb
+++ b/lib/foreman_inventory_upload/generators/fact_helpers.rb
@@ -57,6 +57,7 @@ module ForemanInventoryUpload
       end
 
       def obfuscate_hostname?(host)
+        # return true if Setting[:insights_minimal_data_collection]
         insights_client_setting = fact_value(host, 'insights_client::obfuscate_hostname_enabled')
         insights_client_setting = ActiveModel::Type::Boolean.new.cast(insights_client_setting)
         return insights_client_setting unless insights_client_setting.nil?
@@ -75,6 +76,7 @@ module ForemanInventoryUpload
       end
 
       def obfuscate_ips?(host)
+        # return true if Setting[:insights_minimal_data_collection]
         insights_client_setting = fact_value(host, 'insights_client::obfuscate_ip_enabled')
         insights_client_setting = ActiveModel::Type::Boolean.new.cast(insights_client_setting)
         return insights_client_setting unless insights_client_setting.nil?

--- a/lib/foreman_inventory_upload/generators/fact_helpers.rb
+++ b/lib/foreman_inventory_upload/generators/fact_helpers.rb
@@ -75,7 +75,6 @@ module ForemanInventoryUpload
       end
 
       def obfuscate_ips?(host)
-        # return true if Setting[:insights_minimal_data_collection]
         insights_client_setting = fact_value(host, 'insights_client::obfuscate_ip_enabled')
         insights_client_setting = ActiveModel::Type::Boolean.new.cast(insights_client_setting)
         return insights_client_setting unless insights_client_setting.nil?

--- a/lib/foreman_inventory_upload/generators/fact_helpers.rb
+++ b/lib/foreman_inventory_upload/generators/fact_helpers.rb
@@ -57,7 +57,6 @@ module ForemanInventoryUpload
       end
 
       def obfuscate_hostname?(host)
-        # return true if Setting[:insights_minimal_data_collection]
         insights_client_setting = fact_value(host, 'insights_client::obfuscate_hostname_enabled')
         insights_client_setting = ActiveModel::Type::Boolean.new.cast(insights_client_setting)
         return insights_client_setting unless insights_client_setting.nil?

--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -17,6 +17,8 @@ module ForemanInventoryUpload
               'distribution::name',
               'uname::release',
               'lscpu::flags',
+              'hypervisor::type',
+              'hypervisor::version',
               'distribution::version',
               'distribution::id',
               'virt::is_guest',

--- a/webpack/ForemanInventoryUpload/Components/InventorySettings/MinimalInventoryDropdown.js
+++ b/webpack/ForemanInventoryUpload/Components/InventorySettings/MinimalInventoryDropdown.js
@@ -21,7 +21,7 @@ const MinimalInventoryDropdown = ({ setChosenValue }) => {
     minimal: {
       title: __('Minimal data collection'),
       description: __(
-        'Only send the minimum required data to Red Hat cloud, and obfuscate wherever possible'
+        'Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled'
       ),
     },
     optional: {


### PR DESCRIPTION
### What are the changes introduced in this pull request?
* Created a new method called `insights_minimal_data_collection` in `slice.rb` which will be called to only gather the minimal info needed for SWATCH to consume data while leaving out fqdn, ip and a lot of other data when minimal data collection is set`
* Updated the installed packages logic in `slice.rb` to not send packages if minimal data collection is set
* Added two new fields to `queries.rb` that SWATCH needs for virt-who hypervisors that we were not sending off
```bash
'hypervisor::type',
'hypervisor::version',
```
* Added unit tests for multiple scenarios to support the Q2 TDD goal

### Considerations taken when implementing this change?
* Based it on Jeremy's pr https://github.com/theforeman/foreman_rh_cloud/pull/979 once that gets in, I will rebase this so it's just the backend components

### What are the testing steps for this pull request?
* Check out PR
* Tested with the following scenarios:

Scenario one: minimal option toggled - only minimal valid Json file created
```json
{
  "report_slice_id": "de92044d-9d77-4895-83c4-a476f5020519",
  "hosts": [
    {
      "account": "5235210",
      "subscription_manager_id": "9fc621b9-08c3-4085-a749-bfed38c3052e",
      "insights_id": "9fc621b9-08c3-4085-a749-bfed38c3052e",
      "bios_uuid": "203F234F-58C7-4237-8DDF-A17A2838A66C",
      "bios_vendor": "SeaBIOS",
      "bios_version": "1.16.1-1.el9",
      "arch": "x86_64",
      "infrastructure_type": "virtual",
      "system_profile": {
        "installed_products": [
          {
            "name": "Red Hat Enterprise Linux for x86_64",
            "id": "479"
          }
        ],
        "cores_per_socket": 1,
        "system_memory_bytes": 3836579840,
        "number_of_cpus": 1,
        "number_of_sockets": 1
      },
      "cpu_socket(s)": "1"
    },
    {
      "account": "5235210",
      "subscription_manager_id": "26c066fe-d90f-414c-9df4-8048fa6ffca6",
      "bios_uuid": "B3C7F8DB-47B6-4F30-9AF4-6A5485EF2FCC",
      "bios_vendor": "SeaBIOS",
      "bios_version": "1.16.1-1.el9",
      "arch": "x86_64",
      "infrastructure_type": "virtual",
      "system_profile": {
        "installed_products": [
          {
            "name": "Red Hat Enterprise Linux for x86_64",
            "id": "479"
          }
        ],
        "cores_per_socket": 1,
        "system_memory_bytes": 24930463744,
        "number_of_cpus": 6,
        "number_of_sockets": 6
      },
      "cpu_socket(s)": "6"
    },
    {
      "account": "5235210",
      "subscription_manager_id": "7fbd08ef-4418-49fd-8bc6-94892ed4a036",
      "bios_uuid": "4c4c4544-0053-3310-8047-b5c04f595833",
      "infrastructure_type": "physical",
      "system_profile": {
        "number_of_sockets": 2
      },
      "cpu_socket(s)": "2",
      "hypervisor_type": "VMware ESXi",
      "hypervisor_version": "6.7.0"
    },
    {
      "account": "5235210",
      "subscription_manager_id": "c4be8b47-8e85-48d5-a0a8-77aa4e4e018f",
      "bios_uuid": "4c4c4544-0031-3010-805a-cac04f4c3032",
      "infrastructure_type": "physical",
      "system_profile": {
        "number_of_sockets": 2
      },
      "cpu_socket(s)": "2",
      "hypervisor_type": "VMware ESXi",
      "hypervisor_version": "6.7.0"
    },
    {
      "account": "5235210",
      "subscription_manager_id": "ea4ddd0c-8506-4652-b108-069f24c9d6de",
      "bios_uuid": "4c4c4544-0031-4310-804b-b8c04f435931",
      "infrastructure_type": "physical",
      "system_profile": {
        "number_of_sockets": 2
      },
      "cpu_socket(s)": "2",
      "hypervisor_type": "VMware ESXi",
      "hypervisor_version": "6.7.0"
    },
    {
      "account": "5235210",
      "subscription_manager_id": "9bf518d5-87ce-46d6-8ef0-47ce98464a2c",
      "bios_uuid": "4c4c4544-0031-4410-804b-b8c04f435931",
      "infrastructure_type": "physical",
      "system_profile": {
        "number_of_sockets": 4
      },
      "cpu_socket(s)": "4",
      "hypervisor_type": "VMware ESXi",
      "hypervisor_version": "6.7.0"
    },
    {
      "account": "5235210",
      "subscription_manager_id": "7f44aeff-d94e-4d3e-b3fa-9f17ff7c9301",
      "bios_uuid": "4c4c4544-0031-4310-804d-b8c04f435931",
      "infrastructure_type": "physical",
      "system_profile": {
        "number_of_sockets": 4
      },
      "cpu_socket(s)": "4",
      "hypervisor_type": "VMware ESXi",
      "hypervisor_version": "6.7.0"
    },
    {
      "account": "5235210",
      "subscription_manager_id": "65a35ff9-e16e-4428-b595-8fffae663ae1",
      "bios_uuid": "4c4c4544-0031-4310-804c-b8c04f435931",
      "infrastructure_type": "physical",
      "system_profile": {
        "number_of_sockets": 4
      },
      "cpu_socket(s)": "4",
      "hypervisor_type": "VMware ESXi",
      "hypervisor_version": "6.7.0"
    },
    {
      "account": "5235210",
      "subscription_manager_id": "1cedfb75-143d-4246-b837-8cd3025d4b95",
      "bios_uuid": "4c4c4544-0031-4410-804a-b8c04f435931",
      "infrastructure_type": "physical",
      "system_profile": {
        "number_of_sockets": 4
      },
      "cpu_socket(s)": "4",
      "hypervisor_type": "VMware ESXi",
      "hypervisor_version": "6.7.0"
    },
    {
      "account": "5235210",
      "subscription_manager_id": "e4f81a31-b857-4ccd-b578-853e69138e34",
      "bios_uuid": "d812420e-66d7-3e00-8485-46a7fd3b3d6b",
      "infrastructure_type": "physical",
      "system_profile": {
        "number_of_sockets": 2
      },
      "cpu_socket(s)": "2",
      "hypervisor_type": "VMware ESXi",
      "hypervisor_version": "6.7.0"
    }
  ]
}
```
scenario two. minimal but obfuscate host name setting overridden to false - only minimal valid Json file created
scenario three. minimal but Ip setting toggled to false - only minimal valid Json file created
scenario four. minimal but exclude packages set to false - only minimal valid Json file created
scenario five: optional no settings flipped - Creates valid JSON file
scenario six. optional - fqdn setting toggled to true, changed hostname for non-insights hosts
```json
{
      "fqdn": "6762def79cd47b73d564bd0fe429b0a3675a124c.example.com",
      "account": "5235210",
      "subscription_manager_id": "e4f81a31-b857-4ccd-b578-853e69138e34",
      "satellite_id": "e4f81a31-b857-4ccd-b578-853e69138e34",
      "bios_uuid": "d812420e-66d7-3e00-8485-46a7fd3b3d6b",
      "system_profile": {
        "number_of_sockets": 2,
        "network_interfaces": [],
        "katello_agent_running": false,
        "infrastructure_type": "physical",
        "installed_packages": [],
        "satellite_managed": true
      },
```
scenario seven. option - ip setting toggle to true, masked ip for non-insights host
```json
  "hosts": [
    {
      "fqdn": "ip-10-0-167-117.rhos-01.prod.psi.rdu2.redhat.com",
      "account": "5235210",
      "subscription_manager_id": "9fc621b9-08c3-4085-a749-bfed38c3052e",
      "satellite_id": "9fc621b9-08c3-4085-a749-bfed38c3052e",
      "bios_uuid": "203F234F-58C7-4237-8DDF-A17A2838A66C",
      "vm_uuid": "203F234F-58C7-4237-8DDF-A17A2838A66C",
      "insights_id": "9fc621b9-08c3-4085-a749-bfed38c3052e",
      "ip_addresses": [
        "10.230.230.1"
      ],
```
scenario eight optional - exclude packages toggled to true - Creates report without packages