### PR TITLE
Correctly checks for iop features in a smartproxy

### DIFF
--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -122,11 +122,11 @@ module ForemanRhCloud
   end
 
   def self.with_iop_smart_proxy?
-    SmartProxy.with_features('iop').exists?
+    SmartProxy.unscoped.with_features('iop').exists?
   end
 
   def self.iop_smart_proxy
-    SmartProxy.with_features('iop').first
+    SmartProxy.unscoped.with_features('iop').first
   end
 
   def self.ca_cert


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The plugin.rb in foreman checks for IoP before the taxonomies are set. This means iops calls in plugin.rb will always have be false (since the smart proxy is scoped by taxonomy).
This PR tries to address that marking those checks as unscoped.

#### What are the testing steps for this pull request?
Setup an IoP environment

Before PR

- "Vulnerability" and "Inventory upload"  menu items will be hidden

After PR

- "Vulnerability" and "Inventory upload"  menu items should be available




## Summary by Sourcery

Use unscoped queries when checking for IoP features in smart proxy helper methods to avoid false negatives caused by taxonomy scoping.

Bug Fixes:
- Modify with_iop_smart_proxy? to use SmartProxy.unscoped for IoP feature checks.
- Update iop_smart_proxy to use SmartProxy.unscoped when retrieving a smart proxy with IoP features.