### PR TITLE
Add yum_repos to slice

### DIFF
--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -166,7 +166,10 @@ module InsightsCloud::Api
           :with_content,
           :with_hostgroup,
           :with_parameter,
-          content_view_environments: [make_cve(lifecycle_environment: env), make_cve(lifecycle_environment: env2)],
+          content_facet: FactoryBot.build(
+            :content_facet,
+            content_view_environments: [make_cve(lifecycle_environment: env), make_cve(lifecycle_environment: env2)]
+          ),
           organization: env.organization
         )
 

--- a/test/factories/inventory_upload_factories.rb
+++ b/test/factories/inventory_upload_factories.rb
@@ -1,87 +1,3 @@
-# redefine katello factories, as long as katello is not compatible with dynamic properties
-FactoryBot.define do
-  factory :katello_organization, :class => "Organization" do
-    type { "Organization" }
-    sequence(:name) { |n| "Organization#{n}" }
-    sequence(:label) { |n| "org#{n}" }
-    sequence(:id) { |n| n }
-
-    trait :acme_corporation do
-      name { "ACME_Corporation" }
-      type { "Organization" }
-      description { "This is the first Organization." }
-      label { "acme_corporation_label" }
-    end
-
-    trait :with_library do
-      association :library, :factory => :katello_library
-    end
-
-    factory :acme_corporation, :traits => [:acme_corporation]
-  end
-end
-
-FactoryBot.define do
-  factory :katello_content_view, :class => Katello::ContentView do
-    sequence(:name) { |n| "Database#{n}" }
-    description { "This content view is for database content" }
-    association :organization, :factory => :katello_organization
-
-    trait :composite do
-      composite { true }
-    end
-  end
-end
-
-FactoryBot.define do
-  factory :katello_content_view_environment, :class => Katello::ContentViewEnvironment do
-    sequence(:name) { |n| "name#{n}" }
-    sequence(:label) { |n| "label#{n}" }
-  end
-end
-
-FactoryBot.define do
-  factory :katello_k_t_environment, :aliases => [:katello_environment], :class => Katello::KTEnvironment do
-    sequence(:name) { |n| "Environment#{n}" }
-    sequence(:label) { |n| "environment#{n}" }
-    association :organization, :factory => :katello_organization
-  end
-end
-
-FactoryBot.define do
-  factory :katello_content_facets, :aliases => [:content_facet], :class => ::Katello::Host::ContentFacet do
-    sequence(:uuid) { |n| "uuid-#{n}" }
-  end
-end
-
-FactoryBot.define do
-  factory :katello_subscription_facets, :aliases => [:subscription_facet], :class => ::Katello::Host::SubscriptionFacet do
-    sequence(:uuid) { |n| "00000000-%<n>04d-%<r>04d-0000-000000000000" % { n: n, r: rand(500) } }
-    facts { { 'memory.memtotal' => "12 GB" } }
-  end
-end
-
-FactoryBot.define do
-  factory :katello_subscription, :class => Katello::Subscription do
-  end
-end
-
-FactoryBot.define do
-  factory :katello_pool, :class => Katello::Pool do
-    active { true }
-    end_date { Date.today + 1.year }
-    cp_id { 1 }
-
-    association :organization, :factory => :katello_organization
-
-    after(:build) do |pool, _evaluator|
-      pool.subscription.organization = pool.organization
-    end
-
-    association :subscription, :factory => :katello_subscription
-  end
-end
-
 FactoryBot.define do
   factory :katello_host_collection_host, :class => Katello::HostCollectionHosts do
     host_id { nil }
@@ -94,34 +10,10 @@ FactoryBot.define do
   end
 end
 
+# Fix Katello factories to return a valid UUID
 FactoryBot.modify do
-  factory :host do
-    transient do
-      content_view { nil }
-      lifecycle_environment { nil }
-      content_source { nil }
-      content_view_environments { [] }
-    end
-
-    trait :with_content do
-      association :content_facet, :factory => :content_facet, :strategy => :build
-
-      after(:build) do |host, evaluator|
-        if host.content_facet
-          if evaluator.content_view && evaluator.lifecycle_environment
-            host.content_facet.assign_single_environment(
-              content_view_id: evaluator.content_view.id,
-              lifecycle_environment_id: evaluator.lifecycle_environment.id
-            )
-          end
-          host.content_facet.content_source = evaluator.content_source if evaluator.content_source
-          host.content_facet.content_view_environments = evaluator.content_view_environments unless evaluator.content_view_environments.empty?
-        end
-      end
-    end
-
-    trait :with_subscription do
-      association :subscription_facet, :factory => :subscription_facet, :strategy => :build
-    end
+  factory :katello_subscription_facets, :aliases => [:subscription_facet], :class => ::Katello::Host::SubscriptionFacet do
+    sequence(:uuid) { |n| "00000000-%<n>04d-%<r>04d-0000-000000000000" % { n: n, r: rand(500) } }
+    facts { { 'memory.memtotal' => "12 GB" } }
   end
 end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -2,10 +2,16 @@
 require 'test_helper'
 
 # Add plugin to FactoryBot's paths
-FactoryBot.definition_file_paths << "#{ForemanTasks::Engine.root}/test/factories"
+# task engine is defined implicitly by Katello
 FactoryBot.definition_file_paths << "#{ForemanRemoteExecution::Engine.root}/test/factories"
+FactoryBot.definition_file_paths << "#{ForemanTasks::Engine.root}/test/factories"
+# skip foreman_task factories, since we already have those definitions in ForemanTasks
+FactoryBot.definition_file_paths +=
+  Dir.glob("#{Katello::Engine.root}/test/factories/**/*.rb")
+  .reject { |f| f =~ /foreman_task|recurring_logic/ }
+  .map { |f| f.gsub('.rb', '') } # .rb extension is will be appended by factorybot
+
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
-# FactoryBot.definition_file_paths << "#{Katello::Engine.root}/test/factories"
 FactoryBot.reload
 
 begin

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -2,14 +2,14 @@
 require 'test_helper'
 
 # Add plugin to FactoryBot's paths
-# task engine is defined implicitly by Katello
-FactoryBot.definition_file_paths << "#{ForemanRemoteExecution::Engine.root}/test/factories"
-FactoryBot.definition_file_paths << "#{ForemanTasks::Engine.root}/test/factories"
-# skip foreman_task factories, since we already have those definitions in ForemanTasks
+katello_files = Dir.glob("#{Katello::Engine.root}/test/factories/**/*.rb")
 FactoryBot.definition_file_paths +=
-  Dir.glob("#{Katello::Engine.root}/test/factories/**/*.rb")
+  katello_files
+  # skip foreman_task factories, since we already have those definitions in ForemanTasks
   .reject { |f| f =~ /foreman_task|recurring_logic/ }
   .map { |f| f.gsub('.rb', '') } # .rb extension is will be appended by factorybot
+FactoryBot.definition_file_paths << "#{ForemanRemoteExecution::Engine.root}/test/factories"
+FactoryBot.definition_file_paths << "#{ForemanTasks::Engine.root}/test/factories"
 
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryBot.reload

--- a/test/unit/services/foreman_rh_cloud/cloud_request_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/cloud_request_forwarder_test.rb
@@ -22,7 +22,10 @@ class CloudRequestForwarderTest < ActiveSupport::TestCase
       :with_content,
       :with_hostgroup,
       :with_parameter,
-      content_view_environments: [make_cve(lifecycle_environment: env), make_cve(lifecycle_environment: env2)],
+      content_facet: FactoryBot.build(
+        :content_facet,
+        content_view_environments: [make_cve(lifecycle_environment: env), make_cve(lifecycle_environment: env2)]
+      ),
       organization: env.organization
     )
 

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -998,6 +998,39 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     assert_not_nil actual_host['insights_id']
   end
 
+  test 'reports yum repos' do
+    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(true)
+    FactoryBot.create(:katello_content, cp_content_id: '1', organization: @host.organization, name: 'Test Content', label: 'test-content')
+    repo = FactoryBot.build(
+      :katello_repository,
+      :fedora_17_x86_64_dev,
+      :with_content_view,
+      product: FactoryBot.create(:katello_product, :redhat, :with_provider, organization: @host.organization)
+    )
+    # force-save the root repo to avoid validation errors
+    repo.root.save(validate: false)
+    repo.save(validate: false)
+    @host.content_facet.bound_repositories << repo
+    @host.content_facet.content_source = FactoryBot.create(:smart_proxy, :with_pulp3)
+    @host.save(validate: false)
+
+    batch = Host.where(id: @host.id).in_batches.first
+    generator = create_generator(batch)
+    json_str = generator.render
+    actual = JSON.parse(json_str.join("\n"))
+
+    assert_not_nil(actual_host = actual['hosts'].first)
+    assert_not_nil(actual_system_profile = actual_host['system_profile'])
+    assert_not_nil(actual_yum_repos = actual_system_profile['yum_repos'])
+    assert_equal 1, actual_yum_repos.count
+    assert_not_nil(actual_yum_repo = actual_yum_repos.first)
+    assert_equal 'Test Content', actual_yum_repo['name']
+    assert_equal 'test-content', actual_yum_repo['id']
+    assert_match /fedora_17/, actual_yum_repo['base_url']
+    assert_equal true, actual_yum_repo['enabled']
+    assert_equal true, actual_yum_repo['gpgcheck']
+  end
+
   private
 
   def create_generator(batch, name = '00000000-0000-0000-0000-000000000000')

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -1026,7 +1026,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     assert_not_nil(actual_yum_repo = actual_yum_repos.first)
     assert_equal 'Test Content', actual_yum_repo['name']
     assert_equal 'test-content', actual_yum_repo['id']
-    assert_match /fedora_17/, actual_yum_repo['base_url']
+    assert_match(/fedora_17/, actual_yum_repo['base_url'])
     assert_equal true, actual_yum_repo['enabled']
     assert_equal true, actual_yum_repo['gpgcheck']
   end

--- a/test/unit/tags_generator_test.rb
+++ b/test/unit/tags_generator_test.rb
@@ -26,7 +26,10 @@ class TagsGeneratorTest < ActiveSupport::TestCase
       organization: env.organization,
       location: @location2,
       hostgroup: @hostgroup2,
-      content_view_environments: [make_cve(lifecycle_environment: env), make_cve(lifecycle_environment: env2)]
+      content_facet: FactoryBot.build(
+        :content_facet,
+        content_view_environments: [make_cve(lifecycle_environment: env), make_cve(lifecycle_environment: env2)]
+      )
     )
 
     @host.organization.pools << FactoryBot.create(:katello_pool, account_number: '1234', cp_id: 1)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This PR adds yum_repos node to the report, only in IoP case.

#### Considerations taken when implementing this change?

I did not want to disrupt the hosted use case, so added the node only if we are in IoP mode

#### What are the testing steps for this pull request?

Generate and upload an rh_cloud report and observe the yum_repos node under system_profile.

## Summary by Sourcery

Add yum_repos reporting to the system_profile slice generator in IoP mode and update tests and factories accordingly

New Features:
- Include a yum_repos array under system_profile when with_local_advisor_engine? is true

Enhancements:
- Remove outdated Katello factory definitions and fix the subscription_facet factory to generate valid UUIDs

Tests:
- Add a unit test to verify yum_repos entries in the slice generator output
- Update existing tests to build hosts with content_facet instead of using content_view_environments directly