### PR TITLE
Release 11.4.1

### DIFF
--- a/app/services/foreman_rh_cloud/cloud_request.rb
+++ b/app/services/foreman_rh_cloud/cloud_request.rb
@@ -8,6 +8,10 @@ module ForemanRhCloud
         proxy: ForemanRhCloud.transformed_http_proxy_string,
       }.deep_merge(params)
 
+      if ForemanRhCloud.with_local_advisor_engine?
+        final_params[:ssl_ca_file] ||= ForemanRhCloud.ca_cert
+      end
+
       response = RestClient::Request.execute(final_params)
 
       logger.debug("Response headers for request url #{final_params[:url]} are: #{response.headers}")

--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -34,7 +34,13 @@ module ForemanRhCloud
         ),
       }
       requested_url = original_request.original_fullpath.end_with?('/') ? original_request.path + '/' : original_request.path
-      base_params.merge(path_params(requested_url, certs))
+      params = path_params(requested_url, certs)
+
+      if ForemanRhCloud.with_local_advisor_engine?
+        params[:ssl_ca_file] = ForemanRhCloud.ca_cert
+      end
+
+      base_params.merge(params)
     end
 
     def prepare_forward_payload(original_request, controller_name)

--- a/app/services/foreman_rh_cloud/rules_ingester.rb
+++ b/app/services/foreman_rh_cloud/rules_ingester.rb
@@ -13,7 +13,18 @@ module ForemanRhCloud
 
     def fetch_rules_data
       advisor_url = "#{ForemanRhCloud.on_premise_url}/r/insights/v1/static/release/content.json"
-      JSON.parse(Net::HTTP.get(URI.parse(advisor_url)), symbolize_names: true)
+      uri = URI.parse(advisor_url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+
+      # Set CA certificate
+      http.ca_file = ForemanRhCloud.ca_cert
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+      request = Net::HTTP::Get.new(uri.request_uri)
+
+      response = http.request(request)
+      JSON.parse(response.body, symbolize_names: true)
     end
 
     def fetch_rules_and_resolutions

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -212,4 +212,15 @@ module ForemanRhCloud
   def self.with_local_advisor_engine?
     SETTINGS.dig(:foreman_rh_cloud, :use_local_advisor_engine) || false
   end
+
+  def self.ca_cert
+    # The reference to candlepin ca_cert_file can be removed
+    # once the setting is dropped. Foreman 3.15 introduces
+    # a single CA file that bundles all CAs.
+    if ::SETTINGS.dig(:katello, :candlepin, :ca_cert_file)
+      ::SETTINGS[:katello][:candlepin][:ca_cert_file]
+    else
+      ::SETTINGS[:ssl_ca_file]
+    end
+  end
 end

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '11.4.0'.freeze
+  VERSION = '11.4.1'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "11.4.0",
+  "version": "11.4.1",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Enable SSL CA certificate handling for advisor and cloud API requests and bump the package version to 11.4.1

Enhancements:
- Add CA certificate support for HTTP connections in the rules ingester
- Introduce ForemanRhCloud.ca_cert to fetch the appropriate CA bundle from settings
- Include ssl_ca_file parameter when forwarding and executing cloud requests with a local advisor engine

Chores:
- Bump ForemanRhCloud version to 11.4.1 in version.rb and package.json