### PR TITLE
Add endpoint to translate Insights UUIDs and redirect

### DIFF
--- a/app/controllers/insights_cloud/ui_requests_controller.rb
+++ b/app/controllers/insights_cloud/ui_requests_controller.rb
@@ -75,6 +75,18 @@ module InsightsCloud
       res.headers[new_header] = header_content
     end
 
+    def translate_insights_host
+      Rails.logger.info "translate_insights_host"
+      facet = InsightsFacet.find_by(uuid: params[:uuid])
+      if facet.present?
+        Rails.logger.info "Found InsightsFacet #{params[:uuid]}"
+        redirect_to host_details_page_path(facet&.host_id)
+      else
+        Rails.logger.error "Could not find InsightsFacet for #{params[:uuid]}"
+        redirect_to '/page-not-found'
+      end
+    end
+
     private
 
     def ensure_org

--- a/app/controllers/insights_cloud/ui_requests_controller.rb
+++ b/app/controllers/insights_cloud/ui_requests_controller.rb
@@ -76,11 +76,10 @@ module InsightsCloud
     end
 
     def translate_insights_host
-      Rails.logger.info "translate_insights_host"
       facet = InsightsFacet.find_by(uuid: params[:uuid])
       if facet.present?
-        Rails.logger.info "Found InsightsFacet #{params[:uuid]}"
-        redirect_to host_details_page_path(facet&.host_id)
+        Rails.logger.debug "Found InsightsFacet #{params[:uuid]}"
+        redirect_to host_details_page_path(facet.host_id)
       else
         Rails.logger.error "Could not find InsightsFacet for #{params[:uuid]}"
         redirect_to '/page-not-found'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do
     match '/api/lightspeed/*path', to: 'machine_telemetries#forward_request', via: :all
   end
 
+  get '/insights_hosts/:uuid', to: 'insights_cloud/ui_requests#translate_insights_host'
+
   # API routes
 
   namespace :api, :defaults => { :format => 'json' } do

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -56,7 +56,7 @@ module ForemanRhCloud
               '/foreman_rh_cloud/insights_cloud': [:index], # for bookmarks and later for showing the page
               'insights_cloud/hits': [:index, :show, :auto_complete_search, :resolutions],
               'insights_cloud/settings': [:index, :show],
-              'insights_cloud/ui_requests': [:forward_request],
+              'insights_cloud/ui_requests': [:forward_request, :translate_insights_host],
               'react': [:index],
             },
             :resource_type => ::InsightsHit.name

--- a/test/controllers/insights_cloud/ui_requests_controller_test.rb
+++ b/test/controllers/insights_cloud/ui_requests_controller_test.rb
@@ -9,6 +9,29 @@ module InsightsCloud
       FactoryBot.create(:common_parameter, name: InsightsCloud.enable_client_param, key_type: 'boolean', value: true)
     end
 
+    context '#translate_insights_host' do
+      setup do
+        @org = FactoryBot.create(:organization)
+        @loc = FactoryBot.create(:location)
+        @host = FactoryBot.create(:host, :with_subscription, :organization => @org)
+        @facet = InsightsFacet.create(host: @host, uuid: @host.subscription_facet.uuid)
+      end
+
+      test "should redirect to host details page by id" do
+        get :translate_insights_host, params: { "uuid" => @host.subscription_facet.uuid }, session: set_session
+        assert_equal 302, @response.status
+        assert @response.redirect?
+        assert_equal "http://test.host/new/hosts/#{@host.id}", @response.redirect_url
+      end
+
+      test "should redirect to not-found page" do
+        get :translate_insights_host, params: { "uuid" => "foo" }, session: set_session
+        assert_equal 302, @response.status
+        assert @response.redirect?
+        assert_equal "http://test.host/page-not-found", @response.redirect_url
+      end
+    end
+
     context '#forward_request' do
       include MockCerts
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add a new endpoint, `/insights_hosts/:uuid`, where you can supply an Insights UUID and Rails will redirect you to the host details page of that host (using the database ID).

#### Considerations taken when implementing this change?

see comment

Also, feedback is accepted on (a) what to call the endpoint; and (b) what controller it goes in. These are just initial guesses.

#### What are the testing steps for this pull request?

Get a host with an Insights facet
In the browser, visit `/insights_hosts/<insights_uuid>`
Confirm that it redirects correctly

In the browser, visit `/insights_hosts/foo`
Confirm that it redirects to error page

## Summary by Sourcery

Add a new endpoint to translate an Insights UUID to a host database ID and redirect to the host details page or a not-found page.

New Features:
- Add GET /insights_hosts/:uuid endpoint for translating Insights UUIDs
- Implement translate_insights_host action in the UI requests controller to look up the InsightsFacet by UUID and redirect accordingly
- Register translate_insights_host action in the plugin permissions