### PR TITLE
Add auto release for v10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+---
+name: Release
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: Release gem
+    runs-on: ubuntu-latest
+    environment: release
+    if: github.repository_owner == 'theforeman'
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: voxpupuli/ruby-release@v0


### PR DESCRIPTION
## Summary by Sourcery

Add GitHub Actions workflow to automate gem releases on tag pushes

CI:
- Introduce a release workflow that triggers on tag pushes and runs voxpupuli/ruby-release with id-token permissions
- Restrict the workflow to run only when the repository owner is 'theforeman'