### PR TITLE
Correct some exception handling

### DIFF
--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -22,7 +22,7 @@ module InsightsCloud::Api
         response_obj = e.response.presence || e.exception
         return render json: { message: response_obj.to_s, error: response_obj.to_s }, status: :gateway_timeout
       rescue RestClient::Unauthorized => e
-        logger.info("Forwarding request auth error: #{e}")
+        logger.warn("Forwarding request auth error: #{e}")
         message = 'Authentication to the Insights Service failed.'
         return render json: { message: message, error: message }, status: :unauthorized
       rescue RestClient::NotModified => e
@@ -42,8 +42,8 @@ module InsightsCloud::Api
         }, status: code
       rescue StandardError => e
         # Catch any other exceptions here, such as Errno::ECONNREFUSED
-        logger.info("Cloud request failed with exception: #{e}")
-        return render json: { error: e }, status: :bad_gateway
+        logger.warn("Cloud request failed with exception: #{e}")
+        return render json: { error: e.to_s }, status: :bad_gateway
       end
 
       # Append redhat-specific headers

--- a/app/services/foreman_rh_cloud/cloud_request.rb
+++ b/app/services/foreman_rh_cloud/cloud_request.rb
@@ -19,13 +19,13 @@ module ForemanRhCloud
       response
     rescue RestClient::Exceptions::Timeout => ex
       logger.debug("Timeout exception raised for request url #{final_params[:url]}: #{ex}")
-      raise ex
+      raise
     rescue RestClient::ExceptionWithResponse => ex
       logger.debug("Response headers for request url #{final_params[:url]} with status code #{ex.http_code} are: #{ex.http_headers} and body: #{ex.http_body}")
-      raise ex
+      raise
     rescue StandardError => ex
       logger.debug("Exception raised for request url #{final_params[:url]}: #{ex}")
-      raise ex
+      raise
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Added  unit test for time out exceptions
Made sure the raise command raises the original exception
Changed some info's to warns.

## Summary by Sourcery

Improve exception handling and logging for cloud request interactions

Bug Fixes:
- Ensure original exceptions are re-raised correctly
- Improve error response formatting for different exception types

Enhancements:
- Change logging from info to warn for error scenarios
- Modify error response to include more precise error messages

Tests:
- Add unit test for handling RestClient timeout exceptions