### PR TITLE
SAT-36223 - Add yum repos to report for iop and hosted

### DIFF
--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -253,7 +253,6 @@ module ForemanInventoryUpload
 
       def report_yum_repos(host)
         return unless host&.content_facet&.bound_repositories&.any?
-        return unless ForemanRhCloud.with_iop_smart_proxy?
 
         @stream.array_field('yum_repos') do
           host.content_facet.bound_repositories.each_with_index do |repo, index|

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -999,7 +999,6 @@ class SliceGeneratorTest < ActiveSupport::TestCase
   end
 
   test 'reports yum repos' do
-    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
     FactoryBot.create(:katello_content, cp_content_id: '1', organization: @host.organization, name: 'Test Content', label: 'test-content')
     repo = FactoryBot.build(
       :katello_repository,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Add yum repos to slice regardless of iop or hosted for Vulnerability service in HCC without connecting all of their systems with RHC/insights-client for full analytics

#### Considerations taken when implementing this change?

* Made sure it works with IOP and hosted

#### What are the testing steps for this pull request?

* Check out PR
* Register a client and have content synchronized and the client have a sub/content_facet
* Generate the report and see if the repos are present in the report.

## Summary by Sourcery

Always report yum_repos in the slice

New Features:
- Include bound yum repositories in the inventory slice for all hosts with content_facet, independent of IOP or hosted configuration

Tests:
- Remove IOP-specific stub from slice generator test to reflect unconditional yum_repos reporting