### PR TITLE
Rename Insights tab to Recommendations

### DIFF
--- a/webpack/ForemanRhCloudFills.js
+++ b/webpack/ForemanRhCloudFills.js
@@ -21,7 +21,7 @@ const fills = [
     weight: 400,
     metadata: {
       hideTab: isNotRhelHost,
-      title: __('Insights'),
+      title: __('Recommendations'),
     },
   },
   {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Rename the host details 'Insights' tab to 'Recommendations.' This applies to both iop and hosted configurations.

Downstream, 'Insights' is translated to 'Red Hat Lightspeed,' so for IoP we have 'Red Hat Lightspeed' and 'Vulnerabilities' tabs alongside each other. This is incorrect because 'Red Hat Lightspeed' is the parent product for both Advisor (Recommendations) and Vulnerability services. Changing the tab title to 'Recommendations' will result in consistent tab naming - 'Recommendations' both upstream and downstream, and tabs reflect the same category of thing (object names) - 'Recommmendations' / 'Vulnerabilities'.

#### Considerations taken when implementing this change?

This is per the original mocks.

QE will need to adjust automations.

#### What are the testing steps for this pull request?

ensure tests are green

## Summary by Sourcery

Enhancements:
- Update ForemanRhCloudFills tab title from "Insights" to "Recommendations"