### PR TITLE
Integrate CVE Details component into a new page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     end
     get 'insights_cloud', to: '/react#index' # Uses foreman's react controller
     get 'insights_vulnerability', to: '/react#index'
+    get 'insights_vulnerability/:cve_id', to: '/react#index'
   end
 
   scope :module => :'insights_cloud/api', :path => :redhat_access do

--- a/webpack/CveDetailsPage/CveDetailsPage.js
+++ b/webpack/CveDetailsPage/CveDetailsPage.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
+import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
+
+const CveDetailsPage = () => {
+  const { cveId } = useParams();
+  const scope = 'vulnerability';
+  const module = './CveDetailPage';
+
+  return (
+    <ScalprumProvider {...providerOptions}>
+      <div className="rh-cloud-cve-details-page">
+        <ScalprumComponent scope={scope} module={module} cveId={cveId} />
+      </div>
+    </ScalprumProvider>
+  );
+};
+
+export default CveDetailsPage;

--- a/webpack/CveDetailsPage/CveDetailsPage.test.js
+++ b/webpack/CveDetailsPage/CveDetailsPage.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CveDetailsPage from './CveDetailsPage';
+
+// Mock react-router-dom
+jest.mock('react-router-dom', () => ({
+  useParams: jest.fn(() => ({ cveId: 'CVE-2021-1234' })),
+}));
+
+jest.mock('@scalprum/react-core', () => ({
+  ScalprumComponent: jest.fn(props => (
+    <div data-testid="mock-scalprum-component">{JSON.stringify(props)}</div>
+  )),
+  ScalprumProvider: jest.fn(({ children }) => <div>{children}</div>),
+}));
+
+describe('CveDetailsPage component', () => {
+  it('renders the container with correct class', () => {
+    const { container } = render(<CveDetailsPage />);
+    expect(
+      container.querySelector('.rh-cloud-cve-details-page')
+    ).toBeTruthy();
+  });
+
+  it('passes cveId from URL params to ScalprumComponent', () => {
+    const { getByTestId } = render(<CveDetailsPage />);
+    const mockComponent = getByTestId('mock-scalprum-component');
+    expect(mockComponent.textContent).toContain('CVE-2021-1234');
+  });
+});

--- a/webpack/CveDetailsPage/index.js
+++ b/webpack/CveDetailsPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './CveDetailsPage';

--- a/webpack/ForemanRhCloudPages.js
+++ b/webpack/ForemanRhCloudPages.js
@@ -5,6 +5,7 @@ import ForemanInventoryUpload from './ForemanInventoryUpload';
 import InsightsVulnerabilityListPage from './InsightsVulnerability/InsightsVulnerabilityListPage';
 import InsightsCloudSync from './InsightsCloudSync';
 import InsightsHostDetailsTab from './InsightsHostDetailsTab';
+import CveDetailsPage from './CveDetailsPage';
 
 const pages = [
   { name: 'ForemanInventoryUpload', type: ForemanInventoryUpload },
@@ -14,6 +15,7 @@ const pages = [
     name: 'InsightsVulnerabilityListPage',
     type: InsightsVulnerabilityListPage,
   },
+  { name: 'CveDetailsPage', type: CveDetailsPage },
 ];
 
 export const registerPages = () => {
@@ -35,6 +37,11 @@ export const routes = [
     path: '/foreman_rh_cloud/insights_vulnerability',
     exact: true,
     render: props => <InsightsVulnerabilityListPage {...props} />,
+  },
+  {
+    path: '/foreman_rh_cloud/insights_vulnerability/:cveId',
+    exact: true,
+    render: props => <CveDetailsPage {...props} />,
   },
 ];
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a new CVE details page, accessible via the <CVE ID> link

## Summary by Sourcery

Integrate a new CVE details page into the application with client and server routing and registry updates

New Features:
- Add CveDetailsPage React component to load individual CVE details via Scalprum
- Expose client-side route /insights_vulnerability/:cveId to render the CVE details page
- Add server-side route insights_vulnerability/:cve_id to serve the new CVE details frontend

Enhancements:
- Register CveDetailsPage in the page registry within ForemanRhCloudPages

Tests:
- Add skeleton test file for CveDetailsPage