### PR TITLE
SAT-34609 - Use shared GH action for JS testing

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -1,32 +1,17 @@
 name: JS
+
+permissions:
+  contents: read
+
 on:
+  push:
+    branches:
+      - develop
   pull_request:
-    paths:
-      - 'webpack/**'
-      - 'package.json'
-      - '.github/workflows/js_ci.yml'
+
 jobs:
   test_js:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version:  ${{ matrix.node-version }}
-      - name: Npm install
-        run: |
-          npm install --legacy-peer-deps
-      - name: Run plugin linter
-        run: |
-          npm run lint
-      - name: Run custom plugin linter
-        run: |
-          npm run lint:spelling
-      - name: Run plugin tests
-        run: |
-          npm run test
+    name: JavaScript
+    uses: theforeman/actions/.github/workflows/foreman_plugin_js.yml@v0
+    with:
+      plugin: foreman_rh_cloud


### PR DESCRIPTION
## Summary by Sourcery

Switch the JavaScript CI workflow to use the shared Foreman plugin action and broaden its triggers.

Enhancements:
- Replace custom Node.js setup, lint, and test steps with theforeman/actions/foreman_plugin_js.yml shared workflow
- Rename the job to 'JavaScript' and pass the plugin parameter to the shared action

CI:
- Add a push trigger for the develop branch and remove path filters on pull requests