### PR TITLE
add padding for Vulnerabilities host details tab

### DIFF
--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
 import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
+import './CVEsHostDetailsTab.scss';
 
 const CVEsHostDetailsTab = ({ systemId }) => {
   const scope = 'vulnerability';

--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.scss
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.scss
@@ -1,0 +1,3 @@
+div.rh-cloud-insights-vulnerability-host-details-component {
+  padding: 24px;
+}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Add consistent padding to the Vulnerabilities host details tab by introducing a new SCSS file and importing it into the component.

Enhancements:
- Introduce CVEsHostDetailsTab.scss to apply 24px padding to the host details component
- Import the new SCSS file into CVEsHostDetailsTab.js to activate the styling