### PR TITLE
Fixes #35249 - Add link to doc about Minimal data collection setting

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
@@ -3,6 +3,7 @@ import { Text } from '@patternfly/react-core';
 import { useSelector } from 'react-redux';
 
 import { translate as __ } from 'foremanReact/common/I18n';
+import { getDocsURL } from 'foremanReact/common/helpers';
 import { FormattedMessage } from 'react-intl';
 import { selectSubscriptionConnectionEnabled } from '../../../InventorySettings/InventorySettingsSelectors';
 
@@ -53,6 +54,16 @@ export const PageDescription = () => {
           />
         </Text>
       )}
+      <Text ouiaId="text-minimal-data-collection">
+        {__('Learn more about ')}
+        <a
+          href={getDocsURL('Managing_Hosts', 'setting-minimal-data-collection')}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {__('Minimal data collection setting')}
+        </a>
+      </Text>
       <Text ouiaId="text-more-info-subscription">
         {__('For more information about the Subscriptions service, see:')}
         &nbsp;

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/__tests__/PageDescription.test.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/__tests__/PageDescription.test.js
@@ -15,6 +15,8 @@ jest.mock('react-intl', () => {
     }),
   };
 });
+jest.mock('foremanReact/common/helpers', () => ({ getDocsURL: () => {} }));
+
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add link to doc about Minimal data collection setting

Depends on https://github.com/RedHatSatellite/foreman_theme_satellite/pull/220

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. check out https://github.com/RedHatSatellite/foreman_theme_satellite/pull/220.

2.  modify foreman_theme_satellite/lib/foreman_theme_satellite/engine.rb

  ```
    def self.get_satellite_version
         metadata_field('version', '6.18.0-development')                => change version to 6.18                                                                                                                              
    end
```

3.  Add to foreman/bundler.d/foreman_theme_satellite.local.rb:

     `gemspec :path => '../foreman_theme_satellite', :development_group => 'foreman_theme_satellite_dev', :name => 'foreman_theme_satellite'`

4.  Start foreman.

5.  Insights -> Inventory Upload -> Learn more about Minimal data collection setting

6.  Click the `Minimal data collection setting` link.

7.  Add `content-preview.` before `docs.redhat.com.....` in the popup window so the URL becomes `https://content-preview.docs.redhat.com/en/documentation/red_hat_satellite/6.18/html/managing_hosts/monitoring-hosts-by-using-insights#setting-minimal-data-collection`. 
The doc should be displayed correctly.

## Summary by Sourcery

Enhancements:
- Insert new text and link to the Red Hat Satellite documentation for the minimal data collection setting