### PR TITLE
Bump version to 12.1.2

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.1.1'.freeze
+  VERSION = '12.1.2'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.1.1",
+  "version": "12.1.2",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Bump project version from 12.1.1 to 12.1.2

Build:
- Update Ruby gem version to 12.1.2
- Update npm package version to 12.1.2