### PR TITLE
build commits into @theforeman/develop copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -40,6 +40,8 @@ jobs:
   - <<: *copr
     trigger: commit
     branch: develop
+    owner: '@theforeman'
+    project: develop
 
 srpm_build_deps:
   - wget


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

instead of building to `packit/theforeman-foreman_rh_cloud-develop` this builds into `@theforeman/develop` so that all plugins can have a central "nightly" place

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Can't be tested before merging.

https://packit.dev/docs/configuration/upstream/copr_build#using-a-custom-copr-project was followed

## Summary by Sourcery

Build:
- Configure Copr owner as '@theforeman' and project as 'develop' in .packit.yaml