### PR TITLE
Allow hosts controller to find hosts by Subscription UUID

### DIFF
--- a/app/controllers/foreman_rh_cloud/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/foreman_rh_cloud/concerns/api/v2/hosts_controller_extensions.rb
@@ -1,0 +1,22 @@
+module ForemanRhCloud
+  module Concerns
+    module Api
+      module V2
+        module HostsControllerExtensions
+          extend ActiveSupport::Concern
+
+          included do
+            def find_resource
+              insights_host = ::Katello::Host::SubscriptionFacet.find_by(uuid: params[:id])&.host
+              if insights_host.present?
+                Rails.logger.debug "ForemanRhCloud host found by subscription uuid: #{params[:id]}"
+              end
+              @host = insights_host || super
+              @host
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -83,6 +83,12 @@ module ForemanRhCloud
         :description => N_('Configure Cloud Connector on given hosts'),
         :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
       )
+
+      # API controller extensions
+      ::Api::V2::HostsController.include ::ForemanRhCloud::Concerns::Api::V2::HostsControllerExtensions
+
+      # Controller extensions
+      ::HostsController.include ::ForemanRhCloud::Concerns::Api::V2::HostsControllerExtensions
     end
 
     # Ideally this code belongs to an initializer. The problem is that Katello controllers are not initialized completely until after the end of the to_prepare blocks


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Override the `find_resource` method of Foreman's `Api::V2::HostsController` and `HostsController`, so that you can access hosts by ~~Insights UUID~~ Subscription UUID.

#### Considerations taken when implementing this change?

We already have a gem in place, FriendlyId, that allows us to use host FQDNs as IDs. Sadly, though, that gem does not allow using more than one field name as an ID. So I had to develop this custom solution.

Originally I had only extended `Api::V2::HostsController`, but the Host Statuses card was not working. I realized that makes a call to `/hosts/:id/statuses` (note the lack of `api/v2`) so I had to extend the other controller as well.

#### What are the testing steps for this pull request?

Try to access the host details page via Subscription UUID in the url, such as
```
https://centos9-katello-devel.fedora.example.com/new/hosts/c39d1627-c958-433b-afc9-b3242be6717a#/Insights
```

## Summary by Sourcery

Override the find_resource method in Foreman’s API V2 and UI HostsController to enable fetching hosts by Subscription UUID

Enhancements:
- Include a concern in the engine to extend both Api::V2::HostsController and HostsController with custom behavior
- Override find_resource to first attempt host lookup via Katello::Host::SubscriptionFacet by UUID before falling back to default ID lookup