### PR TITLE
Add @redhat-cloud-services/frontend-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,9 @@
     "stylelint-config-standard": "~18.0.0",
     "surge": "~0.20.3",
     "redux-mock-store": "~1.2.2"
+  },
+  "dependencies": {
+    "@redhat-cloud-services/frontend-components-utilities": "^3.7.6",
+    "@redhat-cloud-services/frontend-components": "^3.7.6"
   }
 }


### PR DESCRIPTION
Replaces https://github.com/theforeman/foreman_rh_cloud/pull/989

#### What are the changes introduced in this pull request?

Add `@redhat-cloud-services/frontend-components` to `package.json`. Prepares for https://github.com/theforeman/foreman/pull/10342

#### Considerations taken when implementing this change?

`npm i` wouldn't work because Foreman is not yet updated, so this has not been tested.

#### What are the testing steps for this pull request?

## Summary by Sourcery

Add Red Hat Cloud Services frontend components dependencies and update configuration setting descriptions

Enhancements:
- Clarify descriptions for obfuscate_inventory_hostnames and obfuscate_inventory_ips settings
- Update insights_minimal_data_collection description to reflect excluded fields in reports

Build:
- Add @redhat-cloud-services/frontend-components and frontend-components-utilities to package.json