### PR TITLE
rhel advisor sync and package changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,19 +21,26 @@
   "peerDependencies": {
     "@theforeman/vendor": ">= 15.0.1"
   },
+  "dependencies": {
+    "@scalprum/core": "^0.8.1",
+    "@scalprum/react-core": "^0.9.3",
+    "@unleash/proxy-client-react": "^5.0.0",
+    "react-intl": "^7.1.11",
+    "unleash-proxy-client": "^3.7.6"
+  },
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@theforeman/builder": ">= 15.0.1",
-    "@theforeman/test": ">= 15.0.1",
     "@theforeman/eslint-plugin-foreman": ">= 15.0.1",
+    "@theforeman/test": ">= 15.0.1",
     "babel-eslint": "~10.0.0",
     "eslint": "~6.7.2",
     "eslint-plugin-spellcheck": "~0.0.17",
     "jed": "~1.1.1",
     "prettier": "~1.19.1",
+    "redux-mock-store": "~1.2.2",
     "stylelint": "~9.3.0",
     "stylelint-config-standard": "~18.0.0",
-    "surge": "~0.20.3",
-    "redux-mock-store": "~1.2.2"
+    "surge": "~0.20.3"
   }
 }

--- a/webpack/InsightsCloudSync/InsightsCloudSync.js
+++ b/webpack/InsightsCloudSync/InsightsCloudSync.js
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
+import { TextInput, Button } from '@patternfly/react-core';
+import { ScalprumComponent } from '@scalprum/react-core';
+import {
+  ScalprumContextWrapper,
+  ScalprumContext,
+} from '../common/ScalprumModule/ScalprumContext';
 import InsightsTable from './Components/InsightsTable';
+import { useAdvisorEngineConfig } from '../common/Hooks/ConfigHooks';
 import RemediationModal from './Components/RemediationModal';
 import {
   INSIGHTS_SYNC_PAGE_TITLE,
@@ -54,4 +61,64 @@ InsightsCloudSync.defaultProps = {
   query: '',
 };
 
-export default InsightsCloudSync;
+const LocalAdvisorPlaceholder = props => {
+  const { config, setConfig } = useContext(ScalprumContext);
+  const [scope, setScope] = useState('advisor');
+  const path = `apps/${scope}`;
+  const module = './RulesTableWrapped';
+  const manifestLocation = `/${path}/fed-mods.json`;
+
+  const [value, setValue] = useState(scope);
+
+  useEffect(() => {
+    setConfig({
+      [scope]: {
+        name: scope,
+        manifestLocation,
+        cdnPath: `/${path}/`,
+      },
+    });
+  }, [setConfig, scope, path, manifestLocation]);
+
+  return (
+    <>
+      <span>
+        <TextInput
+          value={value}
+          type="text"
+          onChange={(_event, val) => setValue(val)}
+          aria-label="manifest location"
+        />
+        <Button variant="primary" onClick={() => setScope(value)}>
+          Set scope
+        </Button>
+      </span>
+      <pre style={{ paddingBottom: '2em' }}>{manifestLocation}</pre>
+      {config[scope] && (
+        <ScalprumComponent scope={scope} module={module} {...props} />
+      )}
+    </>
+  );
+};
+
+const LocalAdvisorPlaceholderWrapped = () => (
+  <ScalprumContextWrapper>
+    <LocalAdvisorPlaceholder IopRemediationModal={RemediationModal} />
+  </ScalprumContextWrapper>
+);
+
+const RecommendationsPage = props => {
+  // TODO: remove next line before merging
+  return <LocalAdvisorPlaceholderWrapped />;
+
+  // eslint-disable-next-line no-unreachable
+  const isLocalAdvisorEngine = useAdvisorEngineConfig();
+
+  return isLocalAdvisorEngine ? (
+    <LocalAdvisorPlaceholder />
+  ) : (
+    <InsightsCloudSync {...props} />
+  );
+};
+
+export default RecommendationsPage;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Rhel advisor related changes that were made recently, they should be preserved so we wont loose/discard them
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Replace the default InsightsCloudSync export with a new RecommendationsPage that temporarily renders a local RHEL advisor placeholder and lays groundwork for toggling between local and cloud sync engines.

New Features:
- Introduce LocalAdvisorPlaceholder component to configure and render advisor modules dynamically via ScalprumContext.
- Add RecommendationsPage as the new default export that wraps the advisor UI and will handle engine selection.

Enhancements:
- Integrate ScalprumContextWrapper and dynamic scope setting UI for loading remote modules.
- Include a TODO-guarded branch for future switching between the local advisor engine and the original cloud sync component.

Build:
- Add @scalprum/core, @scalprum/react-core, @unleash/proxy-client-react, unleash-proxy-client, and react-intl to project dependencies.