### PR TITLE
Fix bottom margin styling issues in Advisor and Vulnerability

### DIFF
--- a/webpack/ForemanRhCloudPages.js
+++ b/webpack/ForemanRhCloudPages.js
@@ -8,6 +8,7 @@ import InsightsCloudSync from './InsightsCloudSync';
 import IopRecommendationDetails from './IopRecommendationDetails/IopRecommendationDetails';
 import InsightsHostDetailsTab from './InsightsHostDetailsTab';
 import CveDetailsPage from './CveDetailsPage';
+import './common/styles.scss';
 
 const pages = [
   { name: 'ForemanInventoryUpload', type: ForemanInventoryUpload },

--- a/webpack/common/styles.scss
+++ b/webpack/common/styles.scss
@@ -1,0 +1,7 @@
+// overwrite bootstrap style which added unintended bottom margins to chips
+// and dropdowns in Advisor and Vulnerability
+.vulnerability, .advisor {
+  ul, ol {
+    margin-bottom: 0px;
+  }
+}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fix the additional bottom margin in chips and dropdowns:

<img width="373" height="129" alt="image" src="https://github.com/user-attachments/assets/2ff31424-4cae-40f9-8e81-0b90c667c6d6" />

<img width="367" height="380" alt="image" src="https://github.com/user-attachments/assets/af808621-dcba-414c-b096-bd5364b013f3" />

<img width="458" height="182" alt="image" src="https://github.com/user-attachments/assets/c2967785-8258-460a-a1de-8d6a167e5c0a" />

#### Considerations taken when implementing this change?
--

#### What are the testing steps for this pull request?

Check toolbars in Vulnerability and Advisor pages -- they should not have bottom margins shown in screenshots above.


---

Feel free to suggest another place to store the styles, but since they apply to multiple pages it didn't make sense to me to store duplicate stylesheets next to individual page files.

---

## Summary by Sourcery

Fix unintended bottom margins in Advisor and Vulnerability by adding and importing a shared stylesheet that overrides Bootstrap list margins

Bug Fixes:
- Remove unintended bottom margins from ul and ol elements in Advisor and Vulnerability UI

Enhancements:
- Import the common stylesheet in ForemanRhCloudPages to apply the style overrides