### PR TITLE
SAT-35343 - Change Optional data collection to Analytics data collection

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/InventorySettings/MinimalInventoryDropdown.js
+++ b/webpack/ForemanInventoryUpload/Components/InventorySettings/MinimalInventoryDropdown.js
@@ -25,7 +25,7 @@ const MinimalInventoryDropdown = ({ setChosenValue }) => {
       ),
     },
     optional: {
-      title: __('Optional data collection'),
+      title: __('Analytics data collection'),
       description: __(
         'Send additional data to enhance Insights services, as per the settings'
       ),


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Per Rich Jerido, the name needs to be changed to be something more apt to what it's doing. This was the name they decided on

#### What are the testing steps for this pull request?
* Check out PR
* Check the inventory host page and see if the new name is there

## Summary by Sourcery

Enhancements:
- Rename dropdown title to ‘Analytics data collection’ to better reflect its purpose