### PR TITLE
fix(RHINENG-19870): Disable Remediate button for manual recommendations

### DIFF
--- a/webpack/InsightsCloudSync/Components/RemediationModal/RemediationModal.js
+++ b/webpack/InsightsCloudSync/Components/RemediationModal/RemediationModal.js
@@ -24,6 +24,7 @@ const RemediationModal = ({
   error,
   isAllSelected,
   query,
+  isDisabled,
 }) => {
   const [rows, setRows] = React.useState([]);
   const [open, setOpen] = React.useState(false);
@@ -48,7 +49,7 @@ const RemediationModal = ({
       <Button
         ouiaId="button-remediate"
         variant="primary"
-        isDisabled={isEmpty(selectedIds)}
+        isDisabled={isDisabled || isEmpty(selectedIds)}
         onClick={() => {
           toggleModal();
         }}
@@ -99,6 +100,7 @@ RemediationModal.propTypes = {
   error: PropTypes.string,
   isAllSelected: PropTypes.bool,
   query: PropTypes.string,
+  isDisabled: PropTypes.bool,
 };
 
 RemediationModal.defaultProps = {
@@ -108,6 +110,7 @@ RemediationModal.defaultProps = {
   error: null,
   isAllSelected: false,
   query: null,
+  isDisabled: false,
 };
 
 export default RemediationModal;


### PR DESCRIPTION
Recommendations without playbooks shouldn't activate the Remediate button.  See screenshot.  This PR is in conjunction with Advisor PR: https://github.com/RedHatInsights/insights-advisor-frontend/pull/1527


<img width="1920" height="1042" alt="Screenshot from 2025-08-05 20-41-03" src="https://github.com/user-attachments/assets/a812fb78-fcc3-4e5a-8b29-b7b289b209c5" />

## Summary by Sourcery

Disable the Remediate button in the modal for recommendations without playbooks by introducing an isDisabled prop and updating the button's disabled state accordingly.

Bug Fixes:
- Prevent the Remediate button from activating when isDisabled is true or no items are selected
- Add isDisabled prop to RemediationModal and include it in PropTypes and defaultProps