### PR TITLE
SAT-35946: Fix forwarding of requests with pipe | character

### DIFF
--- a/app/controllers/insights_cloud/ui_requests_controller.rb
+++ b/app/controllers/insights_cloud/ui_requests_controller.rb
@@ -7,9 +7,12 @@ module InsightsCloud
     # The method that "proxies" requests over to Cloud
     def forward_request
       begin
+        path_match = request.original_fullpath.match(%r{^/insights_cloud/(?<path>[^?]*)})&.[](:path)
+        path_to_forward = path_match || params.require(:path)
+
         @cloud_response = ::ForemanRhCloud::InsightsApiForwarder.new.forward_request(
           request,
-          params.require(:path),
+          path_to_forward,
           controller_name,
           User.current,
           @organization,


### PR DESCRIPTION
(cherry picked from commit 33dd32074fc8183d146e7018e9c4ba525d113deb)

Requests to Insights APIs via the Foreman_rh_cloud plugin are failing with HTTP 502 (error bad URI(is not URI?)) when the request URI contains a pipe symbol. Pipes are regularly used by Advisor within rule names.

## Summary by Sourcery

Bug Fixes:
- Prevent HTTP 502 errors when forwarding requests containing '|' by using original_fullpath to capture the path segment.