### PR TITLE
Fixed whitelisted paths

### DIFF
--- a/app/services/foreman_rh_cloud/insights_api_forwarder.rb
+++ b/app/services/foreman_rh_cloud/insights_api_forwarder.rb
@@ -5,13 +5,13 @@ module ForemanRhCloud
     include ForemanRhCloud::GatewayRequest
 
     SCOPED_REQUESTS = [
-      %r{/api/vulnerability/v1/vulnerabilities/cves},
-      %r{/api/vulnerability/v1/dashbar},
-      %r{/api/vulnerability/v1/cves/[^/]+/affected_systems},
-      %r{/api/vulnerability/v1/systems/[^/]+/cves},
-      %r{/api/insights/.*},
-      %r{/api/inventory/.*},
-      %r{/api/tasks/.*},
+      { test: %r{api/vulnerability/v1/vulnerabilities/cves}, tag_name: :tags },
+      { test: %r{api/vulnerability/v1/dashbar}, tag_name: :tags },
+      { test: %r{api/vulnerability/v1/cves/[^/]+/affected_systems}, tag_name: :tags },
+      { test: %r{api/vulnerability/v1/systems/[^/]+/cves}, tag_name: :tags },
+      { test: %r{api/insights/.*}, tag_name: :tags },
+      { test: %r{api/inventory/.*}, tag_name: :tags },
+      { test: %r{api/tasks/.*}, tag_name: :tags },
     ].freeze
 
     def forward_request(original_request, path, controller_name, user, organization, location)
@@ -31,10 +31,10 @@ module ForemanRhCloud
       execute_cloud_request(request_opts)
     end
 
-    def prepare_tags(user, organization, location)
+    def prepare_tags(user, organization, location, tag_name)
       [
         TagsAuth.auth_tag_for(user, organization, location),
-      ].map { |tag_value| [:tag, tag_value] }
+      ].map { |tag_value| [tag_name, tag_value] }
     end
 
     def prepare_request_opts(original_request, path, forward_payload, forward_params)
@@ -70,7 +70,8 @@ module ForemanRhCloud
     def prepare_forward_params(original_request, path, user:, organization:, location:)
       forward_params = original_request.query_parameters.to_a
 
-      forward_params += prepare_tags(user, organization, location) if scope_request?(original_request, path)
+      tag_name = scope_request?(original_request, path)
+      forward_params += prepare_tags(user, organization, location, tag_name) if tag_name
 
       forward_params
     end
@@ -92,9 +93,10 @@ module ForemanRhCloud
     end
 
     def scope_request?(original_request, path)
-      return false unless original_request.get?
+      return nil unless original_request.get?
 
-      SCOPED_REQUESTS.any? { |request_pattern| request_pattern.match?(path) }
+      request_pattern = SCOPED_REQUESTS.find { |pattern| pattern[:test].match?(path) }
+      request_pattern[:tag_name] if request_pattern
     end
 
     def core_app_name

--- a/app/services/foreman_rh_cloud/tags_auth.rb
+++ b/app/services/foreman_rh_cloud/tags_auth.rb
@@ -22,15 +22,16 @@ module ForemanRhCloud
     def update_tag
       logger.debug("Updating tags for user: #{@user}, org: #{@org.name}, loc: #{@loc.name}")
 
+      payload = tags_query_payload
       params = {
         method: :post,
         url: "#{InsightsCloud.gateway_url}/tags",
         headers: {
           content_type: :json,
         },
-        payload: tags_query_payload.to_json,
+        payload: payload.to_json,
       }
-      execute_cloud_request(params)
+      execute_cloud_request(params) unless payload[:host_id_list].empty?
     end
 
     def allowed_hosts

--- a/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
@@ -32,7 +32,7 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
       actual = actual_params[:headers][:params]
-      assert_equal "U:\"#{@user.login}\"O:\"#{@organization.name}\"L:\"#{@location.name}\"", tag_value(actual.find { |param| param[0] == :tag && tag_name(param[1]) =~ /#{ForemanRhCloud::TagsAuth::TAG_NAME}/ }[1])
+      assert_equal "U:\"#{@user.login}\"O:\"#{@organization.name}\"L:\"#{@location.name}\"", tag_value(actual.find { |param| param[0] == :tags && tag_name(param[1]) =~ /#{ForemanRhCloud::TagsAuth::TAG_NAME}/ }[1])
       true
     end
 
@@ -82,7 +82,7 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
       actual = actual_params[:headers][:params]
-      assert_equal "U:\"#{@user.login}\"O:\"#{@organization.name}\"L:\"#{@location.name}\"", tag_value(actual.find { |param| param[0] == :tag && tag_name(param[1]) =~ /#{ForemanRhCloud::TagsAuth::TAG_NAME}/ }[1])
+      assert_equal "U:\"#{@user.login}\"O:\"#{@organization.name}\"L:\"#{@location.name}\"", tag_value(actual.find { |param| param[0] == :tags && tag_name(param[1]) =~ /#{ForemanRhCloud::TagsAuth::TAG_NAME}/ }[1])
       assert_equal 5, actual.find { |param| param[0] == :page }[1]
       assert_equal 42, actual.find { |param| param[0] == :per_page }[1]
       true
@@ -158,6 +158,47 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
 
     # This test asserts the parameters that are sent to the execute_cloud_request method.
     # This is done by setting the expectation before the actual call.
+  end
+
+  test 'scope_request? should return tag_name for scoped requests' do
+    get_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/v1/vulnerabilities/cves',
+      'REQUEST_METHOD' => 'GET',
+      'rack.input' => ::Puma::NullIO.new
+    )
+
+    result = @forwarder.send(:scope_request?, get_req, 'api/vulnerability/v1/vulnerabilities/cves')
+    assert_equal :tags, result
+  end
+
+  test 'scope_request? should return nil for non-GET requests' do
+    post_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/v1/cves',
+      'REQUEST_METHOD' => 'POST',
+      'rack.input' => ::Puma::NullIO.new
+    )
+
+    result = @forwarder.send(:scope_request?, post_req, '/api/vulnerability/v1/cves')
+    assert_nil result
+  end
+
+  test 'scope_request? should return nil for unmatched paths' do
+    get_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/unmatched/path',
+      'REQUEST_METHOD' => 'GET',
+      'rack.input' => ::Puma::NullIO.new
+    )
+
+    result = @forwarder.send(:scope_request?, get_req, '/api/unmatched/path')
+    assert_nil result
+  end
+
+  test 'prepare_tags should use provided tag_name' do
+    result = @forwarder.send(:prepare_tags, @user, @organization, @location, :custom_tag)
+
+    assert_equal 1, result.length
+    assert_equal :custom_tag, result[0][0]
+    assert_equal "U:\"#{@user.login}\"O:\"#{@organization.name}\"L:\"#{@location.name}\"", tag_value(result[0][1])
   end
 
   def tag_value(param_value)

--- a/test/unit/services/foreman_rh_cloud/tags_auth_test.rb
+++ b/test/unit/services/foreman_rh_cloud/tags_auth_test.rb
@@ -10,7 +10,7 @@ class TagsAuthTest < ActiveSupport::TestCase
     @auth = ::ForemanRhCloud::TagsAuth.new(@user, @org, @loc, @logger)
   end
 
-  test 'Generates tags update request' do
+  test 'Generates tags update request when hosts are present' do
     uuid1 = 'test_uuid1'
     uuid2 = 'test_uuid2'
 
@@ -23,6 +23,20 @@ class TagsAuthTest < ActiveSupport::TestCase
       assert_equal ForemanRhCloud::TagsAuth::TAG_NAMESPACE, actual['tags'].first['namespace']
       assert_equal "U:\"#{@user.login}\"O:\"#{@org.name}\"L:\"#{@loc.name}\"", actual['tags'].first['value']
     end
+
+    @auth.update_tag
+  end
+
+  test 'Should not execute cloud request when no hosts are present' do
+    @auth.expects(:allowed_hosts).returns([])
+    @auth.expects(:execute_cloud_request).never
+
+    @auth.update_tag
+  end
+
+  test 'Should not execute cloud request when allowed_hosts is nil' do
+    @auth.expects(:allowed_hosts).returns(nil)
+    @auth.expects(:execute_cloud_request).never
 
     @auth.update_tag
   end


### PR DESCRIPTION
- Now the paths are properly recognized.
- Fixed top correct parameter names (tags instead of tag)
- Fixed an edge case where no hosts were present

#### What are the testing steps for this pull request?
Make sure that no hosts are present for empty org
Make sure hosts are displayed if the org is not empty

## Summary by Sourcery

Enhance API request forwarding by mapping whitelisted paths to dynamic tag parameters, update the default tag key to :tags, and prevent unnecessary tag update calls when no hosts exist.

Bug Fixes:
- Fix forwarded parameter key from :tag to :tags
- Ensure whitelisted paths are correctly recognized

Enhancements:
- Refactor SCOPED_REQUESTS to associate each path pattern with a custom tag_name
- Update prepare_tags and scope_request? to use the dynamic tag_name for scoped GET requests
- Skip executing the cloud tag update request when the host_id_list is empty

Tests:
- Adjust existing tests to expect :tags instead of :tag
- Add unit tests for scope_request? behavior (GET vs non-GET and unmatched paths)
- Add tests for prepare_tags with a custom tag_name
- Add tests to verify update_tag skips the cloud request when no hosts are present