### PR TITLE
Add CVEs tab to Host Details page

### DIFF
--- a/app/views/api/v2/hosts/insights/single.rabl
+++ b/app/views/api/v2/hosts/insights/single.rabl
@@ -1,0 +1,5 @@
+node :vulnerability do
+  {
+    enabled: ForemanRhCloud.with_local_advisor_engine?,
+  }
+end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -128,7 +128,7 @@ module ForemanRhCloud
 
           register_facet InsightsFacet, :insights do
             configure_host do
-              api_view :list => 'api/v2/hosts/insights/insights'
+              api_view :list => 'api/v2/hosts/insights/insights', :single => 'api/v2/hosts/insights/single'
               set_dependent_action :destroy
             end
           end

--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const CVEsHostDetailsTab = ({ hostName }) => (
+  <div>
+    <h1>
+      {__('CVEs tab for host:')} {hostName}
+    </h1>
+  </div>
+);
+
+CVEsHostDetailsTab.propTypes = {
+  hostName: PropTypes.string.isRequired,
+};
+
+export default CVEsHostDetailsTab;

--- a/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
+++ b/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CVEsHostDetailsTab from '../CVEsHostDetailsTab';
+
+describe('CVEsHostDetailsTab', () => {
+  it('renders without crashing', () => {
+    render(<CVEsHostDetailsTab hostName="test-host.example.com" />);
+    expect(
+      screen.getByText('CVEs tab for host: test-host.example.com')
+    ).toBeTruthy();
+  });
+
+  it('renders the host name', () => {
+    const hostName = 'test-host.example.com';
+    render(<CVEsHostDetailsTab hostName={hostName} />);
+    expect(screen.getByText(`CVEs tab for host: ${hostName}`)).toBeTruthy();
+  });
+});

--- a/webpack/CVEsHostDetailsTab/index.js
+++ b/webpack/CVEsHostDetailsTab/index.js
@@ -1,0 +1,3 @@
+import CVEsHostDetailsTab from './CVEsHostDetailsTab';
+
+export default CVEsHostDetailsTab;

--- a/webpack/ForemanRhCloudFills.js
+++ b/webpack/ForemanRhCloudFills.js
@@ -3,7 +3,8 @@ import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';
 import InventoryAutoUploadSwitcher from './ForemanInventoryUpload/SubscriptionsPageExtension/InventoryAutoUpload';
 import NewHostDetailsTab from './InsightsHostDetailsTab/NewHostDetailsTab';
 import { InsightsTotalRiskChartWrapper } from './InsightsHostDetailsTab/InsightsTotalRiskChartWrapper';
-import { isNotRhelHost } from './ForemanRhCloudHelpers';
+import { isNotRhelHost, vulnerabilityDisabled } from './ForemanRhCloudHelpers';
+import CVEsHostDetailsTab from './CVEsHostDetailsTab/CVEsHostDetailsTab';
 
 const fills = [
   {
@@ -26,6 +27,15 @@ const fills = [
     name: 'insights-total-risk-chart',
     component: props => <InsightsTotalRiskChartWrapper {...props} />,
     weight: 2800,
+  },
+  {
+    slot: 'host-details-page-tabs',
+    name: 'CVEs',
+    component: props => <CVEsHostDetailsTab {...props} />,
+    weight: 300,
+    metadata: {
+      hideTab: vulnerabilityDisabled,
+    },
   },
 ];
 

--- a/webpack/ForemanRhCloudHelpers.js
+++ b/webpack/ForemanRhCloudHelpers.js
@@ -11,3 +11,6 @@ export const isNotRhelHost = ({ hostDetails }) =>
     // eslint-disable-next-line camelcase
     hostDetails?.operatingsystem_name
   );
+
+export const vulnerabilityDisabled = ({ hostDetails }) =>
+  isNotRhelHost({ hostDetails }) || !hostDetails?.vulnerability?.enabled;

--- a/webpack/__tests__/ForemanRhCloudHelpers.test.js
+++ b/webpack/__tests__/ForemanRhCloudHelpers.test.js
@@ -1,10 +1,39 @@
 import { testSelectorsSnapshotWithFixtures } from '@theforeman/test';
-import { foremanUrl } from '../ForemanRhCloudHelpers';
+import { foremanUrl, vulnerabilityDisabled } from '../ForemanRhCloudHelpers';
 
 global.URL_PREFIX = 'MY_TEST_URL_PREFIX.example.com';
 
 const fixtures = {
   'should return foreman Url': () => foremanUrl('/test_path'),
+  'vulnerabilityDisabled returns false for RHEL host with vulnerability enabled': () =>
+    vulnerabilityDisabled({
+      hostDetails: {
+        operatingsystem_name: 'Red Hat Enterprise Linux',
+        vulnerability: { enabled: true },
+      },
+    }),
+  'vulnerabilityDisabled returns true for non-RHEL host': () =>
+    vulnerabilityDisabled({
+      hostDetails: {
+        operatingsystem_name: 'Ubuntu',
+        vulnerability: { enabled: true },
+      },
+    }),
+  'vulnerabilityDisabled returns true for RHEL host with vulnerability disabled': () =>
+    vulnerabilityDisabled({
+      hostDetails: {
+        operatingsystem_name: 'Red Hat Enterprise Linux',
+        vulnerability: { enabled: false },
+      },
+    }),
+  'vulnerabilityDisabled returns true for missing vulnerability object': () =>
+    vulnerabilityDisabled({
+      hostDetails: {
+        operatingsystem_name: 'Red Hat Enterprise Linux',
+      },
+    }),
+  'vulnerabilityDisabled returns true for missing hostDetails': () =>
+    vulnerabilityDisabled({}),
 };
 
 describe('ForemanRhCloud helpers', () =>

--- a/webpack/__tests__/__snapshots__/ForemanRhCloudHelpers.test.js.snap
+++ b/webpack/__tests__/__snapshots__/ForemanRhCloudHelpers.test.js.snap
@@ -1,3 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ForemanRhCloud helpers should return foreman Url 1`] = `"MY_TEST_URL_PREFIX.example.com/test_path"`;
+
+exports[`ForemanRhCloud helpers vulnerabilityDisabled returns false for RHEL host with vulnerability enabled 1`] = `false`;
+
+exports[`ForemanRhCloud helpers vulnerabilityDisabled returns true for RHEL host with vulnerability disabled 1`] = `true`;
+
+exports[`ForemanRhCloud helpers vulnerabilityDisabled returns true for missing hostDetails 1`] = `true`;
+
+exports[`ForemanRhCloud helpers vulnerabilityDisabled returns true for missing vulnerability object 1`] = `true`;
+
+exports[`ForemanRhCloud helpers vulnerabilityDisabled returns true for non-RHEL host 1`] = `true`;


### PR DESCRIPTION
## Summary by Sourcery

Add a new CVEs tab to the host details page by creating the CVEsHostDetailsTab component, registering it in the fills and pages, and conditionally hiding it for non-RHEL hosts

New Features:
- Introduce CVEsHostDetailsTab component to display CVEs for a host
- Add a new 'CVEs' tab to the host details page with conditional visibility for RHEL hosts
- Register the CVEsHostDetailsTab in the application's page registry

Tests:
- Add initial test file for the CVEsHostDetailsTab component