### PR TITLE
Refactor local advisor engine config with SmartProxy-based detection 

### DIFF
--- a/app/controllers/api/v2/rh_cloud/advisor_engine_config_controller.rb
+++ b/app/controllers/api/v2/rh_cloud/advisor_engine_config_controller.rb
@@ -7,7 +7,7 @@ module Api
         api :GET, "/rh_cloud/advisor_engine_config", N_("Show if system is configured to use local iop-advisor-engine.")
         def show
           render json: {
-            use_local_advisor_engine: ForemanRhCloud.with_local_advisor_engine?,
+            use_iop_mode: ForemanRhCloud.with_iop_smart_proxy?,
           }, status: :ok
         end
       end

--- a/app/controllers/api/v2/rh_cloud/cloud_request_controller.rb
+++ b/app/controllers/api/v2/rh_cloud/cloud_request_controller.rb
@@ -1,6 +1,9 @@
 module Api::V2::RhCloud
   class CloudRequestController < ::Api::V2::BaseController
+    include ForemanRhCloud::IopSmartProxyAccess
     layout false
+
+    before_action :require_no_iop_smart_proxy, only: [:update]
 
     KNOWN_DIRECTIVES = {
       'playbook-sat' => :handle_run_playbook_request,

--- a/app/controllers/api/v2/rh_cloud/inventory_controller.rb
+++ b/app/controllers/api/v2/rh_cloud/inventory_controller.rb
@@ -5,6 +5,9 @@ module Api
         include ::Api::Version2
         include InventoryUpload::ReportActions
         include InventoryUpload::TaskActions
+        include ForemanRhCloud::IopSmartProxyAccess
+
+        before_action :require_no_iop_smart_proxy, only: [:enable_cloud_connector]
 
         api :GET, "/organizations/:organization_id/rh_cloud/report", N_("Download latest report")
         param :organization_id, Integer, required: true, desc: N_("Set the current organization context for the request")

--- a/app/controllers/concerns/foreman_rh_cloud/iop_smart_proxy_access.rb
+++ b/app/controllers/concerns/foreman_rh_cloud/iop_smart_proxy_access.rb
@@ -1,0 +1,19 @@
+module ForemanRhCloud
+  module IopSmartProxyAccess
+    extend ActiveSupport::Concern
+
+    private
+
+    def require_no_iop_smart_proxy
+      return unless ForemanRhCloud.with_iop_smart_proxy?
+
+      render json: { error: 'Not available when using IoP Smart Proxy' }, status: :not_found
+    end
+
+    def require_iop_smart_proxy
+      return if ForemanRhCloud.with_iop_smart_proxy?
+
+      render json: { error: 'Not available without IoP Smart Proxy' }, status: :not_found
+    end
+  end
+end

--- a/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
@@ -10,7 +10,7 @@ module InsightsCloud
     end
 
     def generate_host_report
-      return unless ForemanRhCloud.with_local_advisor_engine?
+      return unless ForemanRhCloud.with_iop_smart_proxy?
 
       logger.debug("Generating host-specific report for host #{@host.name}")
 

--- a/app/controllers/foreman_inventory_upload/uploads_controller.rb
+++ b/app/controllers/foreman_inventory_upload/uploads_controller.rb
@@ -1,6 +1,9 @@
 module ForemanInventoryUpload
   class UploadsController < ::ApplicationController
     include InventoryUpload::ReportActions
+    include ForemanRhCloud::IopSmartProxyAccess
+
+    before_action :require_no_iop_smart_proxy, only: [:enable_cloud_connector]
 
     def last
       label = ForemanInventoryUpload::Async::UploadReportJob.output_label(params[:organization_id])

--- a/app/controllers/foreman_rh_cloud/foreman_rh_cloud_controller.rb
+++ b/app/controllers/foreman_rh_cloud/foreman_rh_cloud_controller.rb
@@ -1,0 +1,23 @@
+module ForemanRhCloud
+  class ForemanRhCloudController < ApplicationController
+    include ForemanRhCloud::IopSmartProxyAccess
+    layout 'layouts/react_application'
+    skip_before_action :authorize, :only => :index
+
+    before_action :require_no_iop_smart_proxy, only: [:inventory_upload]
+    before_action :require_iop_smart_proxy, only: [:recommendations]
+
+    def index
+      response.headers['X-Request-Path'] = request.path
+      render("react/index", formats: [:html])
+    end
+
+    def inventory_upload
+      index
+    end
+
+    def recommendations
+      index
+    end
+  end
+end

--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -12,7 +12,7 @@ module InsightsCloud::Api
     skip_after_action :log_response_body, :only => [:forward_request]
     skip_before_action :check_media_type, :only => [:forward_request]
     after_action :update_host_insights_status, only: [:forward_request]
-    after_action :update_host_facet, only: [:forward_request], if: -> { ForemanRhCloud.with_local_advisor_engine? }
+    after_action :update_host_facet, only: [:forward_request], if: -> { ForemanRhCloud.with_iop_smart_proxy? }
 
     # The method that "proxies" requests over to Cloud
     def forward_request

--- a/app/services/foreman_rh_cloud/cert_auth.rb
+++ b/app/services/foreman_rh_cloud/cert_auth.rb
@@ -11,7 +11,7 @@ module ForemanRhCloud
 
     def execute_cloud_request(params)
       organization = params.delete(:organization)
-      certs = ForemanRhCloud.with_local_advisor_engine? ? foreman_certificate : candlepin_id_cert(organization)
+      certs = ForemanRhCloud.with_iop_smart_proxy? ? foreman_certificate : candlepin_id_cert(organization)
       final_params = {
         ssl_client_cert: OpenSSL::X509::Certificate.new(certs[:cert]),
         ssl_client_key: OpenSSL::PKey.read(certs[:key]),

--- a/app/services/foreman_rh_cloud/cloud_request.rb
+++ b/app/services/foreman_rh_cloud/cloud_request.rb
@@ -8,7 +8,7 @@ module ForemanRhCloud
         proxy: ForemanRhCloud.transformed_http_proxy_string,
       }.deep_merge(params)
 
-      if ForemanRhCloud.with_local_advisor_engine?
+      if ForemanRhCloud.with_iop_smart_proxy?
         final_params[:ssl_ca_file] ||= ForemanRhCloud.ca_cert
       end
 

--- a/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
+++ b/app/services/foreman_rh_cloud/cloud_request_forwarder.rb
@@ -37,7 +37,7 @@ module ForemanRhCloud
       requested_url = original_request.original_fullpath.end_with?('/') ? original_request.path + '/' : original_request.path
       params = path_params(requested_url)
 
-      if ForemanRhCloud.with_local_advisor_engine?
+      if ForemanRhCloud.with_iop_smart_proxy?
         params[:ssl_ca_file] = ForemanRhCloud.ca_cert
       end
 

--- a/app/services/foreman_rh_cloud/hit_remediations_retriever.rb
+++ b/app/services/foreman_rh_cloud/hit_remediations_retriever.rb
@@ -2,7 +2,7 @@ module ForemanRhCloud
   class HitRemediationsRetriever < RemediationsRetriever
     def initialize(hit_remediation_pairs, logger: Logger.new(IO::NULL))
       super(logger: logger)
-      @is_iop = ForemanRhCloud.with_local_advisor_engine?
+      @is_iop = ForemanRhCloud.with_iop_smart_proxy?
       @hit_remediation_pairs = (hit_remediation_pairs || []).map(&:with_indifferent_access)
       logger.debug("Querying playbook for #{hit_remediation_pairs}")
     end

--- a/app/views/api/v2/hosts/insights/base.rabl
+++ b/app/views/api/v2/hosts/insights/base.rabl
@@ -6,6 +6,6 @@ end
 node :insights_hits_count do |facet|
   facet.hits&.count
 end
-node :use_local_advisor_engine do |_facet|
-  ForemanRhCloud.with_local_advisor_engine?
+node :use_iop_mode do |_facet|
+  ForemanRhCloud.with_iop_smart_proxy?
 end

--- a/app/views/api/v2/hosts/insights/single.rabl
+++ b/app/views/api/v2/hosts/insights/single.rabl
@@ -1,5 +1,5 @@
 node :vulnerability do
   {
-    enabled: ForemanRhCloud.with_local_advisor_engine?,
+    enabled: ForemanRhCloud.with_iop_smart_proxy?,
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,7 @@ Rails.application.routes.draw do
     get 'settings', to: 'uploads_settings#index'
     post 'setting', to: 'uploads_settings#set_advanced_setting'
 
-    unless ForemanRhCloud.with_iop_smart_proxy?
-      post 'cloud_connector', to: 'uploads#enable_cloud_connector'
-    end
+    post 'cloud_connector', to: 'uploads#enable_cloud_connector'
 
     resources :tasks, only: [:create, :show]
 
@@ -35,13 +33,9 @@ Rails.application.routes.draw do
   end
 
   namespace :foreman_rh_cloud do
-    unless ForemanRhCloud.with_iop_smart_proxy?
-      get 'inventory_upload', to: '/react#index'
-    end
-    if ForemanRhCloud.with_iop_smart_proxy?
-      get 'recommendations', to: '/react#index'
-      get 'recommendations/:rule_id', to: '/react#index'
-    end
+    get 'inventory_upload', to: 'foreman_rh_cloud#inventory_upload'
+    get 'recommendations', to: 'foreman_rh_cloud#recommendations'
+    get 'recommendations/:rule_id', to: 'foreman_rh_cloud#recommendations'
     get 'insights_cloud', to: '/react#index' # Uses foreman's react controller
     get 'insights_vulnerability', to: '/react#index'
     get 'insights_vulnerability/:cve_id', to: '/react#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     get 'settings', to: 'uploads_settings#index'
     post 'setting', to: 'uploads_settings#set_advanced_setting'
 
-    unless ForemanRhCloud.with_local_advisor_engine?
+    unless ForemanRhCloud.with_iop_smart_proxy?
       post 'cloud_connector', to: 'uploads#enable_cloud_connector'
     end
 
@@ -35,10 +35,10 @@ Rails.application.routes.draw do
   end
 
   namespace :foreman_rh_cloud do
-    unless ForemanRhCloud.with_local_advisor_engine?
+    unless ForemanRhCloud.with_iop_smart_proxy?
       get 'inventory_upload', to: '/react#index'
     end
-    if ForemanRhCloud.with_local_advisor_engine?
+    if ForemanRhCloud.with_iop_smart_proxy?
       get 'recommendations', to: '/react#index'
       get 'recommendations/:rule_id', to: '/react#index'
     end

--- a/lib/foreman_inventory_upload/async/generate_all_reports_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_all_reports_job.rb
@@ -13,7 +13,7 @@ module ForemanInventoryUpload
           return
         end
 
-        if ForemanRhCloud.with_local_advisor_engine?
+        if ForemanRhCloud.with_iop_smart_proxy?
           plan_self # so that 'run' runs
         else
           after_delay do
@@ -34,7 +34,7 @@ module ForemanInventoryUpload
       end
 
       def run
-        output[:status] = _('The scheduled process is disabled because this Foreman is configured with the use_local_advisor_engine option.') if ForemanRhCloud.with_local_advisor_engine?
+        output[:status] = _('The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy.') if ForemanRhCloud.with_iop_smart_proxy?
       end
 
       def rescue_strategy_for_self

--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -60,7 +60,7 @@ module ForemanInventoryUpload
       end
 
       def certificate
-        ForemanRhCloud.with_local_advisor_engine? ? foreman_certificate : manifest_certificate
+        ForemanRhCloud.with_iop_smart_proxy? ? foreman_certificate : manifest_certificate
       end
 
       def manifest_certificate

--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -253,7 +253,7 @@ module ForemanInventoryUpload
 
       def report_yum_repos(host)
         return unless host&.content_facet&.bound_repositories&.any?
-        return unless ForemanRhCloud.with_local_advisor_engine?
+        return unless ForemanRhCloud.with_iop_smart_proxy?
 
         @stream.array_field('yum_repos') do
           host.content_facet.bound_repositories.each_with_index do |repo, index|

--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -4,13 +4,12 @@ require 'uri'
 
 module ForemanRhCloud
   def self.on_premise_url
-    return unless ForemanRhCloud.with_local_advisor_engine?
-    port = ENV['ADVISOR_ENGINE_PORT'] || "24443"
-    ENV['ADVISOR_ENGINE_URL'] || "https://localhost:#{port}"
+    return unless ForemanRhCloud.with_iop_smart_proxy?
+    ForemanRhCloud.iop_smart_proxy&.url
   end
 
   def self.env_or_on_premise_url(env_var_name)
-    ENV[env_var_name] || on_premise_url
+    on_premise_url || ENV[env_var_name]
   end
 
   def self.base_url
@@ -47,7 +46,7 @@ module ForemanRhCloud
   end
 
   def self.proxy_string
-    return '' if ForemanRhCloud.with_local_advisor_engine?
+    return '' if ForemanRhCloud.with_iop_smart_proxy?
 
     HttpProxy.default_global_content_proxy&.full_url ||
     ForemanRhCloud.global_foreman_proxy ||
@@ -106,7 +105,7 @@ module ForemanRhCloud
   end
 
   def self.legacy_insights_ca
-    "#{ForemanRhCloud::Engine.root}/config/rh_cert-api_chain.pem" unless ForemanRhCloud.with_local_advisor_engine?
+    "#{ForemanRhCloud::Engine.root}/config/rh_cert-api_chain.pem" unless ForemanRhCloud.with_iop_smart_proxy?
   end
 
   def self.cloud_url_validator

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -122,7 +122,8 @@ module ForemanRhCloud
   end
 
   def self.with_iop_smart_proxy?
-    SmartProxy.with_features('iop').exists?
+    return @is_iop unless @is_iop.nil?
+    @is_iop = SmartProxy.with_features('iop').exists?
   end
 
   def self.iop_smart_proxy

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -121,8 +121,12 @@ module ForemanRhCloud
     end
   end
 
-  def self.with_local_advisor_engine?
-    SETTINGS.dig(:foreman_rh_cloud, :use_local_advisor_engine) || false
+  def self.with_iop_smart_proxy?
+    SmartProxy.with_features('iop').exists?
+  end
+
+  def self.iop_smart_proxy
+    SmartProxy.with_features('iop').first
   end
 
   def self.ca_cert

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -95,7 +95,7 @@ module ForemanRhCloud
             url: '/foreman_rh_cloud/insights_vulnerability',
             url_hash: { controller: :react, action: :index },
             parent: :insights_menu,
-            if: -> { ForemanRhCloud.with_local_advisor_engine? }
+            if: -> { ForemanRhCloud.with_iop_smart_proxy? }
         end
 
         register_facet InsightsFacet, :insights do

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -48,6 +48,7 @@ module ForemanRhCloud
             'foreman_inventory_upload/uploads_settings': [:index],
             'foreman_inventory_upload/missing_hosts': [:index],
             'api/v2/rh_cloud/advisor_engine_config': [:show],
+            'foreman_rh_cloud/foreman_rh_cloud': [:inventory_upload, :recommendations],
             'react': [:index]
           )
           permission(

--- a/lib/insights_cloud/async/insights_scheduled_sync.rb
+++ b/lib/insights_cloud/async/insights_scheduled_sync.rb
@@ -13,7 +13,7 @@ module InsightsCloud
           return
         end
 
-        if ForemanRhCloud.with_local_advisor_engine?
+        if ForemanRhCloud.with_iop_smart_proxy?
           plan_self
         else
           after_delay do
@@ -23,7 +23,7 @@ module InsightsCloud
       end
 
       def run
-        output[:status] = _('The scheduled process is disabled because this Foreman is configured with the use_local_advisor_engine option.') if ForemanRhCloud.with_local_advisor_engine?
+        output[:status] = _('The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy.') if ForemanRhCloud.with_iop_smart_proxy?
       end
 
       def plan_full_sync

--- a/lib/inventory_sync/async/inventory_hosts_sync.rb
+++ b/lib/inventory_sync/async/inventory_hosts_sync.rb
@@ -9,7 +9,7 @@ module InventorySync
 
       def plan(organizations)
         # Do not run for local advisor, since we use sub-man id to identify hosts.
-        return if ForemanRhCloud.with_local_advisor_engine?
+        return if ForemanRhCloud.with_iop_smart_proxy?
         # by default the tasks will be executed concurrently
         super(organizations)
         plan_self_host_sync

--- a/lib/inventory_sync/async/inventory_scheduled_sync.rb
+++ b/lib/inventory_sync/async/inventory_scheduled_sync.rb
@@ -13,7 +13,7 @@ module InventorySync
           return
         end
 
-        if ForemanRhCloud.with_local_advisor_engine?
+        if ForemanRhCloud.with_iop_smart_proxy?
           plan_self # so that 'run' runs
         else
           after_delay do
@@ -35,7 +35,7 @@ module InventorySync
       end
 
       def run
-        output[:status] = _('The scheduled process is disabled because this Foreman is configured with the use_local_advisor_engine option.') if ForemanRhCloud.with_local_advisor_engine?
+        output[:status] = _('The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy.') if ForemanRhCloud.with_iop_smart_proxy?
       end
 
       def plan_remove_insights_hosts(org_id)

--- a/lib/tasks/insights.rake
+++ b/lib/tasks/insights.rake
@@ -24,7 +24,7 @@ namespace :rh_cloud_insights do
   desc "Re-announce all organizations into Sources on RH cloud."
   task announce_to_sources: [:environment] do
     logger = Logging::Logger.new(STDOUT)
-    if ForemanRhCloud.with_local_advisor_engine?
+    if ForemanRhCloud.with_iop_smart_proxy?
       logger.warn('Task announce_to_sources is not available when using local advisor engine')
     else
       Organization.unscoped.each do |org|

--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -46,7 +46,7 @@ namespace :rh_cloud_inventory do
           archived_report_generator.render(organization: organization, filter: filter)
           puts "Successfully generated #{target} for organization id #{organization}"
 
-          next unless ForemanRhCloud.with_local_advisor_engine?
+          next unless ForemanRhCloud.with_iop_smart_proxy?
 
           puts 'Creating missing insights facets'
           hosts_without_facets = ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: 'null? insights_uuid')

--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -9,7 +9,7 @@ namespace :rh_cloud_inventory do
       else
         organizations = [Organization.where(:id => ENV['organization_id']).first]
       end
-      disconnected = ForemanRhCloud.with_local_advisor_engine?
+      disconnected = ForemanRhCloud.with_iop_smart_proxy?
       User.as_anonymous_admin do
         organizations.each do |organization|
           ForemanTasks.async_task(
@@ -71,7 +71,7 @@ namespace :rh_cloud_inventory do
       base_folder = ENV['target'] || ForemanInventoryUpload.generated_reports_folder
       organization_id = ENV['organization_id']
       report_file = ForemanInventoryUpload.facts_archive_name(organization_id)
-      disconnected = ForemanRhCloud.with_local_advisor_engine?
+      disconnected = ForemanRhCloud.with_iop_smart_proxy?
       ForemanTasks.sync_task(ForemanInventoryUpload::Async::QueueForUploadJob, base_folder, report_file, organization_id, disconnected)
       puts "Uploaded #{report_file}"
     end

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -154,7 +154,7 @@ module InsightsCloud::Api
 
       test "should create insights facet" do
         assert_nil InsightsFacet.find_by(host_id: @host.id)
-        ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(true)
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
         req = RestClient::Request.new(:method => 'GET', :url => 'http://test.theforeman.org/')
         net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
         net_http_resp[:content_type] = 'application/zip'

--- a/test/controllers/insights_sync/settings_controller_test.rb
+++ b/test/controllers/insights_sync/settings_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_plugin_helper'
 class SettingsControllerTest < ActionController::TestCase
   tests InsightsCloud::SettingsController
   def setup
-    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(false)
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
   end
 
   test 'should return allow_auto_insights_sync setting' do

--- a/test/jobs/inventory_scheduled_sync_test.rb
+++ b/test/jobs/inventory_scheduled_sync_test.rb
@@ -14,14 +14,14 @@ class InventoryScheduledSyncTest < ActiveSupport::TestCase
     ForemanTasks.sync_task(InventorySync::Async::InventoryScheduledSync)
   end
 
-  test 'Skips execution if with_local_advisor_engine? is true' do
-    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(true)
+  test 'Skips execution if with_iop_smart_proxy? is true' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
 
     InventorySync::Async::InventoryScheduledSync.any_instance.expects(:plan_org_sync).never
 
     task = ForemanTasks.sync_task(InventorySync::Async::InventoryScheduledSync)
     status = task.output[:status].to_s
-    assert_match(/Foreman is configured with the use_local_advisor_engine option/, status)
+    assert_match(/Foreman is configured with a local IoP Smart Proxy/, status)
   end
 
   test 'Skips execution if auto upload is disabled' do

--- a/test/unit/rh_cloud_http_proxy_test.rb
+++ b/test/unit/rh_cloud_http_proxy_test.rb
@@ -4,7 +4,7 @@ class RhCloudHttpProxyTest < ActiveSupport::TestCase
   setup do
     @global_content_proxy_mock = 'http://global:content@localhost:80'
     @global_foreman_proxy_mock = 'http://global:foreman@localhost:80'
-    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(false)
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
   end
 
   test 'selects global content proxy' do
@@ -20,8 +20,8 @@ class RhCloudHttpProxyTest < ActiveSupport::TestCase
   end
 
   test 'returns empty string in on-prem setup' do
-    ForemanRhCloud.unstub(:with_local_advisor_engine?)
-    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(true)
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
 
     assert_empty ForemanRhCloud.proxy_setting
   end

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -999,7 +999,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
   end
 
   test 'reports yum repos' do
-    ForemanRhCloud.stubs(:with_local_advisor_engine?).returns(true)
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
     FactoryBot.create(:katello_content, cp_content_id: '1', organization: @host.organization, name: 'Test Content', label: 'test-content')
     repo = FactoryBot.build(
       :katello_repository,

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -132,7 +132,7 @@ const InsightsTab = props => {
   const { response } = props;
   const isLocalAdvisorEngine =
     // eslint-disable-next-line camelcase
-    response?.insights_attributes?.use_local_advisor_engine;
+    response?.insights_attributes?.use_iop_mode;
 
   return isLocalAdvisorEngine ? (
     <IopInsightsTabWrapped {...props} />
@@ -144,7 +144,7 @@ const InsightsTab = props => {
 InsightsTab.propTypes = {
   response: PropTypes.shape({
     insights_attributes: {
-      use_local_advisor_engine: PropTypes.bool,
+      use_iop_mode: PropTypes.bool,
     },
   }),
 };

--- a/webpack/common/Hooks/ConfigHooks.js
+++ b/webpack/common/Hooks/ConfigHooks.js
@@ -14,6 +14,5 @@ export const useAdvisorEngineConfig = () => {
   );
 
   // eslint-disable-next-line camelcase
-  const isLocalAdvisorEngine = advisorEngineConfig?.use_local_advisor_engine;
-  return isLocalAdvisorEngine;
+  return advisorEngineConfig?.use_iop_mode;
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Replace configuration-based IoP detection with SmartProxy feature detection. The system now automatically detects Insights on Premise mode by checking for SmartProxy instances with the 'Insights' feature instead of relying on environment variables and settings.

#### Considerations taken when implementing this change?
The main goal was to preserve backward compatibility while moving from static environment variable configuration to dynamic detection based on SmartProxy settings. Instead of relying on manually set ENV vars, the system now determines IoP mode by querying the SmartProxy, which improves accuracy and makes it easier to maintain.
There's a small trade-off in performance (a DB query instead of reading a cached variable), but it removes the need for operational ENV management. Renaming the API field from `use_local_advisor_engine` to `use_iop_mode` makes the purpose clearer.

I'm still considering whether to keep the `with_local_advisor_engine?` method and mark it as deprecated, mainly to ensure older code paths continue to work during the transition.

#### What are the testing steps for this pull request?
1. Add Smart Proxy with Insights feature:
   * URL: `https://localhost:24443`
   * Ensure **Insights** is enabled.
2. UI menu checks (based on IoP mode):
   * Insights → Vulnerability: should be **visible** if IoP mode is **enabled**.
3. Host details:
   * Go to any host page.
   * **Vulnerabilities tab** should load correctly.

## Summary by Sourcery

Replace static local advisor engine configuration with dynamic SmartProxy-based IoP detection and rename relevant flags, updating all routes, controllers, services, jobs, views, tests, and front end components accordingly.

New Features:
- Add with_iop_smart_proxy? and iop_smart_proxy methods for automatic SmartProxy feature detection
- Introduce ForemanRhCloudController and IopSmartProxyAccess concern to guard actions based on IoP SmartProxy presence

Enhancements:
- Remove use_local_advisor_engine setting and environment variable checks in favor of SmartProxy feature checks across routes, services, generators, and rake tasks
- Rename API, RABL, and front end attribute use_local_advisor_engine to use_iop_mode
- Simplify routing to always expose cloud connector, inventory_upload, and recommendations endpoints

Tests:
- Update tests to stub with_iop_smart_proxy? and assert messaging and behavior reflecting new IoP SmartProxy detection