### PR TITLE
Stop using postgresql-evr

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -28,6 +28,5 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
     with:
       plugin: foreman_rh_cloud
-      postgresql_container: ghcr.io/theforeman/postgresql-evr
       test_existing_database: false
       foreman_version: ${{ matrix.foreman }}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Katello has dropped this and is no longer needed.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

CI must be green.

## Summary by Sourcery

CI:
- Remove postgresql_container setting from ruby_tests.yml