### PR TITLE
Add Recommendations column

### DIFF
--- a/app/views/api/v2/hosts/insights/base.rabl
+++ b/app/views/api/v2/hosts/insights/base.rabl
@@ -3,3 +3,9 @@ attributes :uuid
 node :insights_hit_details do |facet|
   facet&.host&.facts('insights::hit_details')&.values&.first
 end
+node :insights_hits_count do |facet|
+  facet.hits&.count
+end
+node :use_local_advisor_engine do |_facet|
+  ForemanRhCloud.with_local_advisor_engine?
+end

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
+
+const RecommendationsCell = hostDetails => {
+  const insightsAttributes = propsToCamelCase(
+    // eslint-disable-next-line camelcase
+    hostDetails?.insights_attributes ?? {}
+  );
+  // Local insights advisor
+  if (insightsAttributes.useLocalAdvisorEngine) {
+    // TODO: Replace this placeholder with the actual local advisor integration
+    return <span>Local advisor placeholder</span>;
+  }
+
+  // Hosted insights advisor
+  const { insightsHitsCount: hitsCount } = insightsAttributes;
+  if (hitsCount === undefined || hitsCount === null) return '—';
+  const hostname = hostDetails?.name;
+  const encodedHostname = encodeURIComponent(hostname);
+  const hitsUrl = `/foreman_rh_cloud/insights_cloud?search=hostname+%3D+${encodedHostname}`;
+  return <a href={hitsUrl}>{hitsCount}</a>;
+};
+
+const hostsIndexColumnExtensions = [
+  {
+    columnName: 'insights_recommendations_count',
+    title: __('Recommendations'),
+    wrapper: RecommendationsCell,
+    weight: 1500,
+    isSorted: true,
+  },
+];
+
+hostsIndexColumnExtensions.forEach(column => {
+  column.tableName = 'hosts';
+  column.categoryName = 'Insights';
+  column.categoryKey = 'insights';
+});
+
+export default hostsIndexColumnExtensions;

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -1,7 +1,10 @@
+import { registerColumns } from 'foremanReact/components/HostsIndex/Columns/core';
 import { registerReducers } from './ForemanRhCloudReducers';
 import { registerFills } from './ForemanRhCloudFills';
 import { registerRoutes } from './ForemanRhCloudPages';
+import hostsIndexColumnExtensions from './ForemanColumnExtensions/index';
 
 registerReducers();
 registerFills();
 registerRoutes();
+registerColumns(hostsIndexColumnExtensions);


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This adds a Recommendations column to the new All Hosts page.

- It should now be available to add in Manage Columns
- If you already have the column added on the legacy page, that table preference will carry over to the New UI page

If you're using local Insights advisor, the column will just show a placeholder text. I will soon replace that with a Scalprum component in a separate PR.

If you're using hosted Insights, the column will show the number of Insights hits with a link to the Recommendations page.

#### Considerations taken when implementing this change?

I could also link to the host details page Insights tab. Thoughts?

#### What are the testing steps for this pull request?

Get a host registered to Insights
Send the inventory upload report
Sync recommendations
Get at least one recommendation for your host
Add the column on Hosts > All Hosts > New UI

## Summary by Sourcery

Add a Recommendations column to the new All Hosts page, backed by API support and a React extension that displays placeholder text for local advisor or links to hosted Insights.

New Features:
- Expose insights_hits_count and use_local_advisor_engine in the hosts API for Insights integration
- Register a new Recommendations column in the Hosts table with a React cell that links to Insights or shows a placeholder

Enhancements:
- Carry over existing column visibility preferences from the legacy Hosts UI to the new interface