### PR TITLE
Do not use http proxy settings for local advisor engine

### DIFF
--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -47,6 +47,8 @@ module ForemanRhCloud
   end
 
   def self.proxy_string
+    return '' if ForemanRhCloud.with_local_advisor_engine?
+
     HttpProxy.default_global_content_proxy&.full_url ||
     ForemanRhCloud.global_foreman_proxy ||
     ''


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Do not use the foreman or content http proxy setting if local advisor engine is enabled.

SAT-33408

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1.) Client:
```
# insights-client
```

2.) Set a proxy (valid or not) on the Satellite:
```
# hammer http-proxy create --name=myproxy \
--url http://myproxy.example.com:8080  \
--username=proxy_username \
--password=proxy_password

# hammer settings set --name=content_default_http_proxy --value=myproxy
```

3.) Client:
```
# insights-client
```