### PR TITLE
Don't JSONify empty payloads

### DIFF
--- a/app/services/foreman_rh_cloud/url_remediations_retriever.rb
+++ b/app/services/foreman_rh_cloud/url_remediations_retriever.rb
@@ -28,7 +28,7 @@ module ForemanRhCloud
     end
 
     def payload
-      @payload.to_json
+      @payload.present? ? @payload.to_json : @payload # don't run .to_json if @payload is ''
     end
 
     def method


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In UrlRemediationsRetriever, we had a method

```rb
def payload
   @payload.to_json
end
```

For some reason, with the default payload of `''` this was ending up as invalid JSON on the other end. Removing `.to_json` resolves the issue.

#### Considerations taken when implementing this change?

I'm still not sure of the root cause here, but this unblocks Advisor remediation playbook downloads.

#### What are the testing steps for this pull request?

talk to Dan