### PR TITLE
Update to new name of API node for useIopMode

### DIFF
--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -46,7 +46,7 @@ const RecommendationsCell = hostDetails => {
     hostDetails?.insights_attributes ?? {}
   );
 
-  return insightsAttributes.useLocalAdvisorEngine ? (
+  return insightsAttributes.useIopMode ? (
     <IopRecommendationsCell hostDetails={hostDetails} />
   ) : (
     <HostedRecommendationsCell hostDetails={hostDetails} />


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Since https://github.com/theforeman/foreman_rh_cloud/pull/1049, the All Hosts page Recommendations column displays '-' even if a host has recommendations.

It's because the name of the API response node changed from `use_local_advisor_engine` to `use_iop_mode` and we didn't catch it via grep because I used `propsToCamelCase`.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Set up IoP with hosts with recommendations
2. Go to Hosts - All Hosts and add the Recommendations column
3. verify that the numbers of recommendations are correct
4. verify that 'HostedRecommendationsCell' does not appear in the React tree when in IoP mode

## Summary by Sourcery

Enhancements:
- Rename insights attribute useLocalAdvisorEngine to useIopMode for selecting the appropriate recommendations cell