### PR TITLE
add Forwarded header to cloud requests

### DIFF
--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -17,7 +17,7 @@ module InsightsCloud::Api
     def forward_request
       certs = candlepin_id_cert @organization
       begin
-        @cloud_response = ::ForemanRhCloud::CloudRequestForwarder.new.forward_request(request, controller_name, @branch_id, certs)
+        @cloud_response = ::ForemanRhCloud::CloudRequestForwarder.new.forward_request(request, controller_name, @branch_id, certs, @host)
       rescue RestClient::Exceptions::Timeout => e
         response_obj = e.response.presence || e.exception
         return render json: { message: response_obj.to_s, error: response_obj.to_s }, status: :gateway_timeout


### PR DESCRIPTION
Requests that are generated by a host, as opposed to a user will receive a forwarded header with host uuid.

## Summary by Sourcery

Add support for including a Forwarded HTTP header with the host’s subscription UUID on cloud requests originating from a host.

New Features:
- Include a Forwarded header containing the host subscription facet UUID on forwarded cloud requests.

Enhancements:
- Extend CloudRequestForwarder.forward_request and prepare_request_opts to accept a host parameter and generate the Forwarded header via a new helper.
- Update MachineTelemetriesController to pass the host into the forwarding pipeline.

Tests:
- Adjust unit tests to create and supply a host object when invoking CloudRequestForwarder.