### PR TITLE
SAT-34713 - Update Hybrid rake task to prompt for org_id and custom_url

### DIFF
--- a/lib/tasks/hybrid_cloud.rake
+++ b/lib/tasks/hybrid_cloud.rake
@@ -1,64 +1,122 @@
 require 'io/console'
+require 'uri'
 
-namespace :rh_cloud do |args|
-  desc 'Register Satellite Organization with Hybrid Cloud API. \
-        Specify org_id=x replace your organization ID with x. \
-        Specify SATELLITE_RH_CLOUD_URL=https://x with the Hybrid Cloud endpoint you are connecting to.'
+def logger
+  @logger ||= Logger.new(STDOUT)
+end
+
+namespace :rh_cloud do
+  desc 'Register Satellite Organization with Hybrid Cloud API.'
+  # This task registers the Satellite Organization with the Hybrid Cloud API.
+  # It requires the user to input their organization ID, Insights URL, and token.
+  # The task will then send a POST request to the Hybrid Cloud API to register the organization.
+  # The response will be logged, and any errors will be caught and logged as well.
+  # The task will exit with an error message if the organization does not have a manifest imported or if the token is not entered.
+  # The task will also log a warning if the custom URL is not set and the default one is used.
   task hybridcloud_register: [:environment] do
     include ::ForemanRhCloud::CertAuth
     include ::InsightsCloud::CandlepinCache
 
-    def logger
-      @logger ||= Logger.new(STDOUT)
+    # Helper method to get the registrations URL, with a warning for default usage
+    def registrations_url(custom_url)
+      if custom_url.empty?
+        logger.warn("Custom url is not set, using the default one: #{ForemanRhCloud.base_url}")
+        URI.join(ForemanRhCloud.base_url, '/api/identity/certificate/registrations').to_s
+      else
+        URI.join(custom_url, '/api/identity/certificate/registrations').to_s
+      end
     end
 
-    def registrations_url
-      logger.warn("Custom url is not set, using the default one: #{ForemanRhCloud.base_url}") if ENV['SATELLITE_RH_CLOUD_URL'].empty?
-      ForemanRhCloud.base_url + '/api/identity/certificate/registrations'
+    # --- Input Collection ---
+    puts "Paste in your organization ID, this can be retrieved with the command: hammer organization list"
+    loop do
+      input = STDIN.gets.chomp
+      if input.match?(/^\d+$/) # Checks if input consists only of digits
+        @user_org_id = input.to_i
+        break
+      else
+        puts "Invalid input. Please enter a numeric organization ID."
+      end
     end
 
-    if ENV['org_id'].nil?
-      logger.error('ERROR: org_id needs to be specified.')
+    puts "\n" + "-" * 50 + "\n\n"
+    puts 'Paste in your Custom Insights URL. If nothing is entered, the default will be used.'
+    insights_user_input = STDIN.gets.chomp
+
+    # --- Data Preparation ---
+
+    organization = Organization.find_by(id: @user_org_id)
+
+    if organization.nil?
+      logger.error("Organization with ID '#{@user_org_id}' not found.")
       exit(1)
     end
 
-    @organization = Organization.find_by(id: ENV['org_id'].to_i) # saw this coming in as a string, so making sure it gets passed as an integer.
-    @uid = cp_owner_id(@organization)
-    @hostname = ForemanRhCloud.foreman_host_name
-    logger.error('Organization provided does not have a manifest imported.') + exit(1) if @uid.nil?
-
-    puts 'Paste your token, output will be hidden.'
-    @token = STDIN.noecho(&:gets).chomp
-    logger.error('Token was not entered.') + exit(1) if @token.empty?
-
-    def headers
-      {
-        Authorization: "Bearer #{@token}",
-      }
+    uid = cp_owner_id(organization)
+    if uid.nil?
+      logger.error('Organization provided does not have a manifest imported.')
+      exit(1)
     end
 
-    def payload
-      {
-        "uid": @uid,
-        "display_name": "#{@hostname}+#{@organization.label}",
-      }
+    hostname = ForemanRhCloud.foreman_host_name
+    insights_url = registrations_url(insights_user_input)
+
+    puts "\n" + "-" * 50 + "\n\n"
+    puts 'Paste in your Hybrid Cloud API token, output will be hidden.'
+    puts 'This token can be retrieved from the Hybrid Cloud console.'
+    token = STDIN.noecho(&:gets).chomp
+
+    if token.empty?
+      logger.error('Token was not entered.')
+      exit(1)
     end
 
-    def method
-      :post
-    end
+    # --- API Request Configuration ---
+
+    headers = {
+      Authorization: "Bearer #{token}",
+    }
+
+    payload = {
+      'uid': uid,
+      "display_name": "#{hostname}+#{organization.label}",
+    }
+
+    # --- Execute Request ---
 
     begin
       response = execute_cloud_request(
-        organization: @organization,
-        method: method,
-        url: registrations_url,
+        organization: organization,
+        method: :post,
+        url: insights_url,
         headers: headers,
         payload: payload.to_json
       )
-      logger.debug(response)
+      logger.debug("Cloud request completed: status=#{response.code}, body_preview=#{response.body&.slice(0, 200)}")
+    # Add a more specific rescue for 401 Unauthorized errors
+    rescue RestClient::Unauthorized => _ex
+      logger.error('Registration failed: Your token is invalid or unauthorized. Please check your token and try again.')
+      # Optionally, you can still log the full debug info if helpful for advanced troubleshooting
+      # logger.debug(ex.backtrace.join("\n"))
+      exit(1)
+    rescue RestClient::ExceptionWithResponse => ex
+      # This catches any RestClient exception that has a response (like 400, 403, 404, 500, etc.)
+      status_code = begin
+        ex.response.code
+      rescue StandardError
+        "unknown"
+      end
+      logger.error("Registration failed with HTTP status #{status_code}: #{ex.message}")
+      logger.debug("Response body (if available): #{ex.response.body}")
+      # logger.debug(ex.backtrace.join("\n"))
+      exit(1)
     rescue StandardError => ex
-      logger.error(ex)
+      # This is the catch-all for any other unexpected errors
+      logger.error("An unexpected error occurred during registration: #{ex.message}")
+      # logger.debug(ex.backtrace.join("\n")) # Log backtrace for more info
+      exit(1)
     end
+
+    logger.info("Satellite Organization '#{organization.label}' (ID: #{@user_org_id}) successfully registered.")
   end
 end


### PR DESCRIPTION
* foreman-rake was changed which now clears all env vars except TERM and --whitelist
* Adds new prompts to the user to ask for things we had in the env vars
* Added some comments, added better validation for inputs and added color to the prompts.
* Added some error handling so the ruby traceback is not ugly, with keeping the option to turn it back on(commented)

## Summary by Sourcery

Update the Hybrid Cloud Rake task to interactively prompt for organization ID, custom Insights URL, and API token instead of relying on environment variables, with input validation, colored output, and enhanced error handling.

Enhancements:
- Replace environment variable inputs with interactive prompts for organization ID, custom URL, and API token.
- Validate that the organization ID is numeric and that the organization and token exist before proceeding.
- Add colored console output and separators to improve prompt clarity and user experience.
- Warn when using the default Insights URL and support custom URL input.
- Refactor task into logical sections with helper methods and inline comments for better readability.
- Implement specific error handling for unauthorized and other HTTP errors with clear logging and exit behavior.