### PR TITLE
Update the name to "Vulnerability"

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
       get 'inventory_upload', to: '/react#index'
     end
     get 'insights_cloud', to: '/react#index' # Uses foreman's react controller
-    get 'insights_vulnerabilities', to: '/react#index'
+    get 'insights_vulnerability', to: '/react#index'
   end
 
   scope :module => :'insights_cloud/api', :path => :redhat_access do

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -118,9 +118,9 @@ module ForemanRhCloud
               if: -> { !ForemanRhCloud.with_local_advisor_engine? }
             menu :top_menu, :insights_hits, caption: N_('Recommendations'), url: '/foreman_rh_cloud/insights_cloud', url_hash: { controller: :react, action: :index }, parent: :insights_menu
             menu :top_menu,
-              :insights_vulnerabilities,
-              caption: N_('Vulnerabilities'),
-              url: '/foreman_rh_cloud/insights_vulnerabilities',
+              :insights_vulnerability,
+              caption: N_('Vulnerability'),
+              url: '/foreman_rh_cloud/insights_vulnerability',
               url_hash: { controller: :react, action: :index },
               parent: :insights_menu,
               if: -> { ForemanRhCloud.with_local_advisor_engine? }

--- a/lib/insights_vulnerabilities.rb
+++ b/lib/insights_vulnerabilities.rb
@@ -1,2 +1,0 @@
-module InsightsVulnerabilities
-end

--- a/lib/insights_vulnerability.rb
+++ b/lib/insights_vulnerability.rb
@@ -1,0 +1,2 @@
+module InsightsVulnerability
+end

--- a/webpack/ForemanRhCloudPages.js
+++ b/webpack/ForemanRhCloudPages.js
@@ -2,7 +2,7 @@ import React from 'react';
 import componentRegistry from 'foremanReact/components/componentRegistry';
 import { registerRoutes as foremanRegisterRoutes } from 'foremanReact/routes/RoutingService';
 import ForemanInventoryUpload from './ForemanInventoryUpload';
-import InsightsVulnerabilities from './InsightsVulnerabilities/InsightsVulnerabilities';
+import InsightsVulnerability from './InsightsVulnerability/InsightsVulnerability';
 import InsightsCloudSync from './InsightsCloudSync';
 import InsightsHostDetailsTab from './InsightsHostDetailsTab';
 
@@ -10,7 +10,7 @@ const pages = [
   { name: 'ForemanInventoryUpload', type: ForemanInventoryUpload },
   { name: 'InsightsCloudSync', type: InsightsCloudSync },
   { name: 'InsightsHostDetailsTab', type: InsightsHostDetailsTab },
-  { name: 'InsightsVulnerabilities', type: InsightsVulnerabilities },
+  { name: 'InsightsVulnerability', type: InsightsVulnerability },
 ];
 
 export const registerPages = () => {
@@ -29,9 +29,9 @@ export const routes = [
     render: props => <ForemanInventoryUpload {...props} />,
   },
   {
-    path: '/foreman_rh_cloud/insights_vulnerabilities',
+    path: '/foreman_rh_cloud/insights_vulnerability',
     exact: true,
-    render: props => <InsightsVulnerabilities {...props} />,
+    render: props => <InsightsVulnerability {...props} />,
   },
 ];
 

--- a/webpack/InsightsVulnerability/InsightsVulnerability.js
+++ b/webpack/InsightsVulnerability/InsightsVulnerability.js
@@ -2,12 +2,12 @@ import React from 'react';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-const InsightsVulnerabilities = () => (
-  <PageLayout searchable={false} header={__('Vulnerabilities')}>
-    <div className="insights-vulnerabilities">
+const InsightsVulnerability = () => (
+  <PageLayout searchable={false} header={__('Vulnerability')}>
+    <div className="insights-vulnerability">
       <p>This page is under development. Please check back soon for updates.</p>
     </div>
   </PageLayout>
 );
 
-export default InsightsVulnerabilities;
+export default InsightsVulnerability;

--- a/webpack/InsightsVulnerability/InsightsVulnerability.test.js
+++ b/webpack/InsightsVulnerability/InsightsVulnerability.test.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import InsightsVulnerabilities from './InsightsVulnerabilities';
+import InsightsVulnerability from './InsightsVulnerability';
 
-describe('InsightsVulnerabilities component', () => {
+describe('InsightsVulnerability component', () => {
   it('renders the "under development" message', () => {
-    render(<InsightsVulnerabilities />);
+    render(<InsightsVulnerability />);
     expect(
       screen.getByText(/this page is under development/i)
     ).toBeInTheDocument();
   });
 
   it('renders the container with correct class', () => {
-    const { container } = render(<InsightsVulnerabilities />);
-    expect(container.querySelector('.insights-vulnerabilities')).toBeTruthy();
+    const { container } = render(<InsightsVulnerability />);
+    expect(container.querySelector('.insights-vulnerability')).toBeTruthy();
   });
 });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Consolidate the name from “Vulnerabilities” to singular “Vulnerability” across the engine, routes, React pages, and module files.

Enhancements:
- Rename the top_menu insights_vulnerabilities entry to insights_vulnerability with updated caption and URL
- Update Webpack page registration and route paths to use the InsightsVulnerability component and /insights_vulnerability endpoint
- Replace the old lib/insights_vulnerabilities.rb with a new insights_vulnerability module file