### PR TITLE
SAT-36007 - Fix cveLink on host index page

### DIFF
--- a/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
@@ -31,7 +31,7 @@ export const CVECountCell = ({ hostDetails }) => {
 
   const cveLink = (
     // eslint-disable-next-line camelcase
-    <Link to={`hosts/${hostDetails.name}#/CVEs`}>{cve_count}</Link>
+    <Link to={`hosts/${hostDetails.name}#/Vulnerabilities`}>{cve_count}</Link>
   );
 
   // eslint-disable-next-line camelcase


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Change the CVE count link path from '#/CVEs' to '#/Vulnerabilities' in the CVECountCell component