### PR TITLE
Add service name class to Insights components to fix styling

### DIFF
--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -8,7 +8,7 @@ const CVEsHostDetailsTab = ({ systemId }) => {
   const scope = 'vulnerability';
   const module = './SystemDetailTable';
   return (
-    <div className="rh-cloud-insights-vulnerability-host-details-component">
+    <div className="rh-cloud-insights-vulnerability-host-details-component vulnerability">
       <ScalprumComponent scope={scope} module={module} systemId={systemId} />
     </div>
   );

--- a/webpack/CveDetailsPage/CveDetailsPage.js
+++ b/webpack/CveDetailsPage/CveDetailsPage.js
@@ -10,7 +10,7 @@ const CveDetailsPage = () => {
 
   return (
     <ScalprumProvider {...providerOptions}>
-      <div className="rh-cloud-cve-details-page">
+      <div className="rh-cloud-cve-details-page vulnerability">
         <ScalprumComponent scope={scope} module={module} cveId={cveId} />
       </div>
     </ScalprumProvider>

--- a/webpack/InsightsCloudSync/InsightsCloudSync.js
+++ b/webpack/InsightsCloudSync/InsightsCloudSync.js
@@ -67,13 +67,15 @@ export const generateRuleUrl = ruleId =>
   foremanUrl(`/foreman_rh_cloud/recommendations/${ruleId}`);
 
 const IopRecommendationsPage = props => (
-  <ScalprumComponent
-    scope={scope}
-    module={module}
-    IopRemediationModal={RemediationModal}
-    generateRuleUrl={generateRuleUrl}
-    {...props}
-  />
+  <div className="advisor">
+    <ScalprumComponent
+      scope={scope}
+      module={module}
+      IopRemediationModal={RemediationModal}
+      generateRuleUrl={generateRuleUrl}
+      {...props}
+    />
+  </div>
 );
 
 const IopRecommendationsPageWrapped = props => (

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -113,13 +113,15 @@ const scope = 'advisor';
 const module = './SystemDetailWrapped';
 
 const IopInsightsTab = props => (
-  <ScalprumComponent
-    scope={scope}
-    module={module}
-    IopRemediationModal={RemediationModal}
-    generateRuleUrl={generateRuleUrl}
-    {...props}
-  />
+  <div className="advisor">
+    <ScalprumComponent
+      scope={scope}
+      module={module}
+      IopRemediationModal={RemediationModal}
+      generateRuleUrl={generateRuleUrl}
+      {...props}
+    />
+  </div>
 );
 
 const IopInsightsTabWrapped = props => (

--- a/webpack/InsightsVulnerability/InsightsVulnerabilityListPage.js
+++ b/webpack/InsightsVulnerability/InsightsVulnerabilityListPage.js
@@ -6,7 +6,7 @@ const InsightsVulnerabilityListPage = () => {
   const scope = 'vulnerability';
   const module = './CveListPage';
   return (
-    <div className="rh-cloud-insights-vulnerability-page">
+    <div className="rh-cloud-insights-vulnerability-page vulnerability">
       <ScalprumComponent scope={scope} module={module} />
     </div>
   );

--- a/webpack/IopRecommendationDetails/IopRecommendationDetails.js
+++ b/webpack/IopRecommendationDetails/IopRecommendationDetails.js
@@ -13,7 +13,7 @@ const IopRecommendationDetails = props => {
   // eslint-disable-next-line camelcase
   const ruleId = urlParams?.params?.rule_id;
   return (
-    <div className="iop-recommendation-details-scalprum">
+    <div className="iop-recommendation-details-scalprum advisor">
       <ScalprumComponent
         scope={scope}
         module={module}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Multiple styling issues in Lightspeed are caused by apps not being wrapped in a container with class name same as their service name.

This is a practice used on HCC to isolate CSS so it does not bleed into other apps -- each app is automatically wrapped in a div with class name same as their service name and stylesheets are restricted to only apply within containers of their corresponding app.

#### Considerations taken when implementing this change?
--

#### What are the testing steps for this pull request?

Open Vulnerability app and expand any row inside the table. The expandable section title "CVE description" should be bold. If it's bold than the styles are being applied correctly.

## Before
<img width="373" height="160" alt="image" src="https://github.com/user-attachments/assets/687a1ae1-2631-4f30-b80c-6c6e44edc606" />

<img width="409" height="134" alt="image" src="https://github.com/user-attachments/assets/636c3ef8-456e-48fa-aaa2-14b128770867" />

## After
<img width="373" height="160" alt="image" src="https://github.com/user-attachments/assets/f2319272-b4f5-445c-be2a-8aaa06b209bd" />

<img width="373" height="160" alt="image" src="https://github.com/user-attachments/assets/f9cdeff7-2bdb-4058-a0ef-3606f8dfdf28" />

## Summary by Sourcery

Scope CSS for Insights components by wrapping them in containers with service-specific class names

Enhancements:
- Wrap remediation and host details components in a div/span with the "advisor" class
- Add the "vulnerability" class to CVE host details, details page, and vulnerability list page containers