### PR TITLE
Listen to package profile upload and upload a report specific to this host

### DIFF
--- a/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
@@ -12,12 +12,14 @@ module InsightsCloud
     def generate_host_report
       return unless ForemanRhCloud.with_local_advisor_engine?
 
+      logger.debug("Generating host-specific report for host #{@host.name}")
+
       ForemanTasks.async_task(
         ForemanInventoryUpload::Async::GenerateReportJob,
         ForemanInventoryUpload.generated_reports_folder,
         @host.organization_id,
         false,
-        { id: @host.id }
+        "id=#{@host.id}"
       )
 
       # in IoP case, the hosts are identified by the sub-man ID, and we can assume they already

--- a/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
@@ -3,7 +3,10 @@ module InsightsCloud
     extend ActiveSupport::Concern
 
     included do
+      # This method explicitly listens on Katello actions
+      # rubocop:disable Rails/LexicallyScopedActionFilter
       after_action :generate_host_report, only: [:upload_package_profile, :upload_profiles]
+      # rubocop:enable Rails/LexicallyScopedActionFilter
     end
 
     def generate_host_report
@@ -19,10 +22,10 @@ module InsightsCloud
 
       # in IoP case, the hosts are identified by the sub-man ID, and we can assume they already
       # exist in the local inventory. This will also handle facet creation for new hosts.
-      unless @host.insights
-        insights_facet = @host.build_insights(uuid: @host.subscription_facet.uuid)
-        insights_facet.save
-      end
+      return if @host.insights
+
+      insights_facet = @host.build_insights(uuid: @host.subscription_facet.uuid)
+      insights_facet.save
     end
   end
 end

--- a/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
@@ -1,0 +1,28 @@
+module InsightsCloud
+  module PackageProfileUploadExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      after_action :generate_host_report, only: [:upload_package_profile, :upload_profiles]
+    end
+
+    def generate_host_report
+      return unless ForemanRhCloud.with_local_advisor_engine?
+
+      ForemanTasks.async_task(
+        ForemanInventoryUpload::Async::GenerateReportJob,
+        ForemanInventoryUpload.generated_reports_folder,
+        @host.organization_id,
+        false,
+        { id: @host.id }
+      )
+
+      # in IoP case, the hosts are identified by the sub-man ID, and we can assume they already
+      # exist in the local inventory. This will also handle facet creation for new hosts.
+      unless @host.insights
+        insights_facet = @host.build_insights(uuid: @host.subscription_facet.uuid)
+        insights_facet.save
+      end
+    end
+  end
+end

--- a/app/services/foreman_rh_cloud/cert_auth.rb
+++ b/app/services/foreman_rh_cloud/cert_auth.rb
@@ -10,7 +10,8 @@ module ForemanRhCloud
     end
 
     def execute_cloud_request(params)
-      certs = ForemanRhCloud.with_local_advisor_engine? ? foreman_certificate : candlepin_id_cert(params.delete(:organization))
+      organization = params.delete(:organization)
+      certs = ForemanRhCloud.with_local_advisor_engine? ? foreman_certificate : candlepin_id_cert(organization)
       final_params = {
         ssl_client_cert: OpenSSL::X509::Certificate.new(certs[:cert]),
         ssl_client_key: OpenSSL::PKey.read(certs[:key]),

--- a/app/services/foreman_rh_cloud/cert_auth.rb
+++ b/app/services/foreman_rh_cloud/cert_auth.rb
@@ -20,12 +20,10 @@ module ForemanRhCloud
     end
 
     def foreman_certificate
-      @foreman_certificate ||= begin
-        {
-          cert: File.read(Setting[:ssl_certificate]),
-          key: File.read(Setting[:ssl_priv_key]),
-        }
-      end
+      @foreman_certificate ||= {
+        cert: File.read(Setting[:ssl_certificate]),
+        key: File.read(Setting[:ssl_priv_key]),
+      }
     end
   end
 end

--- a/app/services/foreman_rh_cloud/cert_auth.rb
+++ b/app/services/foreman_rh_cloud/cert_auth.rb
@@ -10,13 +10,22 @@ module ForemanRhCloud
     end
 
     def execute_cloud_request(params)
-      certs = candlepin_id_cert(params.delete(:organization))
+      certs = ForemanRhCloud.with_local_advisor_engine? ? foreman_certificate : candlepin_id_cert(params.delete(:organization))
       final_params = {
         ssl_client_cert: OpenSSL::X509::Certificate.new(certs[:cert]),
         ssl_client_key: OpenSSL::PKey.read(certs[:key]),
       }.deep_merge(params)
 
       super(final_params)
+    end
+
+    def foreman_certificate
+      @foreman_certificate ||= begin
+        {
+          cert: File.read(Setting[:ssl_certificate]),
+          key: File.read(Setting[:ssl_priv_key]),
+        }
+      end
     end
   end
 end

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -53,7 +53,7 @@ module ForemanInventoryUpload
   end
 
   def self.facts_archive_name(organization, filter = nil)
-    "report_for_#{organization}#{filter.empty? ? nil : "[#{filter.parameterize}]" }.tar.xz"
+    "report_for_#{organization}#{filter.empty? ? nil : "[#{filter.parameterize}]"}.tar.xz"
   end
 
   def self.upload_url

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -53,7 +53,7 @@ module ForemanInventoryUpload
   end
 
   def self.facts_archive_name(organization, filter = nil)
-    "report_for_#{organization}#{filter ? "[#{filter.parameterize}]" : nil}.tar.xz"
+    "report_for_#{organization}#{filter.empty? ? nil : "[#{filter.parameterize}]" }.tar.xz"
   end
 
   def self.upload_url

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -52,8 +52,8 @@ module ForemanInventoryUpload
     'uploader.sh'
   end
 
-  def self.facts_archive_name(organization)
-    "report_for_#{organization}.tar.xz"
+  def self.facts_archive_name(organization, filter = nil)
+    "report_for_#{organization}#{filter ? "[#{filter.parameterize}]" : nil}.tar.xz"
   end
 
   def self.upload_url

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -53,7 +53,7 @@ module ForemanInventoryUpload
   end
 
   def self.facts_archive_name(organization, filter = nil)
-    "report_for_#{organization}#{filter.empty? ? nil : "[#{filter.parameterize}]"}.tar.xz"
+    "report_for_#{organization}#{filter.empty? ? nil : "[#{filter.to_s.parameterize}]"}.tar.xz"
   end
 
   def self.upload_url

--- a/lib/foreman_inventory_upload/async/generate_report_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_report_job.rb
@@ -8,7 +8,7 @@ module ForemanInventoryUpload
       def plan(base_folder, organization_id, disconnected, hosts_filter = nil)
         sequence do
           super(
-            GenerateReportJob.output_label("#{organization_id}#{hosts_filter.empty? ? nil : "[#{hosts_filter.parameterize}]" }"),
+            GenerateReportJob.output_label("#{organization_id}#{hosts_filter.empty? ? nil : "[#{hosts_filter.parameterize}]"}"),
             organization_id: organization_id,
             base_folder: base_folder,
             hosts_filter: hosts_filter

--- a/lib/foreman_inventory_upload/async/generate_report_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_report_job.rb
@@ -8,7 +8,7 @@ module ForemanInventoryUpload
       def plan(base_folder, organization_id, disconnected, hosts_filter = nil)
         sequence do
           super(
-            GenerateReportJob.output_label("#{organization_id}#{hosts_filter ? "[#{hosts_filter.parameterize}]" : nil}"),
+            GenerateReportJob.output_label("#{organization_id}#{hosts_filter.empty? ? nil : "[#{hosts_filter.parameterize}]" }"),
             organization_id: organization_id,
             base_folder: base_folder,
             hosts_filter: hosts_filter

--- a/lib/foreman_inventory_upload/async/generate_report_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_report_job.rb
@@ -8,7 +8,7 @@ module ForemanInventoryUpload
       def plan(base_folder, organization_id, disconnected, hosts_filter = nil)
         sequence do
           super(
-            GenerateReportJob.output_label("#{organization_id}#{hosts_filter.empty? ? nil : "[#{hosts_filter.parameterize}]"}"),
+            GenerateReportJob.output_label("#{organization_id}#{hosts_filter.empty? ? nil : "[#{hosts_filter.to_s.parameterize}]"}"),
             organization_id: organization_id,
             base_folder: base_folder,
             hosts_filter: hosts_filter

--- a/lib/foreman_inventory_upload/async/generate_report_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_report_job.rb
@@ -5,18 +5,19 @@ module ForemanInventoryUpload
         "report_for_#{label}"
       end
 
-      def plan(base_folder, organization_id, disconnected)
+      def plan(base_folder, organization_id, disconnected, hosts_filter = nil)
         sequence do
           super(
-            GenerateReportJob.output_label(organization_id),
+            GenerateReportJob.output_label("#{organization_id}#{hosts_filter ? "[#{hosts_filter.parameterize}]" : nil}"),
             organization_id: organization_id,
-            base_folder: base_folder
+            base_folder: base_folder,
+            hosts_filter: hosts_filter
           )
 
           plan_action(
             QueueForUploadJob,
             base_folder,
-            ForemanInventoryUpload.facts_archive_name(organization_id),
+            ForemanInventoryUpload.facts_archive_name(organization_id, hosts_filter),
             organization_id,
             disconnected
           )
@@ -34,7 +35,8 @@ module ForemanInventoryUpload
       def env
         super.merge(
           'target' => base_folder,
-          'organization_id' => organization_id
+          'organization_id' => organization_id,
+          'hosts_filter' => hosts_filter
         )
       end
 
@@ -44,6 +46,10 @@ module ForemanInventoryUpload
 
       def organization_id
         input[:organization_id]
+      end
+
+      def hosts_filter
+        input[:hosts_filter]
       end
     end
   end

--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -33,8 +33,8 @@ module ForemanInventoryUpload
         end
 
         Tempfile.create([organization.name, '.pem']) do |cer_file|
-          cer_file.write(rh_credentials[:cert])
-          cer_file.write(rh_credentials[:key])
+          cer_file.write(certificate[:cert])
+          cer_file.write(certificate[:key])
           cer_file.flush
           @cer_path = cer_file.path
           super
@@ -59,12 +59,27 @@ module ForemanInventoryUpload
         env_vars
       end
 
-      def rh_credentials
-        @rh_credentials ||= begin
+      def certificate
+        return foreman_certificate if ForemanRhCloud.with_local_advisor_engine?
+
+        manifest_certificate
+      end
+
+      def manifest_certificate
+        @manifest_certificate ||= begin
           candlepin_id_certificate = organization.owner_details['upstreamConsumer']['idCert']
           {
             cert: candlepin_id_certificate['cert'],
             key: candlepin_id_certificate['key'],
+          }
+        end
+      end
+
+      def foreman_certificate
+        @foreman_certificate ||= begin
+          {
+            cert: File.read(Setting[:ssl_certificate]),
+            key: File.read(Setting[:ssl_priv_key]),
           }
         end
       end

--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -60,9 +60,7 @@ module ForemanInventoryUpload
       end
 
       def certificate
-        return foreman_certificate if ForemanRhCloud.with_local_advisor_engine?
-
-        manifest_certificate
+        ForemanRhCloud.with_local_advisor_engine? ? foreman_certificate : manifest_certificate
       end
 
       def manifest_certificate

--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -76,12 +76,10 @@ module ForemanInventoryUpload
       end
 
       def foreman_certificate
-        @foreman_certificate ||= begin
-          {
-            cert: File.read(Setting[:ssl_certificate]),
-            key: File.read(Setting[:ssl_priv_key]),
-          }
-        end
+        @foreman_certificate ||= {
+          cert: File.read(Setting[:ssl_certificate]),
+          key: File.read(Setting[:ssl_priv_key]),
+        }
       end
 
       def filename

--- a/lib/foreman_inventory_upload/generators/archived_report.rb
+++ b/lib/foreman_inventory_upload/generators/archived_report.rb
@@ -6,10 +6,10 @@ module ForemanInventoryUpload
         @logger = logger
       end
 
-      def render(organization:)
+      def render(organization:, filter: nil)
         Dir.mktmpdir do |tmpdir|
           @logger.info "Started generating hosts report in #{tmpdir}"
-          host_batches = ForemanInventoryUpload::Generators::Queries.for_org(organization)
+          host_batches = ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: filter || {})
           File.open(File.join(tmpdir, 'metadata.json'), 'w') do |metadata_out|
             metadata_generator = ForemanInventoryUpload::Generators::Metadata.new(metadata_out)
             metadata_generator.render do |inner_generator|

--- a/lib/foreman_inventory_upload/generators/archived_report.rb
+++ b/lib/foreman_inventory_upload/generators/archived_report.rb
@@ -9,7 +9,7 @@ module ForemanInventoryUpload
       def render(organization:, filter: nil)
         Dir.mktmpdir do |tmpdir|
           @logger.info "Started generating hosts report in #{tmpdir}"
-          host_batches = ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: filter || {})
+          host_batches = ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: filter || '')
           File.open(File.join(tmpdir, 'metadata.json'), 'w') do |metadata_out|
             metadata_generator = ForemanInventoryUpload::Generators::Metadata.new(metadata_out)
             metadata_generator.render do |inner_generator|

--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -60,8 +60,8 @@ module ForemanInventoryUpload
           )
       end
 
-      def self.for_org(organization_id, use_batches: true)
-        base_query = for_slice(Host.unscoped.where(organization_id: organization_id))
+      def self.for_org(organization_id, use_batches: true, hosts_query: {})
+        base_query = for_slice(Host.unscoped.where(organization_id: organization_id).where(hosts_query))
         use_batches ? base_query.in_batches(of: ForemanInventoryUpload.slice_size) : base_query
       end
     end

--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -60,8 +60,8 @@ module ForemanInventoryUpload
           )
       end
 
-      def self.for_org(organization_id, use_batches: true, hosts_query: {})
-        base_query = for_slice(Host.unscoped.where(organization_id: organization_id).where(hosts_query))
+      def self.for_org(organization_id, use_batches: true, hosts_query: '')
+        base_query = for_slice(Host.unscoped.where(organization_id: organization_id).search_for(hosts_query))
         use_batches ? base_query.in_batches(of: ForemanInventoryUpload.slice_size) : base_query
       end
     end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -114,8 +114,7 @@ module ForemanRhCloud
               caption: N_('Inventory Upload'),
               url: '/foreman_rh_cloud/inventory_upload',
               url_hash: { controller: :react, action: :index },
-              parent: :insights_menu,
-              if: -> { !ForemanRhCloud.with_local_advisor_engine? }
+              parent: :insights_menu
             menu :top_menu, :insights_hits, caption: N_('Recommendations'), url: '/foreman_rh_cloud/insights_cloud', url_hash: { controller: :react, action: :index }, parent: :insights_menu
             menu :top_menu,
               :insights_vulnerability,
@@ -165,6 +164,8 @@ module ForemanRhCloud
         ::Katello::UINotifications::Subscriptions::ManifestImportSuccess.include ForemanInventoryUpload::Notifications::ManifestImportSuccessNotificationOverride if defined?(Katello)
 
         ::Host::Managed.include RhCloudHost
+
+        ::Katello::Api::Rhsm::CandlepinDynflowProxyController.include InsightsCloud::PackageProfileUploadExtensions
       end
     end
 

--- a/lib/inventory_sync/async/inventory_hosts_sync.rb
+++ b/lib/inventory_sync/async/inventory_hosts_sync.rb
@@ -8,6 +8,8 @@ module InventorySync
       set_callback :step, :around, :create_missing_hosts
 
       def plan(organizations)
+        # Do not run for local advisor, since we use sub-man id to identify hosts.
+        return if ForemanRhCloud.with_local_advisor_engine?
         # by default the tasks will be executed concurrently
         super(organizations)
         plan_self_host_sync

--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -26,6 +26,7 @@ namespace :rh_cloud_inventory do
     task generate: :environment do
       organizations = [ENV['organization_id']]
       base_folder = ENV['target'] || Dir.pwd
+      filter = ENV['hosts_filter']
 
       unless File.writable?(base_folder)
         puts "#{base_folder} is not writable by the current process"
@@ -40,9 +41,9 @@ namespace :rh_cloud_inventory do
 
       User.as_anonymous_admin do
         organizations.each do |organization|
-          target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization))
+          target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization, filter))
           archived_report_generator = ForemanInventoryUpload::Generators::ArchivedReport.new(target, Logger.new(STDOUT))
-          archived_report_generator.render(organization: organization)
+          archived_report_generator.render(organization: organization, filter: filter)
           puts "Successfully generated #{target} for organization id #{organization}"
         end
       end

--- a/test/unit/archived_report_generator_test.rb
+++ b/test/unit/archived_report_generator_test.rb
@@ -50,7 +50,7 @@ class ArchivedReportGeneratorTest < ActiveSupport::TestCase
     batches = Host.where(id: @host.id).in_batches
     test_org = FactoryBot.create(:organization)
 
-    ForemanInventoryUpload::Generators::Queries.expects(:for_org).with(test_org.id, hosts_query: {}).returns(batches)
+    ForemanInventoryUpload::Generators::Queries.expects(:for_org).with(test_org.id, hosts_query: '').returns(batches)
     ForemanInventoryUpload::Generators::Slice.any_instance.stubs(:golden_ticket?).returns(false)
     Dir.mktmpdir do |tmpdir|
       target = File.join(tmpdir, 'test.tar.gz')

--- a/test/unit/archived_report_generator_test.rb
+++ b/test/unit/archived_report_generator_test.rb
@@ -50,7 +50,7 @@ class ArchivedReportGeneratorTest < ActiveSupport::TestCase
     batches = Host.where(id: @host.id).in_batches
     test_org = FactoryBot.create(:organization)
 
-    ForemanInventoryUpload::Generators::Queries.expects(:for_org).with(test_org.id).returns(batches)
+    ForemanInventoryUpload::Generators::Queries.expects(:for_org).with(test_org.id, hosts_query: {}).returns(batches)
     ForemanInventoryUpload::Generators::Slice.any_instance.stubs(:golden_ticket?).returns(false)
     Dir.mktmpdir do |tmpdir|
       target = File.join(tmpdir, 'test.tar.gz')


### PR DESCRIPTION
First we need to make sure the upload task knows to work with arbitrary filter, then we can add the listener and finally we need to make sure the upload task (and all other tasks while we are at it) are using the Foreman certificate instead of the manifest in IoP mode.

## Summary by Sourcery

Implement host-specific report filtering and upload triggers while unifying SSL certificate usage in IoP mode

New Features:
- Allow GenerateReportJob and upload tasks to accept a hosts_filter parameter for arbitrary host selection
- Add an after_action hook on package profile uploads to generate and queue per-host reports in local advisor mode

Enhancements:
- Refactor certificate handling to use Foreman’s SSL cert and key instead of manifest credentials when operating in IoP mode
- Embed hosts_filter identifiers in archive filenames and query logic for report generation

Tests:
- Update archived_report_generator_test to expect the hosts_query parameter

Chores:
- Skip InventoryHostsSync execution for local advisor engine
- Include PackageProfileUploadExtensions in the Candlepin Dynflow proxy controller and adjust engine menu setup