### PR TITLE
Add ability to forward UI requests from the client

### DIFF
--- a/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
@@ -1,0 +1,33 @@
+module InsightsCloud
+  module PackageProfileUploadExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      # This method explicitly listens on Katello actions
+      # rubocop:disable Rails/LexicallyScopedActionFilter
+      after_action :generate_host_report, only: [:upload_package_profile, :upload_profiles]
+      # rubocop:enable Rails/LexicallyScopedActionFilter
+    end
+
+    def generate_host_report
+      return unless ForemanRhCloud.with_local_advisor_engine?
+
+      logger.debug("Generating host-specific report for host #{@host.name}")
+
+      ForemanTasks.async_task(
+        ForemanInventoryUpload::Async::GenerateReportJob,
+        ForemanInventoryUpload.generated_reports_folder,
+        @host.organization_id,
+        false,
+        "id=#{@host.id}"
+      )
+
+      # in IoP case, the hosts are identified by the sub-man ID, and we can assume they already
+      # exist in the local inventory. This will also handle facet creation for new hosts.
+      return if @host.insights
+
+      insights_facet = @host.build_insights(uuid: @host.subscription_facet.uuid)
+      insights_facet.save
+    end
+  end
+end

--- a/app/controllers/insights_cloud/ui_requests_controller.rb
+++ b/app/controllers/insights_cloud/ui_requests_controller.rb
@@ -1,0 +1,96 @@
+module InsightsCloud
+  class UIRequestsController < ::ApplicationController
+    layout false
+
+    before_action :ensure_org, :ensure_loc, :only => [:forward_request]
+
+    # The method that "proxies" requests over to Cloud
+    def forward_request
+      begin
+        @cloud_response = ::ForemanRhCloud::UIRequestForwarder.new.forward_request(
+          request,
+          params.require(:path),
+          controller_name,
+          User.current,
+          @organization,
+          @location
+        )
+      rescue RestClient::Exceptions::Timeout => e
+        response_obj = e.response.presence || e.exception
+        return render json: { message: response_obj.to_s, error: response_obj.to_s }, status: :gateway_timeout
+      rescue RestClient::Unauthorized => e
+        logger.warn("Forwarding request auth error: #{e}")
+        message = 'Authentication to the Insights Service failed.'
+        return render json: { message: message, error: message }, status: :unauthorized
+      rescue RestClient::NotModified => e
+        logger.info("Forwarding request not modified: #{e}")
+        message = 'Cloud request not modified'
+        return render json: { message: message, error: message }, status: :not_modified
+      rescue RestClient::ExceptionWithResponse => e
+        response_obj = e.response.presence || e.exception
+        code = response_obj.try(:code) || response_obj.try(:http_code) || 500
+        message = 'Cloud request failed'
+
+        return render json: {
+          :message => message,
+          :error => response_obj.to_s,
+          :headers => {},
+          :response => response_obj,
+        }, status: code
+      rescue StandardError => e
+        # Catch any other exceptions here, such as Errno::ECONNREFUSED
+        logger.warn("Cloud request failed with exception: #{e}")
+        return render json: { error: e.to_s }, status: :bad_gateway
+      end
+
+      # Append redhat-specific headers
+      @cloud_response.headers.each do |key, _value|
+        assign_header(response, @cloud_response, key, false) if key.to_s.start_with?('x_rh_')
+      end
+
+      # Append general headers
+      assign_header(response, @cloud_response, :x_resource_count, true)
+      headers[Rack::ETAG] = @cloud_response.headers[:etag]
+
+      if @cloud_response.headers[:content_disposition]
+        # If there is a Content-Disposition header, it means we are forwarding binary data, send the raw data with proper
+        # content type
+        send_data @cloud_response, disposition: @cloud_response.headers[:content_disposition], type: @cloud_response.headers[:content_type]
+      elsif @cloud_response.headers[:content_type] =~ /zip/
+        # If there is no Content-Disposition, but the content type is binary according to Content-Type, send the raw data
+        # with proper content type
+        send_data @cloud_response, type: @cloud_response.headers[:content_type]
+      else
+        render json: @cloud_response, status: @cloud_response.code
+      end
+    end
+
+    def assign_header(res, cloud_res, header, transform)
+      header_content = cloud_res.headers[header]
+      return unless header_content
+      new_header = transform ? header.to_s.tr('_', '-') : header.to_s
+      res.headers[new_header] = header_content
+    end
+
+    private
+
+    def ensure_org
+      @organization = Organization.current
+      return render_message 'Organization not found or invalid', :status => 400 unless @organization
+    end
+
+    def ensure_loc
+      @location = Location.current
+      return render_message 'Location not found or invalid', :status => 400 unless @location
+    end
+
+    def base_url
+      InsightsCloud.ui_base_url
+    end
+
+    def render_message(msg, render_options = {})
+      render_options[:json] = { :message => msg }
+      render render_options
+    end
+  end
+end

--- a/app/services/foreman_rh_cloud/gateway_request.rb
+++ b/app/services/foreman_rh_cloud/gateway_request.rb
@@ -1,26 +1,23 @@
 module ForemanRhCloud
-  module CertAuth
+  module GatewayRequest
     extend ActiveSupport::Concern
 
     include CloudRequest
-    include InsightsCloud::CandlepinCache
-
-    def cert_auth_available?(organization)
-      !!candlepin_id_cert(organization)
-    end
 
     def execute_cloud_request(params)
-      certs = ForemanRhCloud.with_local_advisor_engine? ? foreman_certificate : candlepin_id_cert(params.delete(:organization))
+      certs = params.delete(:certs) || foreman_certificates
       final_params = {
         ssl_client_cert: OpenSSL::X509::Certificate.new(certs[:cert]),
         ssl_client_key: OpenSSL::PKey.read(certs[:key]),
+        ssl_ca_file: Setting[:ssl_ca_file],
+        verify_ssl: OpenSSL::SSL::VERIFY_PEER,
       }.deep_merge(params)
 
       super(final_params)
     end
 
-    def foreman_certificate
-      @foreman_certificate ||= {
+    def foreman_certificates
+      {
         cert: File.read(Setting[:ssl_certificate]),
         key: File.read(Setting[:ssl_priv_key]),
       }

--- a/app/services/foreman_rh_cloud/tags_auth.rb
+++ b/app/services/foreman_rh_cloud/tags_auth.rb
@@ -1,0 +1,53 @@
+module ForemanRhCloud
+  class TagsAuth
+    include GatewayRequest
+
+    TAG_NAMESPACE = 'sat_iam'.freeze
+    TAG_SHORT_NAME = 'user'.freeze
+    TAG_NAME = "#{TAG_NAMESPACE}/#{TAG_SHORT_NAME}".freeze
+
+    def self.auth_tag_for(user)
+      new(user, nil).auth_tag
+    end
+
+    attr_reader :logger
+
+    def initialize(user, logger)
+      @user = user
+      @logger = logger
+    end
+
+    def update_tag
+      logger.debug("Updating tags for user: #{@user}")
+
+      params = {
+        method: :post,
+        url: "#{InsightsCloud.gateway_url}/tags",
+        headers: {
+          content_type: :json,
+        },
+        payload: tags_query_payload.to_json,
+      }
+      execute_cloud_request(params)
+    end
+
+    def allowed_hosts
+      Host.authorized_as(@user, nil, nil).joins(:subscription_facet).pluck('katello_subscription_facets.uuid')
+    end
+
+    def tags_query_payload
+      {
+        tags: [{ "namespace": TAG_NAMESPACE, "key": TAG_SHORT_NAME, "value": tag_value }],
+        host_id_list: allowed_hosts,
+      }
+    end
+
+    def tag_value
+      @user.login
+    end
+
+    def auth_tag
+      "#{TAG_NAME}=#{tag_value}"
+    end
+  end
+end

--- a/app/services/foreman_rh_cloud/ui_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/ui_request_forwarder.rb
@@ -1,0 +1,106 @@
+require 'rest-client'
+
+module ForemanRhCloud
+  class UIRequestForwarder
+    include ForemanRhCloud::GatewayRequest
+
+    def forward_request(original_request, path, controller_name, user, organization, location)
+      TagsAuth.new(user, logger).update_tag if scope_request?(original_request)
+
+      forward_params = prepare_forward_params(original_request, user: user, organization: organization, location: location).to_a
+      logger.debug("Request parameters for UI request: #{forward_params}")
+
+      forward_payload = prepare_forward_payload(original_request, controller_name)
+
+      logger.debug("User agent for UI is: #{http_user_agent(original_request)}")
+
+      request_opts = prepare_request_opts(original_request, path, forward_payload, forward_params)
+
+      logger.debug("Sending request to: #{request_opts[:url]}")
+
+      execute_cloud_request(request_opts)
+    end
+
+    def prepare_tags(user, organization, location)
+      [
+        CGI.escape(TagsAuth.auth_tag_for(user)),
+        CGI.escape("satellite/organization=#{organization}"),
+        CGI.escape("satellite/location=#{location}"),
+      ].map { |tag_value| [:tag, tag_value] }
+    end
+
+    def prepare_request_opts(original_request, path, forward_payload, forward_params)
+      base_params = {
+        method: original_request.method,
+        payload: forward_payload,
+        headers: original_headers(original_request).merge(
+          {
+            params: RestClient::ParamsArray.new(forward_params),
+            user_agent: http_user_agent(original_request),
+            content_type: original_request.media_type.presence || original_request.format.to_s,
+          }
+        ),
+      }
+      params = path_params(path)
+
+      base_params.merge(params)
+    end
+
+    def prepare_forward_payload(original_request, controller_name)
+      forward_payload = original_request.request_parameters[controller_name]
+
+      forward_payload = original_request.raw_post.clone if (original_request.post? || original_request.patch?) && original_request.raw_post
+      forward_payload = original_request.body.read if original_request.put?
+
+      forward_payload = original_request.params.slice(:file, :metadata) if original_request.params[:file]
+
+      # fix rails behaviour for http PATCH:
+      forward_payload = forward_payload.to_json if original_request.format.json? && original_request.patch? && forward_payload && !forward_payload.is_a?(String)
+      forward_payload
+    end
+
+    def prepare_forward_params(original_request, user:, organization:, location:)
+      forward_params = original_request.query_parameters.to_a
+
+      forward_params += prepare_tags(user, organization, location) if scope_request?(original_request)
+
+      forward_params
+    end
+
+    def path_params(path)
+      {
+        url: "#{InsightsCloud.ui_base_url}/#{path}",
+      }
+    end
+
+    def original_headers(original_request)
+      headers = {
+        if_none_match: original_request.if_none_match,
+        if_modified_since: original_request.if_modified_since,
+      }.compact
+
+      logger.debug("Sending headers: #{headers}")
+      headers
+    end
+
+    def scope_request?(original_request)
+      original_request.get?
+    end
+
+    def core_app_name
+      BranchInfo.new.core_app_name
+    end
+
+    def core_app_version
+      BranchInfo.new.core_app_version
+    end
+
+    def http_user_agent(original_request)
+      "#{core_app_name}/#{core_app_version};#{ForemanRhCloud::Engine.engine_name}/#{ForemanRhCloud::VERSION};#{original_request.env['HTTP_USER_AGENT']}"
+    end
+
+    def logger
+      Foreman::Logging.logger('app')
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
     match 'hits/:host_id', to: 'hits#show', via: :get
 
     post ':organization_id/parameter', to: 'settings#set_org_parameter', constraints: { organization_id: %r{[^\/]+} }
+
+    match '/*path', constraints: { path: %r{api/[^\?]+} }, to: 'ui_requests#forward_request', via: :all
   end
 
   namespace :foreman_rh_cloud do

--- a/db/seeds.d/200_features.rb
+++ b/db/seeds.d/200_features.rb
@@ -1,0 +1,4 @@
+ForemanRhCloud.on_prem_smart_proxy_features.each do |feature_name|
+  f = Feature.where(:name => feature_name).first_or_create
+  raise "Unable to create proxy feature: #{SeedHelper.format_errors f}" if f.nil? || f.errors.any?
+end

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -52,8 +52,8 @@ module ForemanInventoryUpload
     'uploader.sh'
   end
 
-  def self.facts_archive_name(organization)
-    "report_for_#{organization}.tar.xz"
+  def self.facts_archive_name(organization, filter = nil)
+    "report_for_#{organization}#{filter.empty? ? nil : "[#{filter.to_s.parameterize}]"}.tar.xz"
   end
 
   def self.upload_url

--- a/lib/foreman_inventory_upload/async/generate_report_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_report_job.rb
@@ -5,18 +5,19 @@ module ForemanInventoryUpload
         "report_for_#{label}"
       end
 
-      def plan(base_folder, organization_id, disconnected)
+      def plan(base_folder, organization_id, disconnected, hosts_filter = nil)
         sequence do
           super(
-            GenerateReportJob.output_label(organization_id),
+            GenerateReportJob.output_label("#{organization_id}#{hosts_filter.empty? ? nil : "[#{hosts_filter.to_s.parameterize}]"}"),
             organization_id: organization_id,
-            base_folder: base_folder
+            base_folder: base_folder,
+            hosts_filter: hosts_filter
           )
 
           plan_action(
             QueueForUploadJob,
             base_folder,
-            ForemanInventoryUpload.facts_archive_name(organization_id),
+            ForemanInventoryUpload.facts_archive_name(organization_id, hosts_filter),
             organization_id,
             disconnected
           )
@@ -34,7 +35,8 @@ module ForemanInventoryUpload
       def env
         super.merge(
           'target' => base_folder,
-          'organization_id' => organization_id
+          'organization_id' => organization_id,
+          'hosts_filter' => hosts_filter
         )
       end
 
@@ -44,6 +46,10 @@ module ForemanInventoryUpload
 
       def organization_id
         input[:organization_id]
+      end
+
+      def hosts_filter
+        input[:hosts_filter]
       end
     end
   end

--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -33,8 +33,8 @@ module ForemanInventoryUpload
         end
 
         Tempfile.create([organization.name, '.pem']) do |cer_file|
-          cer_file.write(rh_credentials[:cert])
-          cer_file.write(rh_credentials[:key])
+          cer_file.write(certificate[:cert])
+          cer_file.write(certificate[:key])
           cer_file.flush
           @cer_path = cer_file.path
           super
@@ -59,14 +59,27 @@ module ForemanInventoryUpload
         env_vars
       end
 
-      def rh_credentials
-        @rh_credentials ||= begin
+      def certificate
+        return foreman_certificate if ForemanRhCloud.with_local_advisor_engine?
+
+        manifest_certificate
+      end
+
+      def manifest_certificate
+        @manifest_certificate ||= begin
           candlepin_id_certificate = organization.owner_details['upstreamConsumer']['idCert']
           {
             cert: candlepin_id_certificate['cert'],
             key: candlepin_id_certificate['key'],
           }
         end
+      end
+
+      def foreman_certificate
+        @foreman_certificate ||= {
+          cert: File.read(Setting[:ssl_certificate]),
+          key: File.read(Setting[:ssl_priv_key]),
+        }
       end
 
       def filename

--- a/lib/foreman_inventory_upload/generators/archived_report.rb
+++ b/lib/foreman_inventory_upload/generators/archived_report.rb
@@ -6,10 +6,10 @@ module ForemanInventoryUpload
         @logger = logger
       end
 
-      def render(organization:)
+      def render(organization:, filter: nil)
         Dir.mktmpdir do |tmpdir|
           @logger.info "Started generating hosts report in #{tmpdir}"
-          host_batches = ForemanInventoryUpload::Generators::Queries.for_org(organization)
+          host_batches = ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: filter || '')
           File.open(File.join(tmpdir, 'metadata.json'), 'w') do |metadata_out|
             metadata_generator = ForemanInventoryUpload::Generators::Metadata.new(metadata_out)
             metadata_generator.render do |inner_generator|

--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -58,8 +58,8 @@ module ForemanInventoryUpload
           )
       end
 
-      def self.for_org(organization_id, use_batches: true)
-        base_query = for_slice(Host.unscoped.where(organization_id: organization_id))
+      def self.for_org(organization_id, use_batches: true, hosts_query: '')
+        base_query = for_slice(Host.unscoped.where(organization_id: organization_id).search_for(hosts_query))
         use_batches ? base_query.in_batches(of: ForemanInventoryUpload.slice_size) : base_query
       end
     end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -84,6 +84,7 @@ module ForemanRhCloud
                 '/foreman_rh_cloud/insights_cloud': [:index], # for bookmarks and later for showing the page
                 'insights_cloud/hits': [:index, :show, :auto_complete_search, :resolutions],
                 'insights_cloud/settings': [:index, :show],
+                'insights_cloud/ui_requests': [:forward_request],
                 'react': [:index],
               },
               :resource_type => ::InsightsHit.name
@@ -114,8 +115,7 @@ module ForemanRhCloud
               caption: N_('Inventory Upload'),
               url: '/foreman_rh_cloud/inventory_upload',
               url_hash: { controller: :react, action: :index },
-              parent: :insights_menu,
-              if: -> { !ForemanRhCloud.with_local_advisor_engine? }
+              parent: :insights_menu
             menu :top_menu, :insights_hits, caption: N_('Recommendations'), url: '/foreman_rh_cloud/insights_cloud', url_hash: { controller: :react, action: :index }, parent: :insights_menu
             menu :top_menu,
               :insights_vulnerability,
@@ -165,6 +165,8 @@ module ForemanRhCloud
         ::Katello::UINotifications::Subscriptions::ManifestImportSuccess.include ForemanInventoryUpload::Notifications::ManifestImportSuccessNotificationOverride if defined?(Katello)
 
         ::Host::Managed.include RhCloudHost
+
+        ::Katello::Api::Rhsm::CandlepinDynflowProxyController.include InsightsCloud::PackageProfileUploadExtensions
       end
     end
 
@@ -210,6 +212,30 @@ module ForemanRhCloud
       )
     end
 
+    # Ideally this code belongs to an initializer. The problem is that Katello controllers are not initialized completely until after the end of the to_prepare blocks
+    # This means I can patch the controller only in the after_initialize block that is promised to run after the to_prepare
+    # initializer 'foreman_rh_cloud.allow_smart_proxy_actions', :before => :finisher_hook, :after => 'katello.register_plugin'  do |_app|
+    # end
+    config.after_initialize do
+      # skip overrides in migrations, since the controller initialization depends on tables existense
+      if defined?(Katello) && !Foreman.in_setup_db_rake?
+        Katello::Api::V2::OrganizationsController.include Foreman::Controller::SmartProxyAuth
+        # patch the callbacks order for :download_debug_certificate, since local_find_taxonomy has to run after the user is already initialized
+        Katello::Api::V2::OrganizationsController.skip_before_action(:local_find_taxonomy, only: :download_debug_certificate)
+        Katello::Api::V2::OrganizationsController.add_smart_proxy_filters(
+          [:index, :download_debug_certificate],
+          features: ForemanRhCloud.on_prem_smart_proxy_features
+        )
+        Katello::Api::V2::OrganizationsController.before_action(:local_find_taxonomy, only: :download_debug_certificate)
+
+        Katello::Api::V2::RepositoriesController.include Foreman::Controller::SmartProxyAuth
+        Katello::Api::V2::RepositoriesController.add_smart_proxy_filters(
+          :index,
+          features: ForemanRhCloud.on_prem_smart_proxy_features
+        )
+      end
+    end
+
     rake_tasks do
       Rake::Task['db:seed'].enhance do
         ForemanRhCloud::Engine.load_seed
@@ -230,5 +256,9 @@ module ForemanRhCloud
     else
       ::SETTINGS[:ssl_ca_file]
     end
+  end
+
+  def self.on_prem_smart_proxy_features
+    ['insights']
   end
 end

--- a/lib/insights_cloud.rb
+++ b/lib/insights_cloud.rb
@@ -21,6 +21,14 @@ module InsightsCloud
     ForemanRhCloud.cert_base_url + '/api/remediations/v1/playbook'
   end
 
+  def self.gateway_url
+    ForemanRhCloud.cert_base_url
+  end
+
+  def self.ui_base_url
+    InsightsCloud.gateway_url
+  end
+
   def self.remediation_rule_id(rule_id)
     "advisor:#{rule_id}"
   end

--- a/lib/inventory_sync/async/inventory_hosts_sync.rb
+++ b/lib/inventory_sync/async/inventory_hosts_sync.rb
@@ -8,6 +8,8 @@ module InventorySync
       set_callback :step, :around, :create_missing_hosts
 
       def plan(organizations)
+        # Do not run for local advisor, since we use sub-man id to identify hosts.
+        return if ForemanRhCloud.with_local_advisor_engine?
         # by default the tasks will be executed concurrently
         super(organizations)
         plan_self_host_sync

--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -26,6 +26,7 @@ namespace :rh_cloud_inventory do
     task generate: :environment do
       organizations = [ENV['organization_id']]
       base_folder = ENV['target'] || Dir.pwd
+      filter = ENV['hosts_filter']
 
       unless File.writable?(base_folder)
         puts "#{base_folder} is not writable by the current process"
@@ -40,9 +41,9 @@ namespace :rh_cloud_inventory do
 
       User.as_anonymous_admin do
         organizations.each do |organization|
-          target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization))
+          target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization, filter))
           archived_report_generator = ForemanInventoryUpload::Generators::ArchivedReport.new(target, Logger.new(STDOUT))
-          archived_report_generator.render(organization: organization)
+          archived_report_generator.render(organization: organization, filter: filter)
           puts "Successfully generated #{target} for organization id #{organization}"
         end
       end

--- a/test/controllers/insights_cloud/api/cloud_request_controller_test.rb
+++ b/test/controllers/insights_cloud/api/cloud_request_controller_test.rb
@@ -50,9 +50,11 @@ module InsightsCloud::Api
 
       mock_composer = mock('composer')
       ::JobInvocationComposer.expects(:for_feature).with do |feature, host_ids, params|
+        actual_ids = host_ids.sort
+        expected_ids = [host1.id, host2.id].sort
         feature == :rh_cloud_connector_run_playbook &&
-        host_ids.first == host1.id &&
-        host_ids.last == host2.id
+        actual_ids.first == expected_ids.first &&
+        actual_ids.last == expected_ids.last
       end.returns(mock_composer)
       mock_composer.expects(:trigger!)
       mock_composer.expects(:job_invocation)

--- a/test/controllers/insights_cloud/ui_requests_controller_test.rb
+++ b/test/controllers/insights_cloud/ui_requests_controller_test.rb
@@ -1,0 +1,152 @@
+require 'test_plugin_helper'
+require 'rest-client'
+
+module InsightsCloud
+  class UIRequestsControllerTest < ActionController::TestCase
+    include KatelloCVEHelper
+
+    setup do
+      FactoryBot.create(:common_parameter, name: InsightsCloud.enable_client_param, key_type: 'boolean', value: true)
+    end
+
+    context '#forward_request' do
+      include MockCerts
+
+      setup do
+        @body = 'Cloud response body'
+        @http_req = RestClient::Request.new(:method => 'GET', :url => 'http://test.theforeman.org')
+
+        @org = FactoryBot.create(:organization)
+        @loc = FactoryBot.create(:location)
+        host = FactoryBot.create(:host, :with_subscription, :organization => @org)
+        User.current = ::Katello::CpConsumerUser.new(:uuid => host.subscription_facet.uuid, :login => host.subscription_facet.uuid)
+        InsightsCloud::UIRequestsController.any_instance.stubs(:upstream_owner).returns({ 'uuid' => 'abcdefg' })
+        ForemanRhCloud::TagsAuth.any_instance.stubs(:execute_cloud_request)
+
+        setup_certs_expectation do
+          ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:foreman_certificates)
+        end
+      end
+
+      test "should respond with response from cloud" do
+        net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
+        net_http_resp.add_field 'Set-Cookie', 'Monster'
+        res = RestClient::Response.create(@body, net_http_resp, @http_req)
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:forward_request).returns(res)
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal @body, @response.body
+      end
+
+      test "should handle timeout from cloud" do
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.
+          stubs(:forward_request).
+          raises(RestClient::Exceptions::OpenTimeout.new("Timed out connecting to server"))
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        request_response = JSON.parse(@response.body)
+        # I can't get @response.status to take a nil value so I'm not asserting for that
+
+        assert_equal 'Timed out connecting to server', request_response['error']
+      end
+
+      test "should add headers to response from cloud" do
+        x_resource_count = '101'
+        x_rh_insights_request_id = '202'
+        net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
+        net_http_resp['x_resource_count'] = x_resource_count
+        net_http_resp['x_rh_insights_request_id'] = x_rh_insights_request_id
+        res = RestClient::Response.create(@body, net_http_resp, @http_req)
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:forward_request).returns(res)
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal x_resource_count, @response.headers['x-resource-count']
+        assert_equal x_rh_insights_request_id, @response.headers['x_rh_insights_request_id']
+      end
+
+      test "should set etag header to response from cloud" do
+        etag = '12345'
+        req = RestClient::Request.new(:method => 'GET', :url => 'http://test.theforeman.org', :headers => { "If-None-Match": etag })
+        net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
+        net_http_resp[Rack::ETAG] = etag
+        res = RestClient::Response.create(@body, net_http_resp, req)
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:forward_request).returns(res)
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal etag, @response.headers[Rack::ETAG]
+      end
+
+      test "should set content type header to response from cloud" do
+        req = RestClient::Request.new(:method => 'GET', :url => 'http://test.theforeman.org')
+        net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
+        net_http_resp[:content_type] = 'application/zip'
+        res = RestClient::Response.create(@body, net_http_resp, req)
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:forward_request).returns(res)
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal net_http_resp[:content_type], @response.headers['Content-Type']
+      end
+
+      test "should handle StandardError" do
+        error_message = "Connection refused"
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(Errno::ECONNREFUSED.new)
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal 502, @response.status
+        body = JSON.parse(@response.body)
+        assert_equal error_message, body['error']
+      end
+
+      test "should handle 304 cloud" do
+        net_http_resp = Net::HTTPResponse.new(1.0, 304, "Not Modified")
+        res = RestClient::Response.create(@body, net_http_resp, @http_req)
+
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::NotModified.new(res))
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal 304, @response.status
+        assert_equal 'Cloud request not modified', JSON.parse(@response.body)['message']
+      end
+
+      test "should handle RestClient::Exceptions::Timeout" do
+        timeout_message = "execution expired"
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::Exceptions::Timeout.new(timeout_message))
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal 504, @response.status
+        body = JSON.parse(@response.body)
+        assert_equal timeout_message, body['message']
+        assert_equal timeout_message, body['error']
+      end
+
+      test "should handle failed authentication to cloud" do
+        net_http_resp = Net::HTTPResponse.new(1.0, 401, "Unauthorized")
+        res = RestClient::Response.create(@body, net_http_resp, @http_req)
+
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::Unauthorized.new(res))
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal 401, @response.status
+        assert_equal 'Authentication to the Insights Service failed.', JSON.parse(@response.body)['message']
+      end
+
+      test "should forward errors to the client" do
+        net_http_resp = Net::HTTPResponse.new(1.0, 500, "TEST_RESPONSE")
+        res = RestClient::Response.create(@body, net_http_resp, @http_req)
+        ::ForemanRhCloud::UIRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::InternalServerError.new(res))
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal 500, @response.status
+        assert_equal 'Cloud request failed', JSON.parse(@response.body)['message']
+        assert_match(/#{@body}/, JSON.parse(@response.body)['response'])
+      end
+    end
+
+    def set_session
+      set_session_user.merge(
+        organization_id: @org.id,
+        location_id: @loc.id
+      )
+    end
+  end
+end

--- a/test/unit/archived_report_generator_test.rb
+++ b/test/unit/archived_report_generator_test.rb
@@ -50,7 +50,7 @@ class ArchivedReportGeneratorTest < ActiveSupport::TestCase
     batches = Host.where(id: @host.id).in_batches
     test_org = FactoryBot.create(:organization)
 
-    ForemanInventoryUpload::Generators::Queries.expects(:for_org).with(test_org.id).returns(batches)
+    ForemanInventoryUpload::Generators::Queries.expects(:for_org).with(test_org.id, hosts_query: '').returns(batches)
     ForemanInventoryUpload::Generators::Slice.any_instance.stubs(:golden_ticket?).returns(false)
     Dir.mktmpdir do |tmpdir|
       target = File.join(tmpdir, 'test.tar.gz')

--- a/test/unit/rh_cloud_http_proxy_test.rb
+++ b/test/unit/rh_cloud_http_proxy_test.rb
@@ -4,6 +4,7 @@ class RhCloudHttpProxyTest < ActiveSupport::TestCase
   setup do
     @global_content_proxy_mock = 'http://global:content@localhost:80'
     @global_foreman_proxy_mock = 'http://global:foreman@localhost:80'
+    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(false)
   end
 
   test 'selects global content proxy' do
@@ -16,6 +17,13 @@ class RhCloudHttpProxyTest < ActiveSupport::TestCase
     setup_global_foreman_proxy
 
     assert_equal @global_foreman_proxy_mock, ForemanRhCloud.proxy_setting
+  end
+
+  test 'returns empty string in on-prem setup' do
+    ForemanRhCloud.unstub(:with_local_advisor_engine?)
+    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(true)
+
+    assert_empty ForemanRhCloud.proxy_setting
   end
 
   def setup_global_content_proxy

--- a/test/unit/services/foreman_rh_cloud/tags_auth_test.rb
+++ b/test/unit/services/foreman_rh_cloud/tags_auth_test.rb
@@ -1,0 +1,27 @@
+require 'test_plugin_helper'
+require 'json'
+
+class TagsAuthTest < ActiveSupport::TestCase
+  setup do
+    @user = FactoryBot.build(:user)
+    @logger = Logger.new(IO::NULL)
+    @auth = ::ForemanRhCloud::TagsAuth.new(@user, @logger)
+  end
+
+  test 'Generates tags update request' do
+    uuid1 = 'test_uuid1'
+    uuid2 = 'test_uuid2'
+
+    @auth.expects(:allowed_hosts).returns([uuid1, uuid2])
+    @auth.expects(:execute_cloud_request).with do |actual_params|
+      actual = JSON.parse(actual_params[:payload])
+      assert_includes actual['host_id_list'], uuid1
+      assert_includes actual['host_id_list'], uuid2
+      assert_equal ForemanRhCloud::TagsAuth::TAG_SHORT_NAME, actual['tags'].first['key']
+      assert_equal ForemanRhCloud::TagsAuth::TAG_NAMESPACE, actual['tags'].first['namespace']
+      assert_equal @user.login, actual['tags'].first['value']
+    end
+
+    @auth.update_tag
+  end
+end

--- a/test/unit/services/foreman_rh_cloud/ui_request_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/ui_request_forwarder_test.rb
@@ -1,0 +1,155 @@
+require 'test_plugin_helper'
+require 'puma/null_io'
+
+class UIRequestForwarderTest < ActiveSupport::TestCase
+  include MockCerts
+
+  setup do
+    @forwarder = ::ForemanRhCloud::UIRequestForwarder.new
+    @user = FactoryBot.build(:user)
+    @organization = FactoryBot.build(:organization)
+    @location = FactoryBot.build(:location)
+
+    setup_certs_expectation do
+      @forwarder.stubs(:foreman_certificates)
+    end
+
+    ForemanRhCloud.stubs(:cert_base_url).returns('https://cert.cloud.example.com')
+  end
+
+  test 'should scope GET requests with proper tags' do
+    user_agent = { :foo => :bar }
+    params = {}
+
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/foo/bar',
+      'REQUEST_METHOD' => 'GET',
+      'HTTP_USER_AGENT' => user_agent,
+      'rack.input' => ::Puma::NullIO.new,
+      'action_dispatch.request.query_parameters' => params
+    )
+
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
+    @forwarder.expects(:execute_cloud_request).with do |actual_params|
+      actual = actual_params[:headers][:params]
+      assert_equal @user.name, tag_value(actual.find { |param| param[0] == :tag && tag_name(param[1]) =~ /#{ForemanRhCloud::TagsAuth::TAG_NAME}/ }[1])
+      assert_equal @organization.name, tag_value(actual.find { |param| param[0] == :tag && tag_name(param[1]) =~ %r{satellite/organization} }[1])
+      assert_equal @location.name, tag_value(actual.find { |param| param[0] == :tag && tag_name(param[1]) =~ %r{satellite/location} }[1])
+      true
+    end
+
+    @forwarder.forward_request(req, '/api/vulnerability/v1/cves', 'test_controller', @user, @organization, @location)
+
+    # This test asserts the parameters that are sent to the execute_cloud_request method.
+    # This is done by setting the expectation before the actual call.
+  end
+
+  test 'should merge URI params in GET requests' do
+    user_agent = { :foo => :bar }
+    params = { :page => 5, :per_page => 42 }
+
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/foo/bar',
+      'REQUEST_METHOD' => 'GET',
+      'HTTP_USER_AGENT' => user_agent,
+      'rack.input' => ::Puma::NullIO.new,
+      'action_dispatch.request.query_parameters' => params
+    )
+
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
+    @forwarder.expects(:execute_cloud_request).with do |actual_params|
+      actual = actual_params[:headers][:params]
+      assert_equal @user.name, tag_value(actual.find { |param| param[0] == :tag && tag_name(param[1]) =~ /#{ForemanRhCloud::TagsAuth::TAG_NAME}/ }[1])
+      assert_equal @organization.name, tag_value(actual.find { |param| param[0] == :tag && tag_name(param[1]) =~ %r{satellite/organization} }[1])
+      assert_equal @location.name, tag_value(actual.find { |param| param[0] == :tag && tag_name(param[1]) =~ %r{satellite/location} }[1])
+      assert_equal 5, actual.find { |param| param[0] == :page }[1]
+      assert_equal 42, actual.find { |param| param[0] == :per_page }[1]
+      true
+    end
+
+    @forwarder.forward_request(req, '/api/vulnerability/v1/cves', 'test_controller', @user, @organization, @location)
+    # This test asserts the parameters that are sent to the execute_cloud_request method.
+    # This is done by setting the expectation before the actual call.
+  end
+
+  test 'should not scope POST requests' do
+    post_data = 'Random POST data'
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/foo/bar',
+      'REQUEST_METHOD' => 'POST',
+      'rack.input' => ::Puma::NullIO.new,
+      'RAW_POST_DATA' => post_data
+    )
+
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+    @forwarder.expects(:execute_cloud_request).with do |actual_params|
+      actual = actual_params[:headers][:params]
+      assert_equal 0, actual.count
+      true
+    end
+
+    @forwarder.forward_request(req, '/api/vulnerability/v1/cves', 'test_controller', @user, @organization, @location)
+
+    # This test asserts the parameters that are sent to the execute_cloud_request method.
+    # This is done by setting the expectation before the actual call.
+  end
+
+  test 'should not scope PUT requests' do
+    put_data = 'Random PUT data'
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/foo/bar',
+      'REQUEST_METHOD' => 'PUT',
+      'rack.input' => ::Puma::NullIO.new,
+      'RAW_POST_DATA' => put_data
+    )
+
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+    @forwarder.expects(:execute_cloud_request).with do |actual_params|
+      actual = actual_params[:headers][:params]
+      assert_equal 0, actual.count
+      true
+    end
+
+    @forwarder.forward_request(req, '/api/vulnerability/v1/cves', 'test_controller', @user, @organization, @location)
+
+    # This test asserts the parameters that are sent to the execute_cloud_request method.
+    # This is done by setting the expectation before the actual call.
+  end
+
+  test 'should not scope PATCH requests' do
+    post_data = 'Random PATCH data'
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/foo/bar',
+      'REQUEST_METHOD' => 'PATCH',
+      'rack.input' => ::Puma::NullIO.new,
+      'RAW_POST_DATA' => post_data,
+      "action_dispatch.request.path_parameters" => { :format => "json" }
+    )
+
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+    @forwarder.expects(:execute_cloud_request).with do |actual_params|
+      actual = actual_params[:headers][:params]
+      assert_equal 0, actual.count
+      true
+    end
+
+    @forwarder.forward_request(req, '/api/vulnerability/v1/cves', 'test_controller', @user, @organization, @location)
+
+    # This test asserts the parameters that are sent to the execute_cloud_request method.
+    # This is done by setting the expectation before the actual call.
+  end
+
+  def tag_value(param_value)
+    return param_value unless param_value.is_a?(String)
+
+    tag_string = CGI.unescape(param_value)
+    tag_string.split('=')[1]
+  end
+
+  def tag_name(param_value)
+    return param_value unless param_value.is_a?(String)
+
+    tag_string = CGI.unescape(param_value)
+    tag_string.split('=')[0]
+  end
+end

--- a/webpack/InsightsVulnerability/InsightsVulnerability.js
+++ b/webpack/InsightsVulnerability/InsightsVulnerability.js
@@ -2,10 +2,27 @@ import React from 'react';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
 import { translate as __ } from 'foremanReact/common/I18n';
 
+import { Button } from '@patternfly/react-core';
+import { API } from 'foremanReact/redux/API';
+import { foremanUrl } from '../ForemanRhCloudHelpers';
+
 const InsightsVulnerability = () => (
   <PageLayout searchable={false} header={__('Vulnerability')}>
     <div className="insights-vulnerability">
       <p>This page is under development. Please check back soon for updates.</p>
+      <Button
+        variant="secondary"
+        onClick={(e) => {
+          const response = API.get(
+            foremanUrl('/insights_cloud/api/inventory/v1/hosts')
+          );
+          response.then(result => {
+            console.log(result)
+          });
+        }}
+      >
+        {__('Test ui->api request')}
+      </Button>
     </div>
   </PageLayout>
 );


### PR DESCRIPTION
Make rubocop happy

Fix missing permissions

Add tag generation on GET requests

Switch to foreman's cert instead of manifest one

Add forwarder test button

Switch to insights_cloud/api path

Enable hosts filter in report

Observe package upload actions in Katello

Switch to foreman cert when in IoP mode

Make rubocop happy

Fix filtering errors

Patch Katello controllers to enable access by smart proxy

Make the tests more predictable

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Enable forwarding of UI-originated API requests to the Insights cloud, including automated tagging, certificate management, error handling, and support for host filtering and on-prem smart proxy integration.

New Features:
- Introduce UIRequestForwarder service and InsightsCloud::UIRequestsController to proxy client UI calls to the remote Insights API.
- Add TagsAuth service to automatically scope and tag GET requests with user, organization, and location information.
- Register catch-all API route for UI forwarding and add a test button in the InsightsVulnerability React page for manual UI→API testing.
- Support hosts_filter parameter in inventory report generation through GenerateReportJob, rake task, and query layer.

Bug Fixes:
- Patch Katello API controllers to enable SmartProxyAuth filters and fix permission issues in on-prem mode.
- Ensure empty proxy setting and correct certificate selection when running with local advisor engine.
- Fix parameter merging and filtering logic for cloud request scoping.

Enhancements:
- Centralize SSL certificate handling in a new GatewayRequest concern and switch to Foreman certificates in IoP mode.
- Automatically trigger host-specific report generation after package profile upload in local advisor setups.
- Consolidate InsightsCloud URL helpers for gateway and UI base URLs.

Tests:
- Add unit tests for UIRequestForwarder, UIRequestsController, and TagsAuth covering request forwarding, error handling, and header propagation.
- Update existing tests (rh_cloud_http_proxy, archived_report_generator) to handle on-prem mode and hosts_filter behavior.