### PR TITLE
Add cves column to the new hosts index page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
           "camelcase",
           "checkbox",
           "csrf",
+          "cves",
           "dropdown",
           "donut",
           "hostnames",

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
+import { CVECountCell } from '../InsightsVulnerabilityHostIndexExtensions/CVECountCell';
 
 const RecommendationsCell = hostDetails => {
   const insightsAttributes = propsToCamelCase(
@@ -22,6 +23,8 @@ const RecommendationsCell = hostDetails => {
   return <a href={hitsUrl}>{hitsCount}</a>;
 };
 
+const insightsCategoryName = __('Insights');
+
 const hostsIndexColumnExtensions = [
   {
     columnName: 'insights_recommendations_count',
@@ -29,13 +32,20 @@ const hostsIndexColumnExtensions = [
     wrapper: RecommendationsCell,
     weight: 1500,
     isSorted: true,
+    tableName: 'hosts',
+    categoryName: insightsCategoryName,
+    categoryKey: 'insights',
+  },
+  {
+    columnName: 'cves_count',
+    title: __('Total CVEs'),
+    wrapper: hostDetails => <CVECountCell hostDetails={hostDetails} />,
+    weight: 2600,
+    tableName: 'hosts',
+    categoryName: insightsCategoryName,
+    categoryKey: 'insights',
+    isSorted: false,
   },
 ];
-
-hostsIndexColumnExtensions.forEach(column => {
-  column.tableName = 'hosts';
-  column.categoryName = 'Insights';
-  column.categoryKey = 'insights';
-});
 
 export default hostsIndexColumnExtensions;

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { UnknownIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+
+import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
+
+const vulnerabilityApiPath = path =>
+  insightsCloudUrl(`api/vulnerability/v1/${path}`);
+
+export const CVECountCell = ({ hostDetails }) => {
+  // eslint-disable-next-line camelcase
+  const uuid = hostDetails?.subscription_facet_attributes?.uuid;
+
+  const key = `HOST_CVE_COUNT_${uuid}`;
+  const response = useAPI(
+    uuid ? 'get' : null,
+    vulnerabilityApiPath(`systems?uuid=${uuid}`),
+    {
+      key,
+    }
+  );
+
+  if (uuid === undefined) {
+    return <UnknownIcon />;
+  }
+
+  // eslint-disable-next-line camelcase
+  const { cve_count } = (response.response?.data || [])[0]?.attributes || {};
+
+  const cveLink = (
+    // eslint-disable-next-line camelcase
+    <Link to={`hosts/${hostDetails.name}#/CVEs`}>{cve_count}</Link>
+  );
+
+  // eslint-disable-next-line camelcase
+  return cve_count === undefined ? <UnknownIcon /> : cveLink;
+};
+
+CVECountCell.propTypes = {
+  hostDetails: PropTypes.object.isRequired,
+};
+
+export default CVECountCell;

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { API } from 'foremanReact/redux/API';
+import { CVECountCell } from '../CVECountCell';
+
+jest.mock('foremanReact/redux/API');
+API.get.mockImplementation(async () => ({
+  data: [
+    {
+      attributes: {
+        cve_count: 1,
+      },
+    },
+  ],
+}));
+
+describe('CVECountCell', () => {
+  it('renders an empty cves count column', () => {
+    const hostDetailsMock = {
+      name: 'test-host.example.com',
+      subscription_facet_attributes: {
+        uuid: null, // no subscription
+      },
+    };
+    render(<CVECountCell hostDetails={hostDetailsMock} />);
+    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary by Sourcery

Add CVE column to hosts index and implement end-to-end support for cloud-forwarded UI requests and fact obfuscation enhancements, including new React components, services, and expanded obfuscation logic

New Features:
- Add CVE count column to the hosts index page with a React extension and CVECountCell component fetching counts from the vulnerability API
- Implement UI request proxy through UIRequestsController and InsightsApiForwarder to forward frontend API calls to the cloud with tag-based scoping
- Enhance CloudRequestForwarder to include the host subscription UUID in a Forwarded header for telemetry requests

Enhancements:
- Revamp fact obfuscation logic to support IPv4, IPv6, and hostname obfuscation based on global and host-specific settings, dynamic sequential IP generation, and JSON fact parsing
- Extend inventory slice generator and query definitions to include new insights_client obfuscation facts (obfuscated_ipv4, obfuscate_ipv4/ipv6_enabled, obfuscated_hostname) and remove deprecated ones
- Introduce GatewayRequest concern to centralize certificate loading and SSL configuration for cloud requests
- Add gateway_url and ui_base_url helpers in the insights_cloud library

Tests:
- Add comprehensive unit tests for fact obfuscation methods in FactHelpers
- Extend SliceGenerator tests for hostname and IP obfuscation scenarios
- Add tests for CloudRequestForwarder to verify Forwarded header and CVE payload preparation
- Introduce tests for InsightsApiForwarder and UIRequestsController to validate request scoping, error handling, and header forwarding
- Add unit tests for TagsAuth to verify tag payload generation