### PR TITLE
Add Advisor and Vulnerabilities to Foreman ping

### DIFF
--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -3,19 +3,28 @@ module ForemanRhCloud
     OK_RETURN_CODE = 'ok'.freeze
     FAIL_RETURN_CODE = 'FAIL'.freeze
 
-    SERVICE_URLS = {
-      :advisor => "https://localhost:24443/api/insights/v1/status/live/",
-      :vulnerability => "https://localhost:24443/api/vulnerability/v1/apistatus"
-    }
-
+    
     class << self
+      include ForemanRhCloud::CertAuth
+      
+      def iop_smart_proxy_url
+        @iop_smart_proxy_url ||= ForemanRhCloud.iop_smart_proxy.url
+      end
+
+      def service_urls
+        {
+          :advisor => "#{iop_smart_proxy_url}/api/insights/v1/status/live/",
+          :vulnerability => "#{iop_smart_proxy_url}/api/vulnerability/v1/apistatus"
+        }
+      end
+
       def services
-        SERVICE_URLS.keys
+        service_urls.keys
       end
 
       def status
         {
-          version: ForemanRhCloud::VERSION,
+          iop_smart_proxy_exists: ForemanRhCloud.with_iop_smart_proxy?,
           timeUTC: Time.now.getutc,
         }
       end
@@ -60,8 +69,8 @@ module ForemanRhCloud
 
         options = {}
         options[:ssl_ca_file] = ca_file unless ca_file.nil?
-        options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(File.read(Setting[:ssl_certificate]))
-        options[:ssl_client_key] = OpenSSL::PKey.read(File.read(Setting[:ssl_priv_key])) 
+        options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(foreman_certificate[:cert])
+        options[:ssl_client_key] = OpenSSL::PKey.read(foreman_certificate[:key]) 
 
         client = RestClient::Resource.new(url, options)
 
@@ -77,7 +86,7 @@ module ForemanRhCloud
 
       def ping_service(service_name, service_result_hash)
         exception_watch(service_result_hash) do
-          ping_url(SERVICE_URLS[service_name])
+          ping_url(service_urls[service_name])
         end
       end
     end

--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -5,7 +5,14 @@ module ForemanRhCloud
 
     class << self
       def services
-        [:insights]
+        [:advisor, :vulnerabilities]
+      end
+
+      def status
+        {
+          version: ForemanRhCloud::VERSION,
+          timeUTC: Time.now.getutc,
+        }
       end
 
       def exception_watch(result, &blk)
@@ -33,7 +40,7 @@ module ForemanRhCloud
         result = {}
         services.each do |service|
           result[service] = {}
-          ping_service(result[service])
+          ping_service(service, result[service])
         end
 
         # set overall status result code
@@ -42,9 +49,22 @@ module ForemanRhCloud
         result
       end
 
-      def ping_service(service_result)
-        exception_watch(service_result) do
-          puts "hi"
+      def ping_url(url)
+        ca_file = Setting[:ssl_ca_file]
+        request_id = ::Logging.mdc['request']
+
+        options = {}
+        options[:ssl_ca_file] = ca_file unless ca_file.nil?
+        # options[:headers] = { 'Correlation-ID' => request_id } if request_id
+        client = RestClient::Resource.new(url, options)
+
+        response = client.get
+        response.empty? ? {} : JSON.parse(response).with_indifferent_access
+      end
+
+      def ping_service(service_name, service_result_hash)
+        exception_watch(service_result_hash) do
+          ping_url("https://ip-10-0-168-225.rhos-01.prod.psi.rdu2.redhat.com/insights_cloud/api/insights/v1/rule/?impacting=true")
         end
       end
     end

--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -3,9 +3,14 @@ module ForemanRhCloud
     OK_RETURN_CODE = 'ok'.freeze
     FAIL_RETURN_CODE = 'FAIL'.freeze
 
+    SERVICE_URLS = {
+      :advisor => "http://localhost:24443/api/insights/v1/status/live/",
+      :vulnerabilities => "http://localhost:24443/api/insights/v1/status/live/"
+    }
+
     class << self
       def services
-        [:advisor, :vulnerabilities]
+        SERVICE_URLS.keys
       end
 
       def status
@@ -64,7 +69,7 @@ module ForemanRhCloud
 
       def ping_service(service_name, service_result_hash)
         exception_watch(service_result_hash) do
-          ping_url("https://ip-10-0-168-225.rhos-01.prod.psi.rdu2.redhat.com/insights_cloud/api/insights/v1/rule/?impacting=true")
+          ping_url(SERVICE_URLS[service_name])
         end
       end
     end

--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -62,17 +62,15 @@ module ForemanRhCloud
         result
       end
 
+      def logger
+        Rails.logger
+      end
+
       def ping_url(url)
-        ca_file = Setting[:ssl_ca_file]
-
-        options = {}
-        options[:ssl_ca_file] = ca_file unless ca_file.nil?
-        options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(foreman_certificate[:cert])
-        options[:ssl_client_key] = OpenSSL::PKey.read(foreman_certificate[:key])
-
-        client = RestClient::Resource.new(url, options)
-
-        response = client.get
+        response = execute_cloud_request(
+          method: :get,
+          url: url
+        )
         return {} if response.empty?
         begin
           result = JSON.parse(response).with_indifferent_access

--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -3,10 +3,9 @@ module ForemanRhCloud
     OK_RETURN_CODE = 'ok'.freeze
     FAIL_RETURN_CODE = 'FAIL'.freeze
 
-    
     class << self
       include ForemanRhCloud::CertAuth
-      
+
       def iop_smart_proxy_url
         @iop_smart_proxy_url ||= ForemanRhCloud.iop_smart_proxy.url
       end
@@ -14,7 +13,7 @@ module ForemanRhCloud
       def service_urls
         {
           :advisor => "#{iop_smart_proxy_url}/api/insights/v1/status/live/",
-          :vulnerability => "#{iop_smart_proxy_url}/api/vulnerability/v1/apistatus"
+          :vulnerability => "#{iop_smart_proxy_url}/api/vulnerability/v1/apistatus",
         }
       end
 
@@ -25,7 +24,7 @@ module ForemanRhCloud
       def status
         {
           iop_smart_proxy_exists: ForemanRhCloud.with_iop_smart_proxy?,
-          timeUTC: Time.now.getutc,
+          timeUTC: Time.zone.now.getutc,
         }
       end
 
@@ -41,10 +40,10 @@ module ForemanRhCloud
         result = ping_services
 
         if result[:status] != OK_RETURN_CODE
-          failed_names = result[:services].select do |_name, details|
-            details[:status] != OK_RETURN_CODE
+          failed_names = result[:services].reject do |_name, details|
+            details[:status] == OK_RETURN_CODE
           end
-          fail "The following services have not been started or are reporting errors: #{failed_names.keys.join(', ')}"
+          raise "The following services have not been started or are reporting errors: #{failed_names.keys.join(', ')}"
         end
 
         result
@@ -58,25 +57,24 @@ module ForemanRhCloud
         end
 
         # set overall status result code
-        result = {:services => result}
+        result = { :services => result }
         result[:status] = result[:services].each_value.any? { |v| v[:status] == FAIL_RETURN_CODE } ? FAIL_RETURN_CODE : OK_RETURN_CODE
         result
       end
 
       def ping_url(url)
         ca_file = Setting[:ssl_ca_file]
-        request_id = ::Logging.mdc['request']
 
         options = {}
         options[:ssl_ca_file] = ca_file unless ca_file.nil?
         options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(foreman_certificate[:cert])
-        options[:ssl_client_key] = OpenSSL::PKey.read(foreman_certificate[:key]) 
+        options[:ssl_client_key] = OpenSSL::PKey.read(foreman_certificate[:key])
 
         client = RestClient::Resource.new(url, options)
 
         response = client.get
         return {} if response.empty?
-        begin 
+        begin
           result = JSON.parse(response).with_indifferent_access
         rescue JSON::ParserError, NoMethodError
           result = { :response => response.body&.strip }

--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -4,8 +4,8 @@ module ForemanRhCloud
     FAIL_RETURN_CODE = 'FAIL'.freeze
 
     SERVICE_URLS = {
-      :advisor => "http://localhost:24443/api/insights/v1/status/live/",
-      :vulnerabilities => "http://localhost:24443/api/insights/v1/status/live/"
+      :advisor => "https://localhost:24443/api/insights/v1/status/live/",
+      :vulnerability => "https://localhost:24443/api/vulnerability/v1/apistatus"
     }
 
     class << self
@@ -60,11 +60,19 @@ module ForemanRhCloud
 
         options = {}
         options[:ssl_ca_file] = ca_file unless ca_file.nil?
-        # options[:headers] = { 'Correlation-ID' => request_id } if request_id
+        options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(File.read(Setting[:ssl_certificate]))
+        options[:ssl_client_key] = OpenSSL::PKey.read(File.read(Setting[:ssl_priv_key])) 
+
         client = RestClient::Resource.new(url, options)
 
         response = client.get
-        response.empty? ? {} : JSON.parse(response).with_indifferent_access
+        return {} if response.empty?
+        begin 
+          result = JSON.parse(response).with_indifferent_access
+        rescue JSON::ParserError, NoMethodError
+          result = { :response => response.body&.strip }
+        end
+        result
       end
 
       def ping_service(service_name, service_result_hash)

--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -1,0 +1,52 @@
+module ForemanRhCloud
+  class Ping
+    OK_RETURN_CODE = 'ok'.freeze
+    FAIL_RETURN_CODE = 'FAIL'.freeze
+
+    class << self
+      def services
+        [:insights]
+      end
+
+      def exception_watch(result, &blk)
+        ::Katello::Ping.exception_watch(result, &blk)
+      end
+
+      def ping
+        ping_services
+      end
+
+      def ping!
+        result = ping_services
+
+        if result[:status] != OK_RETURN_CODE
+          failed_names = result[:services].select do |_name, details|
+            details[:status] != OK_RETURN_CODE
+          end
+          fail "The following services have not been started or are reporting errors: #{failed_names.keys.join(', ')}"
+        end
+
+        result
+      end
+
+      def ping_services
+        result = {}
+        services.each do |service|
+          result[service] = {}
+          ping_service(result[service])
+        end
+
+        # set overall status result code
+        result = {:services => result}
+        result[:status] = result[:services].each_value.any? { |v| v[:status] == FAIL_RETURN_CODE } ? FAIL_RETURN_CODE : OK_RETURN_CODE
+        result
+      end
+
+      def ping_service(service_result)
+        exception_watch(service_result) do
+          puts "hi"
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -122,11 +122,11 @@ module ForemanRhCloud
   end
 
   def self.with_iop_smart_proxy?
-    SmartProxy.with_features('iop').exists?
+    SmartProxy.unscoped.with_features('iop').exists?
   end
 
   def self.iop_smart_proxy
-    SmartProxy.with_features('iop').first
+    SmartProxy.unscoped.with_features('iop').first
   end
 
   def self.ca_cert

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -121,8 +121,7 @@ module ForemanRhCloud
 
         register_custom_status InventorySync::InventoryStatus
         register_custom_status InsightsClientReportStatus
-
-        if ForemanRhCloud.with_local_advisor_engine?
+        if ForemanRhCloud.with_iop_smart_proxy?
           register_ping_extension { ForemanRhCloud::Ping.ping }
           register_status_extension { ForemanRhCloud::Ping.status }
         end

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -122,8 +122,10 @@ module ForemanRhCloud
         register_custom_status InventorySync::InventoryStatus
         register_custom_status InsightsClientReportStatus
 
-        register_ping_extension { ForemanRhCloud::Ping.ping }
-        register_status_extension { ForemanRhCloud::Ping.status }
+        if ForemanRhCloud.with_local_advisor_engine?
+          register_ping_extension { ForemanRhCloud::Ping.ping }
+          register_status_extension { ForemanRhCloud::Ping.status }
+        end
 
         describe_host do
           overview_buttons_provider :insights_host_overview_buttons

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -122,6 +122,9 @@ module ForemanRhCloud
         register_custom_status InventorySync::InventoryStatus
         register_custom_status InsightsClientReportStatus
 
+        register_ping_extension { ForemanRhCloud::Ping.ping }
+        register_status_extension { ForemanRhCloud::Ping.status }
+
         describe_host do
           overview_buttons_provider :insights_host_overview_buttons
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a `ForemanRhCloud::Ping` model to `::Foreman::Ping.`

#### Considerations taken when implementing this change?

I am currently pinging only two URLs (see the code). Please let me know if there are any I should add, or change.

#### What are the testing steps for this pull request?

First you need a dev environment with with IoP services running.

You can see the list of services with
```
sudo foreman-maintain service status --brief
```

You should see all the IoP services:
```
$ sudo foreman-maintain service status --brief
Running Status Services
================================================================================
Get status of applicable services: 

Displaying the following service(s):
redis, postgresql, iop-core-engine, iop-core-gateway, iop-core-host-inventory, iop-core-host-inventory-api, iop-core-host-inventory-migrate, iop-core-ingress, iop-core-kafka, iop-core-puptoo, iop-core-yuptoo, iop-service-advisor-backend-api, iop-service-advisor-backend-service, iop-service-remediations-api, iop-service-vmaas-reposcan, iop-service-vmaas-webapp-go, iop-service-vuln-dbupgrade, iop-service-vuln-evaluator-recalc, iop-service-vuln-evaluator-upload, iop-service-vuln-grouper, iop-service-vuln-listener, iop-service-vuln-manager, iop-service-vuln-taskomatic, pulpcore-api, pulpcore-content, pulpcore-worker@1.service, pulpcore-worker@2.service, pulpcore-worker@3.service, pulpcore-worker@4.service, pulpcore-worker@5.service, pulpcore-worker@6.service, tomcat, httpd, foreman-proxy
| displaying redis                                 [OK]                         
| displaying postgresql                            [OK]                         
/ displaying iop-core-engine                       [OK]                         
/ displaying iop-core-gateway                      [OK]                         
/ displaying iop-core-host-inventory               [OK]                         
/ displaying iop-core-host-inventory-api           [OK]                         
/ displaying iop-core-host-inventory-migrate       [OK]                         
/ displaying iop-core-ingress                      [OK]                         
/ displaying iop-core-kafka                        [OK]                         
/ displaying iop-core-puptoo                       [OK]                         
/ displaying iop-core-yuptoo                       [OK]                         
/ displaying iop-service-advisor-backend-api       [OK]                         
/ displaying iop-service-advisor-backend-service   [OK]                         
/ displaying iop-service-remediations-api          [OK]                         
/ displaying iop-service-vmaas-reposcan            [OK]                         
/ displaying iop-service-vmaas-webapp-go           [OK]                         
/ displaying iop-service-vuln-dbupgrade            [OK]                         
/ displaying iop-service-vuln-evaluator-recalc     [OK]                         
/ displaying iop-service-vuln-evaluator-upload     [OK]                         
/ displaying iop-service-vuln-grouper              [OK]                         
/ displaying iop-service-vuln-listener             [OK]                         
/ displaying iop-service-vuln-manager              [OK]                         
/ displaying iop-service-vuln-taskomatic           [OK]                         
/ displaying pulpcore-api                          [OK]                         
/ displaying pulpcore-content                      [OK]                         
/ displaying pulpcore-worker@1.service             [OK]                         
/ displaying pulpcore-worker@2.service             [OK]                         
/ displaying pulpcore-worker@3.service             [OK]                         
/ displaying pulpcore-worker@4.service             [OK]                         
/ displaying pulpcore-worker@5.service             [OK]                         
/ displaying pulpcore-worker@6.service             [OK]                         
/ displaying tomcat                                [OK]                         
/ displaying httpd                                 [OK]                         
/ displaying foreman-proxy                         [OK]                         
/ All services are running                                            [OK]      
--------------------------------------------------------------------------------
```

Until you have the IoP services, don't continue.

In `bundle exec rails console`:
```
pry(main)> ::Ping.ping
...
{:foreman=>{:database=>{:active=>true, :duration_ms=>"1"}, :cache=>{:servers=>[{:status=>"ok", :duration_ms=>"0"}]}},
 :foreman_rh_cloud=>{:services=>{:advisor=>{:status=>"ok", :duration_ms=>"34"}, :vulnerability=>{:status=>"ok", :duration_ms=>"15"}}, :status=>"ok"},
 :katello=>
  {:services=>
    {:candlepin=>{:status=>"ok", :duration_ms=>"21"},
     :candlepin_auth=>{:status=>"ok", :duration_ms=>"21"},
     :foreman_tasks=>{:status=>"ok", :duration_ms=>"251"},
     :katello_events=>{:status=>"ok", :message=>"0 Processed, 0 Failed", :duration_ms=>"2"},
     :candlepin_events=>{:status=>"ok", :message=>"0 Processed, 0 Failed", :duration_ms=>"0"},
     :pulp3=>{:status=>"ok", :duration_ms=>"56"},
     :pulp3_content=>{:status=>"ok", :duration_ms=>"469"}},
   :status=>"ok"}}
```
You should see the `:foreman_rh_cloud` services. also try
```
[2] pry(main)> ForemanRhCloud::Ping.ping
=> {:services=>{:advisor=>{:status=>"ok", :duration_ms=>"26"}, :vulnerability=>{:status=>"ok", :duration_ms=>"15"}}, :status=>"ok"}
```

You can test the FAIL state by stopping a service, such as
```
sudo systemctl stop iop-service-advisor-backend-api
```

## Summary by Sourcery

Add a new Ping model and integrate ping/status endpoints for advisor and vulnerabilities services

New Features:
- Introduce ForemanRhCloud::Ping model to perform health checks against advisor and vulnerabilities services
- Register ping and status extensions into the ForemanRhCloud engine to expose these checks