### PR TITLE
Fixes the RepositoriesController callback order

### DIFF
--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -229,10 +229,15 @@ module ForemanRhCloud
         Katello::Api::V2::OrganizationsController.before_action(:local_find_taxonomy, only: :download_debug_certificate)
 
         Katello::Api::V2::RepositoriesController.include Foreman::Controller::SmartProxyAuth
+        # patch the callbacks order for :index, since find_product has to run after the user is already initialized
+        Katello::Api::V2::RepositoriesController.skip_before_action(:find_product, only: :index)
+        Katello::Api::V2::RepositoriesController.skip_before_action(:find_optional_organization, only: :index)
         Katello::Api::V2::RepositoriesController.add_smart_proxy_filters(
           :index,
           features: ForemanRhCloud.on_prem_smart_proxy_features
         )
+        Katello::Api::V2::RepositoriesController.before_action(:find_product, only: :index)
+        Katello::Api::V2::RepositoriesController.before_action(:find_optional_organization, only: :index)
       end
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
`RepositoriesController` called `find_product` before the user was initialized. This caused access denied errors. This fix orchestrates the call backs in a particular way so that find_product only gets called after the smart proxy user auth

#### What are the testing steps for this pull request?

- Create a Product and repo
- Try to run the following curl command replacing the product_id
- `curl -u admin:changeme 'http://localhost:3000/katello/api/products/<product_id>/repositories'`

Before PR
access denied perms errors

After PR
Correctly pulls the json.

## Summary by Sourcery

Bug Fixes:
- Ensure find_product and find_optional_organization run after SmartProxyAuth in the RepositoriesController index action