### PR TITLE
Release 10.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ for how to install Foreman plugins
 
 #### Inventory upload
 
-In UI: Configure -> Inventory Upload -> Restart
+In UI: Insights -> Inventory Upload -> select the organization -> Generate and upload report
 
 From command-line:
 
@@ -38,7 +38,7 @@ From command-line:
 
 #### Fetch hosts remediation data
 
-In UI: Configure -> Insights -> Sync now
+In UI: Insights -> Recommendations -> Sync recommendations (under the vertical ellipsis)
 
 From command-line:
 
@@ -46,7 +46,7 @@ From command-line:
 
 #### Synchronize inventory status
 
-In UI: Configure -> Inventory Upload -> Sync inventory status
+In UI: Insights -> Inventory Upload -> Sync all inventory status
 
 From command-line:
 

--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -22,7 +22,7 @@ module InsightsCloud::Api
         response_obj = e.response.presence || e.exception
         return render json: { message: response_obj.to_s, error: response_obj.to_s }, status: :gateway_timeout
       rescue RestClient::Unauthorized => e
-        logger.info("Forwarding request auth error: #{e}")
+        logger.warn("Forwarding request auth error: #{e}")
         message = 'Authentication to the Insights Service failed.'
         return render json: { message: message, error: message }, status: :unauthorized
       rescue RestClient::NotModified => e
@@ -42,8 +42,8 @@ module InsightsCloud::Api
         }, status: code
       rescue StandardError => e
         # Catch any other exceptions here, such as Errno::ECONNREFUSED
-        logger.info("Cloud request failed with exception: #{e}")
-        return render json: { error: e }, status: :bad_gateway
+        logger.warn("Cloud request failed with exception: #{e}")
+        return render json: { error: e.to_s }, status: :bad_gateway
       end
 
       # Append redhat-specific headers

--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -16,29 +16,41 @@ module InsightsCloud::Api
     # The method that "proxies" requests over to Cloud
     def forward_request
       certs = candlepin_id_cert @organization
-      @cloud_response = ::ForemanRhCloud::CloudRequestForwarder.new.forward_request(request, controller_name, @branch_id, certs)
+      begin
+        @cloud_response = ::ForemanRhCloud::CloudRequestForwarder.new.forward_request(request, controller_name, @branch_id, certs)
+      rescue RestClient::Exceptions::Timeout => e
+        response_obj = e.response.presence || e.exception
+        return render json: { message: response_obj.to_s, error: response_obj.to_s }, status: :gateway_timeout
+      rescue RestClient::Unauthorized => e
+        logger.info("Forwarding request auth error: #{e}")
+        message = 'Authentication to the Insights Service failed.'
+        return render json: { message: message, error: message }, status: :unauthorized
+      rescue RestClient::NotModified => e
+        logger.info("Forwarding request not modified: #{e}")
+        message = 'Cloud request not modified'
+        return render json: { message: message, error: message }, status: :not_modified
+      rescue RestClient::ExceptionWithResponse => e
+        response_obj = e.response.presence || e.exception
+        code = response_obj.try(:code) || response_obj.try(:http_code) || 500
+        message = 'Cloud request failed'
 
-      return render json: { message: @cloud_response.to_s }, status: :gateway_timeout if @cloud_response.is_a?(RestClient::Exceptions::OpenTimeout)
-
-      if @cloud_response.code == 401
         return render json: {
-          :message => 'Authentication to the Insights Service failed.',
+          :message => message,
+          :error => response_obj.to_s,
           :headers => {},
-        }, status: :bad_gateway
-      end
-
-      if @cloud_response.code >= 300
-        return render json: {
-          :message => 'Cloud request failed',
-          :headers => {},
-          :response => @cloud_response,
-        }, status: @cloud_response.code
+          :response => response_obj,
+        }, status: code
+      rescue StandardError => e
+        # Catch any other exceptions here, such as Errno::ECONNREFUSED
+        logger.info("Cloud request failed with exception: #{e}")
+        return render json: { error: e }, status: :bad_gateway
       end
 
       # Append redhat-specific headers
       @cloud_response.headers.each do |key, value|
         assign_header(response, @cloud_response, key, false) if key.to_s.start_with?('x_rh_')
       end
+
       # Append general headers
       assign_header(response, @cloud_response, :x_resource_count, true)
       headers[Rack::ETAG] = @cloud_response.headers[:etag]
@@ -48,8 +60,8 @@ module InsightsCloud::Api
         # content type
         send_data @cloud_response, disposition: @cloud_response.headers[:content_disposition], type: @cloud_response.headers[:content_type]
       elsif @cloud_response.headers[:content_type] =~ /zip/
-        # if there is no Content-Disposition, but the content type is binary according the content type,
-        # forward the request as binry too
+        # If there is no Content-Disposition, but the content type is binary according to Content-Type, send the raw data
+        # with proper content type
         send_data @cloud_response, type: @cloud_response.headers[:content_type]
       else
         render json: @cloud_response, status: @cloud_response.code

--- a/app/services/foreman_rh_cloud/cloud_request.rb
+++ b/app/services/foreman_rh_cloud/cloud_request.rb
@@ -13,8 +13,14 @@ module ForemanRhCloud
       logger.debug("Response headers for request url #{final_params[:url]} are: #{response.headers}")
 
       response
-    rescue RestClient::Exception => ex
-      logger.debug("Failed response with code #{ex.http_code} headers for request url #{final_params[:url]} are: #{ex.http_headers} and body: #{ex.http_body}")
+    rescue RestClient::Exceptions::Timeout => ex
+      logger.debug("Timeout exception raised for request url #{final_params[:url]}: #{ex}")
+      raise ex
+    rescue RestClient::ExceptionWithResponse => ex
+      logger.debug("Response headers for request url #{final_params[:url]} with status code #{ex.http_code} are: #{ex.http_headers} and body: #{ex.http_body}")
+      raise ex
+    rescue StandardError => ex
+      logger.debug("Exception raised for request url #{final_params[:url]}: #{ex}")
       raise ex
     end
   end

--- a/app/services/foreman_rh_cloud/cloud_request.rb
+++ b/app/services/foreman_rh_cloud/cloud_request.rb
@@ -15,13 +15,13 @@ module ForemanRhCloud
       response
     rescue RestClient::Exceptions::Timeout => ex
       logger.debug("Timeout exception raised for request url #{final_params[:url]}: #{ex}")
-      raise ex
+      raise
     rescue RestClient::ExceptionWithResponse => ex
       logger.debug("Response headers for request url #{final_params[:url]} with status code #{ex.http_code} are: #{ex.http_headers} and body: #{ex.http_body}")
-      raise ex
+      raise
     rescue StandardError => ex
       logger.debug("Exception raised for request url #{final_params[:url]}: #{ex}")
-      raise ex
+      raise
     end
   end
 end

--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -17,8 +17,6 @@ module ForemanRhCloud
       logger.debug("Sending request to: #{request_opts[:url]}")
 
       execute_cloud_request(request_opts)
-    rescue RestClient::ExceptionWithResponse => error_response
-      error_response.response.presence || error_response.exception
     end
 
     def prepare_request_opts(original_request, forward_payload, forward_params, certs)

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '10.0.5'.freeze
+  VERSION = '10.0.6'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -96,13 +96,25 @@ module InsightsCloud::Api
         assert_equal net_http_resp[:content_type], @response.headers['Content-Type']
       end
 
+      test "should handle 304 cloud" do
+        net_http_resp = Net::HTTPResponse.new(1.0, 304, "Not Modified")
+        res = RestClient::Response.create(@body, net_http_resp, @http_req)
+
+        ::ForemanRhCloud::CloudRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::NotModified.new(res))
+
+        get :forward_request, params: { "path" => "platform/module-update-router/v1/channel" }
+        assert_equal 304, @response.status
+        assert_equal 'Cloud request not modified', JSON.parse(@response.body)['message']
+      end
+
       test "should handle failed authentication to cloud" do
         net_http_resp = Net::HTTPResponse.new(1.0, 401, "Unauthorized")
         res = RestClient::Response.create(@body, net_http_resp, @http_req)
-        ::ForemanRhCloud::CloudRequestForwarder.any_instance.stubs(:forward_request).returns(res)
+
+        ::ForemanRhCloud::CloudRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::Unauthorized.new(res))
 
         get :forward_request, params: { "path" => "platform/module-update-router/v1/channel" }
-        assert_equal 502, @response.status
+        assert_equal 401, @response.status
         assert_equal 'Authentication to the Insights Service failed.', JSON.parse(@response.body)['message']
       end
 

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -96,6 +96,16 @@ module InsightsCloud::Api
         assert_equal net_http_resp[:content_type], @response.headers['Content-Type']
       end
 
+      test "should handle StandardError" do
+        error_message = "Connection refused"
+        ::ForemanRhCloud::CloudRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(Errno::ECONNREFUSED.new)
+
+        get :forward_request, params: { "path" => "platform/module-update-router/v1/channel" }
+        assert_equal 502, @response.status
+        body = JSON.parse(@response.body)
+        assert_equal error_message, body['error']
+      end
+
       test "should handle 304 cloud" do
         net_http_resp = Net::HTTPResponse.new(1.0, 304, "Not Modified")
         res = RestClient::Response.create(@body, net_http_resp, @http_req)
@@ -105,6 +115,17 @@ module InsightsCloud::Api
         get :forward_request, params: { "path" => "platform/module-update-router/v1/channel" }
         assert_equal 304, @response.status
         assert_equal 'Cloud request not modified', JSON.parse(@response.body)['message']
+      end
+
+      test "should handle RestClient::Exceptions::Timeout" do
+        timeout_message = "execution expired"
+        ::ForemanRhCloud::CloudRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::Exceptions::Timeout.new(timeout_message))
+
+        get :forward_request, params: { "path" => "platform/module-update-router/v1/channel" }
+        assert_equal 504, @response.status
+        body = JSON.parse(@response.body)
+        assert_equal timeout_message, body['message']
+        assert_equal timeout_message, body['error']
       end
 
       test "should handle failed authentication to cloud" do


### PR DESCRIPTION
## Summary by Sourcery

Add guards to both Insights full and resolutions sync actions to skip execution when organization manifests are expired, deleted, or upstream connection is unavailable, enhance logging of skip conditions, extend test coverage for these scenarios, and bump version to 10.0.6.

Bug Fixes:
- Prevent Insights full sync from running when organization manifests are expired, deleted, or upstream connection fails
- Prevent Insights resolutions sync from running under the same conditions

Enhancements:
- Improve skip-logic in InsightsFullSync to only plan tasks for organizations with valid manifests and connectivity
- Log skip conditions at info level with descriptive messages in both sync actions

Tests:
- Add tests for skipping full sync and resolutions sync when manifest is expired or upstream connection is unavailable

Chores:
- Bump foreman_rh_cloud version to 10.0.6