### PR TITLE
feat: add org label tag

### DIFF
--- a/lib/foreman_inventory_upload/generators/tags.rb
+++ b/lib/foreman_inventory_upload/generators/tags.rb
@@ -41,7 +41,10 @@ module ForemanInventoryUpload
       end
 
       def organizations
-        [['organization', @host.organization.name]]
+        [
+          ['organization', @host.organization.name],
+          ['organization_label', @host.organization.title],
+        ]
       end
 
       def content_data

--- a/test/unit/tags_generator_test.rb
+++ b/test/unit/tags_generator_test.rb
@@ -61,6 +61,7 @@ class TagsGeneratorTest < ActiveSupport::TestCase
     assert_equal @host.content_views.pluck(:name).max, actual['content_view'].map(&:second).max
     assert_equal Foreman.instance_id, actual['satellite_instance_id'].first.last
     assert_equal @host.organization_id.to_s, actual['organization_id'].first.last
+    assert_equal @host.organization.title, actual['organization_label'].first.last
   end
 
   test 'filters tags with empty values' do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Adds `organization_label` to the tags generator for Insights.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

SAT-34615

## Summary by Sourcery

New Features:
- Introduce organization_label tag in host collections to expose organization titles

## Summary by Sourcery

Introduce a new organization_label tag in the tags generator and update tests to validate it

New Features:
- Add organization_label tag to host collections to include organization titles

Tests:
- Add assertion in TagsGeneratorTest to verify the organization_label tag value