### PR TITLE
Build RPM after a PR is merged

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,7 +25,8 @@ actions:
     - bash -c "ls -1t ./foreman_rh_cloud-*.gem | head -n 1"
 
 jobs:
-  - job: copr_build
+  - &copr
+    job: copr_build
     trigger: pull_request
     targets:
       rhel-9:
@@ -35,6 +36,10 @@ jobs:
           - https://yum.theforeman.org/plugins/nightly/el9/x86_64/
           - https://yum.theforeman.org/katello/nightly/katello/el9/x86_64/
     module_hotfixes: true
+
+  - <<: *copr
+    trigger: commit
+    branch: develop
 
 srpm_build_deps:
   - wget


### PR DESCRIPTION
@evgeni I am wondering if this approach would allow a "nightly" build to exist of the mainline branch after a PR is merged. I am not clear if this would result in a consistent repo or location to acquire the RPM from. This would help when cycling through a feature with lots of changes on a repo that is not a nightly repo in foreman-packaging.

## Summary by Sourcery

Configure Packit to trigger Copr builds on the develop branch and publish RHEL-9 RPMs to nightly repositories.

Enhancements:
- Target RHEL-9 builds with the foreman-devel module
- Include nightly repository URLs for foreman, plugins, and katello on el9

CI:
- Add a copr_build job in .packit.yaml triggered on commits to the develop branch