### PR TITLE
fix(tags): generate the internal org label tag value

### DIFF
--- a/lib/foreman_inventory_upload/generators/tags.rb
+++ b/lib/foreman_inventory_upload/generators/tags.rb
@@ -43,7 +43,7 @@ module ForemanInventoryUpload
       def organizations
         [
           ['organization', @host.organization.name],
-          ['organization_label', @host.organization.title],
+          ['organization_label', @host.organization.label],
         ]
       end
 

--- a/test/unit/tags_generator_test.rb
+++ b/test/unit/tags_generator_test.rb
@@ -61,7 +61,7 @@ class TagsGeneratorTest < ActiveSupport::TestCase
     assert_equal @host.content_views.pluck(:name).max, actual['content_view'].map(&:second).max
     assert_equal Foreman.instance_id, actual['satellite_instance_id'].first.last
     assert_equal @host.organization_id.to_s, actual['organization_id'].first.last
-    assert_equal @host.organization.title, actual['organization_label'].first.last
+    assert_equal @host.organization.label, actual['organization_label'].first.last
   end
 
   test 'filters tags with empty values' do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Fixes the Tags generator to use the internal `label` of an Organization (not `title`).

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Use internal organization label instead of title when generating tags

Bug Fixes:
- Use organization.label for the organization_label tag value instead of organization.title

Tests:
- Update tag generator unit test to expect organization.label instead of title