### PR TITLE
Create a new page to show CVE list

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       get 'inventory_upload', to: '/react#index'
     end
     get 'insights_cloud', to: '/react#index' # Uses foreman's react controller
+    get 'insights_vulnerabilities', to: '/react#index'
   end
 
   scope :module => :'insights_cloud/api', :path => :redhat_access do

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -117,6 +117,13 @@ module ForemanRhCloud
               parent: :insights_menu,
               if: -> { !ForemanRhCloud.with_local_advisor_engine? }
             menu :top_menu, :insights_hits, caption: N_('Recommendations'), url: '/foreman_rh_cloud/insights_cloud', url_hash: { controller: :react, action: :index }, parent: :insights_menu
+            menu :top_menu,
+              :insights_vulnerabilities,
+              caption: N_('Vulnerabilities'),
+              url: '/foreman_rh_cloud/insights_vulnerabilities',
+              url_hash: { controller: :react, action: :index },
+              parent: :insights_menu,
+              if: -> { ForemanRhCloud.with_local_advisor_engine? }
           end
 
           register_facet InsightsFacet, :insights do

--- a/lib/insights_vulnerabilities.rb
+++ b/lib/insights_vulnerabilities.rb
@@ -1,0 +1,2 @@
+module InsightsVulnerabilities
+end

--- a/webpack/ForemanRhCloudPages.js
+++ b/webpack/ForemanRhCloudPages.js
@@ -2,6 +2,7 @@ import React from 'react';
 import componentRegistry from 'foremanReact/components/componentRegistry';
 import { registerRoutes as foremanRegisterRoutes } from 'foremanReact/routes/RoutingService';
 import ForemanInventoryUpload from './ForemanInventoryUpload';
+import InsightsVulnerabilities from './InsightsVulnerabilities/InsightsVulnerabilities';
 import InsightsCloudSync from './InsightsCloudSync';
 import InsightsHostDetailsTab from './InsightsHostDetailsTab';
 
@@ -9,6 +10,7 @@ const pages = [
   { name: 'ForemanInventoryUpload', type: ForemanInventoryUpload },
   { name: 'InsightsCloudSync', type: InsightsCloudSync },
   { name: 'InsightsHostDetailsTab', type: InsightsHostDetailsTab },
+  { name: 'InsightsVulnerabilities', type: InsightsVulnerabilities },
 ];
 
 export const registerPages = () => {
@@ -25,6 +27,11 @@ export const routes = [
     path: '/foreman_rh_cloud/inventory_upload',
     exact: true,
     render: props => <ForemanInventoryUpload {...props} />,
+  },
+  {
+    path: '/foreman_rh_cloud/insights_vulnerabilities',
+    exact: true,
+    render: props => <InsightsVulnerabilities {...props} />,
   },
 ];
 

--- a/webpack/InsightsVulnerabilities/InsightsVulnerabilities.js
+++ b/webpack/InsightsVulnerabilities/InsightsVulnerabilities.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const InsightsVulnerabilities = () => (
+  <PageLayout searchable={false} header={__('Vulnerabilities')}>
+    <div className="insights-vulnerabilities">
+      <p>This page is under development. Please check back soon for updates.</p>
+    </div>
+  </PageLayout>
+);
+
+export default InsightsVulnerabilities;

--- a/webpack/InsightsVulnerabilities/InsightsVulnerabilities.test.js
+++ b/webpack/InsightsVulnerabilities/InsightsVulnerabilities.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InsightsVulnerabilities from './InsightsVulnerabilities';
+
+describe('InsightsVulnerabilities component', () => {
+  it('renders the "under development" message', () => {
+    render(<InsightsVulnerabilities />);
+    expect(
+      screen.getByText(/this page is under development/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the container with correct class', () => {
+    const { container } = render(<InsightsVulnerabilities />);
+    expect(container.querySelector('.insights-vulnerabilities')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
- Added a new page to the UI to display a list of CVEs.
- The page is currently a placeholder and does not yet contain any content or functionality.

#### Considerations taken when implementing this change?
- This feature is still under active development.
- At this stage, the goal is to introduce the routing and page structure only, without implementing data fetching or rendering logic.

#### What are the testing steps for this pull request?
1. Launch the Foreman UI. 
2. In the side navigation menu, under the Insights section, locate the new Vulnerabilities page.
3. Click on it and verify that you are redirected to a new (currently empty) page.

## Summary by Sourcery

Add a new CVE list page stub by wiring up routes, menu entry, and component scaffolding for future development

New Features:
- Introduce a placeholder InsightsVulnerabilities page component
- Register the new vulnerabilities route in both the React router and Rails backend
- Add a Vulnerabilities menu entry under the Insights section in the Foreman UI

Tests:
- Scaffold a test file for the new InsightsVulnerabilities component

Chores:
- Create an empty Ruby module for InsightsVulnerabilities