### PR TITLE
Remove unneeded Scalprum placeholder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
           "donut",
           "hostnames",
           "href",
+          "iop",
           "ips",
           "ipv4",
           "dropdown",

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -110,8 +110,7 @@ NewHostDetailsTab.defaultProps = {
 
 // Local Insights advisor
 const scope = 'advisor';
-// eslint-disable-next-line spellcheck/spell-checker
-const module = './HostDetailsLightspeedTabWrapped';
+const module = './SystemDetailsWrapped';
 
 const IopInsightsTab = props => (
   <ScalprumComponent
@@ -129,7 +128,7 @@ const IopInsightsTabWrapped = props => (
   </ScalprumProvider>
 );
 
-const LightspeedTab = props => {
+const InsightsTab = props => {
   const { response } = props;
   const isLocalAdvisorEngine =
     // eslint-disable-next-line camelcase
@@ -142,7 +141,7 @@ const LightspeedTab = props => {
   );
 };
 
-LightspeedTab.propTypes = {
+InsightsTab.propTypes = {
   response: PropTypes.shape({
     insights_attributes: {
       use_local_advisor_engine: PropTypes.bool,
@@ -150,8 +149,8 @@ LightspeedTab.propTypes = {
   }),
 };
 
-LightspeedTab.defaultProps = {
+InsightsTab.defaultProps = {
   response: {},
 };
 
-export default LightspeedTab;
+export default InsightsTab;

--- a/webpack/IopRecommendationDetails/IopRecommendationDetails.js
+++ b/webpack/IopRecommendationDetails/IopRecommendationDetails.js
@@ -8,25 +8,15 @@ import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
 const scope = 'advisor';
 const module = './RecommendationDetailsWrapped';
 
-const invScope = 'inventory';
-const invModule = './HybridInventoryTabs';
-
 const IopRecommendationDetails = props => {
   const urlParams = useRouteMatch('/foreman_rh_cloud/recommendations/:rule_id');
   // eslint-disable-next-line camelcase
   const ruleId = urlParams?.params?.rule_id;
   return (
-    <div className="rh-cloud-recommendation-details-cell">
+    <div className="iop-recommendation-details-scalprum">
       <ScalprumComponent
         scope={scope}
         module={module}
-        IopRemediationModal={RemediationModal}
-        ruleId={ruleId}
-        {...props}
-      />
-      <ScalprumComponent
-        scope={invScope}
-        module={invModule}
         IopRemediationModal={RemediationModal}
         ruleId={ruleId}
         {...props}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Remove unneeded Scalprum placeholder  
 rename LightspeedTab
 add iop to spelling dictionary

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Test on Advisor Test Box and tell me what's broken :)

## Summary by Sourcery

Remove redundant Scalprum placeholder in IOP recommendation details, rename and refactor the LightspeedTab component to InsightsTab with updated module import, and update ESLint config to recognize “iop” in the spelling dictionary.

Enhancements:
- Remove unused ScalprumComponent placeholder and related constants from IopRecommendationDetails.
- Rename LightspeedTab component to InsightsTab and update its module import to SystemDetailsWrapped, adjusting propTypes and defaultProps accordingly.
- Add “iop” to the ESLint spelling dictionary.