### PR TITLE
Do not modify resolution_id unless isIoP

### DIFF
--- a/webpack/InsightsCloudSync/Components/RemediationModal/RemediationHelpers.js
+++ b/webpack/InsightsCloudSync/Components/RemediationModal/RemediationHelpers.js
@@ -3,8 +3,10 @@ import React from 'react';
 import { orderBy } from 'lodash';
 import Resolutions from './Resolutions';
 
-export const getResolutionId = (selectedResolution, id) =>
-  `${id}_${selectedResolution}`;
+export const getResolutionId = (selectedResolution, id, isIop = true) => {
+  if (isIop) return `${id}_${selectedResolution}`;
+  return selectedResolution;
+};
 
 export const modifyRows = (
   remediations,
@@ -25,20 +27,26 @@ export const modifyRows = (
     const selectedResolution = resolutions[0]?.id;
     /* eslint-disable spellcheck/spell-checker */
 
-    // For IoP: {
-    //  hit_id: "c7c6727e-2966-4f7c-87f1-20ef14db7a2d",
+    // For IoP:
+    // All of the values will be plain strings
+    // {
+    //  hit_id: "c7c6727e-2966-4f7c-87f1-20ef14db7a2d", <-- this refers to a host by insights ID
     //  rule_id: "hardening_ssh_client_alive|OPENSSH_HARDENING_CLIENT_ALIVE",
     //  resolution_type: "less_secure",
-    //  resolution_id:"hardening_ssh_client_alive|OPENSSH_HARDENING_CLIENT_ALIVE_less_secure",
+    //  resolution_id:"hardening_ssh_client_alive|OPENSSH_HARDENING_CLIENT_ALIVE_less_secure", <-- joined rule id and resolution type
     // }
-    // for Hosted, hit_id and rule_id will be Foreman database IDs
+    // For non-IoP:
+    // All of the values will be numeric Foreman database IDs
+    // hit_id refers to an InsightsHit
+    // rule_id refers to an InsightsRule
+    // resolution_type and resolution_id both refer to an InsightsResolution (InsightsHit.find(xx).rule.resolutions)
 
     /* eslint-enable spellcheck/spell-checker */
     resolutionToSubmit.push({
       hit_id: isIop ? host_id : id,
       rule_id: id,
       resolution_type: selectedResolution /** defaults to the first resolution if many */,
-      resolution_id: getResolutionId(selectedResolution, id),
+      resolution_id: getResolutionId(selectedResolution, id, isIop),
     });
     return {
       cells: [


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

In non-IoP remediations, a regression was introduced recently that causes

```
'Error during rendering of a job template' error (NoMethodError): undefined method `[]' for nil:NilClass
```

This is because our new `getResolutionId` function has changed behavior and causes the hash lookup here to fail --> https://github.com/theforeman/foreman_rh_cloud/blob/5d433f499ab907ad9aa3fd945f08f92841baff44/app/services/foreman_rh_cloud/hit_remediations_retriever.rb#L58

Changing it back to the previous behavior in non-IoP configurations seems to resolve it.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

On develop branch:
Get a host with a remediation that has 2 or more remediation options
Click Remediate to bring up the modal, but do not click any of the radio buttons -- immediately click the Remediate button to submit
In the REX job inputs, notice the `resolution_id` has two joined numbers, such as "27_28". The template rendering will fail with the NilClass error.

In contrast:
Click Remediate to bring up the modal
Click the second radio button, and then click the first again
Submit
You'd think this should produce the same result, but it doesn't. The input shows an unjoined number (such as "27") and the template rendering succeeds.

After checking out this PR, running the former (first) flow above should also succeed.

## Summary by Sourcery

Bug Fixes:
- Prevent resolution_id from being prefixed with the rule ID when isIop is false by introducing an isIop parameter to getResolutionId and passing it through modifyRows

## Summary by Sourcery

Prevent resolution_id from being prefixed with the rule ID for non-IoP remediations by introducing an isIop flag in getResolutionId and passing it through modifyRows.

Bug Fixes:
- Restore previous resolution_id format for non-IoP remediation flows to prevent nil lookup errors during template rendering

Enhancements:
- Add an isIop flag to getResolutionId and propagate it through modifyRows to control resolution_id formatting