### PR TITLE
Patch Katello controllers to enable access by smart proxy

### DIFF
--- a/db/seeds.d/200_features.rb
+++ b/db/seeds.d/200_features.rb
@@ -1,0 +1,4 @@
+ForemanRhCloud.on_prem_smart_proxy_features.each do |feature_name|
+  f = Feature.where(:name => feature_name).first_or_create
+  raise "Unable to create proxy feature: #{SeedHelper.format_errors f}" if f.nil? || f.errors.any?
+end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -210,6 +210,30 @@ module ForemanRhCloud
       )
     end
 
+    # Ideally this code belongs to an initializer. The problem is that Katello controllers are not initialized completely until after the end of the to_prepare blocks
+    # This means I can patch the controller only in the after_initialize block that is promised to run after the to_prepare
+    # initializer 'foreman_rh_cloud.allow_smart_proxy_actions', :before => :finisher_hook, :after => 'katello.register_plugin'  do |_app|
+    # end
+    config.after_initialize do
+      # skip overrides in migrations, since the controller initialization depends on tables existense
+      if defined?(Katello) && !Foreman.in_setup_db_rake?
+        Katello::Api::V2::OrganizationsController.include Foreman::Controller::SmartProxyAuth
+        # patch the callbacks order for :download_debug_certificate, since local_find_taxonomy has to run after the user is already initialized
+        Katello::Api::V2::OrganizationsController.skip_before_action(:local_find_taxonomy, only: :download_debug_certificate)
+        Katello::Api::V2::OrganizationsController.add_smart_proxy_filters(
+          [:index, :download_debug_certificate],
+          features: ForemanRhCloud.on_prem_smart_proxy_features
+        )
+        Katello::Api::V2::OrganizationsController.before_action(:local_find_taxonomy, only: :download_debug_certificate)
+
+        Katello::Api::V2::RepositoriesController.include Foreman::Controller::SmartProxyAuth
+        Katello::Api::V2::RepositoriesController.add_smart_proxy_filters(
+          :index,
+          features: ForemanRhCloud.on_prem_smart_proxy_features
+        )
+      end
+    end
+
     rake_tasks do
       Rake::Task['db:seed'].enhance do
         ForemanRhCloud::Engine.load_seed
@@ -230,5 +254,9 @@ module ForemanRhCloud
     else
       ::SETTINGS[:ssl_ca_file]
     end
+  end
+
+  def self.on_prem_smart_proxy_features
+    ['insights']
   end
 end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -257,6 +257,6 @@ module ForemanRhCloud
   end
 
   def self.on_prem_smart_proxy_features
-    ['insights']
+    ['Insights']
   end
 end

--- a/test/controllers/insights_cloud/api/cloud_request_controller_test.rb
+++ b/test/controllers/insights_cloud/api/cloud_request_controller_test.rb
@@ -51,8 +51,7 @@ module InsightsCloud::Api
       mock_composer = mock('composer')
       ::JobInvocationComposer.expects(:for_feature).with do |feature, host_ids, params|
         feature == :rh_cloud_connector_run_playbook &&
-        host_ids.first == host1.id &&
-        host_ids.last == host2.id
+        host_ids.sort == [host1.id, host2.id].sort
       end.returns(mock_composer)
       mock_composer.expects(:trigger!)
       mock_composer.expects(:job_invocation)

--- a/test/unit/rh_cloud_http_proxy_test.rb
+++ b/test/unit/rh_cloud_http_proxy_test.rb
@@ -4,6 +4,7 @@ class RhCloudHttpProxyTest < ActiveSupport::TestCase
   setup do
     @global_content_proxy_mock = 'http://global:content@localhost:80'
     @global_foreman_proxy_mock = 'http://global:foreman@localhost:80'
+    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(false)
   end
 
   test 'selects global content proxy' do
@@ -16,6 +17,13 @@ class RhCloudHttpProxyTest < ActiveSupport::TestCase
     setup_global_foreman_proxy
 
     assert_equal @global_foreman_proxy_mock, ForemanRhCloud.proxy_setting
+  end
+
+  test 'returns empty string in on-prem setup' do
+    ForemanRhCloud.unstub(:with_local_advisor_engine?)
+    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(true)
+
+    assert_empty ForemanRhCloud.proxy_setting
   end
 
   def setup_global_content_proxy


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Patching the Katello controllers to enable access from an IoP smart proxy

#### Considerations taken when implementing this change?

The other option is to implement an RBAC scheme similar to the `User` object

#### What are the testing steps for this pull request?

Access the Katello API using cert based auth with a cert that belongs to a smart proxy

## Summary by Sourcery

Patch Katello API controllers to allow Smart Proxy access via certificate authentication, introduce feature listing for on-prem proxies, update proxy-setting tests for on-prem scenarios, and seed the corresponding features in the database.

Enhancements:
- Enable certificate-based Smart Proxy authentication for Katello Organizations and Repositories API by patching controllers with SmartProxyAuth and custom filters
- Introduce on_prem_smart_proxy_features helper to list allowed Smart Proxy features

Tests:
- Adjust HTTP proxy tests to stub on-prem advisor engine detection and add test for empty proxy setting in on-prem mode

Chores:
- Add database seed script to create on-prem Smart Proxy features