### PR TITLE
Switch to iop for smart proxy feature

### DIFF
--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -137,6 +137,6 @@ module ForemanRhCloud
   end
 
   def self.on_prem_smart_proxy_features
-    ['Insights']
+    ['iop']
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This changes from Insights to iop for the feature name to align with our use of `iop` everywhere else. This is required in conjunction with https://github.com/RedHatInsights/iop-gateway/pull/17

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Enhancements:
- Rename on-prem smart proxy feature name from 'Insights' to 'iop'