### PR TITLE
Add deepwiki to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Ruby tests](https://github.com/theforeman/foreman_rh_cloud/actions/workflows/ruby_tests.yml/badge.svg)](https://github.com/theforeman/foreman_rh_cloud/actions/workflows/ruby_tests.yml)
 [![JS](https://github.com/theforeman/foreman_rh_cloud/actions/workflows/js_tests.yml/badge.svg)](https://github.com/theforeman/foreman_rh_cloud/actions/workflows/js_tests.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/theforeman/foreman_rh_cloud)
 
 # ForemanRhCloud
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,13 @@
 
 # ForemanRhCloud
 
-*Introduction here*
-
 ## Installation
 
 See [How_to_Install_a_Plugin](http://projects.theforeman.org/projects/foreman/wiki/How_to_Install_a_Plugin)
 for how to install Foreman plugins
 
-## Usage
-
-*Usage here*
+## Project overview
+See our [wiki](https://deepwiki.com/theforeman/foreman_rh_cloud)
 
 ### In Satellite
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
JPL showed off deepwiki which makes a wiki about the repo and you can search and ask questions, it is located here:

https://deepwiki.com/theforeman/foreman_rh_cloud

Adding the badge to the README and the link to the README itself

## Summary by Sourcery

Documentation:
- Add DeepWiki badge and link to the README