### PR TITLE
Consistently determine the right set of certificates to use

### DIFF
--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -15,9 +15,8 @@ module InsightsCloud::Api
 
     # The method that "proxies" requests over to Cloud
     def forward_request
-      certs = candlepin_id_cert @organization
       begin
-        @cloud_response = ::ForemanRhCloud::CloudRequestForwarder.new.forward_request(request, controller_name, @branch_id, certs, @host)
+        @cloud_response = ::ForemanRhCloud::CloudRequestForwarder.new.forward_request(request, controller_name, @branch_id, @host)
       rescue RestClient::Exceptions::Timeout => e
         response_obj = e.response.presence || e.exception
         return render json: { message: response_obj.to_s, error: response_obj.to_s }, status: :gateway_timeout

--- a/test/unit/services/foreman_rh_cloud/cloud_request_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/cloud_request_forwarder_test.rb
@@ -42,7 +42,7 @@ class CloudRequestForwarderTest < ActiveSupport::TestCase
     }
 
     paths.each do |key, value|
-      actual_params = @forwarder.path_params(key, generate_certs_hash)
+      actual_params = @forwarder.path_params(key)
       assert_equal value, actual_params[:url]
     end
   end
@@ -167,7 +167,7 @@ class CloudRequestForwarderTest < ActiveSupport::TestCase
       'action_dispatch.request.query_parameters' => params
     )
 
-    actual = @forwarder.prepare_request_opts(req, 'TEST PAYLOAD', params, generate_certs_hash, @host)
+    actual = @forwarder.prepare_request_opts(req, 'TEST PAYLOAD', params, @host)
 
     assert_match /foo/, actual[:headers][:user_agent]
     assert_match /bar/, actual[:headers][:user_agent]
@@ -192,7 +192,7 @@ class CloudRequestForwarderTest < ActiveSupport::TestCase
       'action_dispatch.request.query_parameters' => params
     )
 
-    actual = @forwarder.prepare_request_opts(req, 'TEST PAYLOAD', params, generate_certs_hash, @host)
+    actual = @forwarder.prepare_request_opts(req, 'TEST PAYLOAD', params, @host)
 
     assert_match /text\/html/, actual[:headers][:content_type]
   end


### PR DESCRIPTION
Before this change, when a manifest is imported, the manifest certificates were being used and causing SSL errors talking to the Gateway. This attempts to use one code chunk to calculate and provide the set of certificates. With this change I was able to run a `insights-client --register` without errors on the client. When reviewing the `production.log` during a register, I did notice a few 403 and 404s. I am providing a summary of these in case they should work and there is more here to fix:

```
  | Route                                                                  | Method | Status  | Count |
  |------------------------------------------------------------------------|--------|---------|-------|
  | /redhat_access/r/insights/v1/branch_info                               | GET    | 200     | 8     |
  | /redhat_access/r/insights/platform/module-update-router/v1/channel     | GET    | 200     | 2     |
  | /redhat_access/r/insights/v1/static/release/insights-core.el9.egg      | GET    | 404     | 2     |
  | /redhat_access/r/insights/v1/systems                                   | POST   | 403     | 1     |
  | /redhat_access/r/insights/uploads/f8da03e6-2754-411f-b423-465aab8b71cf | POST   | 201     | 1     |
  | /redhat_access/r/insights/platform/inventory/v1/host_exists            | GET    | 404     | 1     |
  | /redhat_access/r/insights/platform/inventory/v1/hosts                  | GET    | 200     | 1     |
```

## Summary by Sourcery

Refactor CloudRequestForwarder to consistently determine TLS certificates via CertAuth, streamline request option preparation, and include organization metadata in forwarded requests

Enhancements:
- Centralize certificate handling by including CertAuth in CloudRequestForwarder and removing explicit cert parameters
- Add host.organization to forwarded request options
- Simplify path parameter logic to rely on centralized CA without manual client cert/key assignments

Tests:
- Update CloudRequestForwarder tests to match revised method signatures without cert parameters