### PR TITLE
Use page-unique ID for Resolutions Radio components

### DIFF
--- a/webpack/InsightsCloudSync/Components/RemediationModal/Resolutions.js
+++ b/webpack/InsightsCloudSync/Components/RemediationModal/Resolutions.js
@@ -22,7 +22,7 @@ const Resolutions = ({
           key={resolution_id}
           ouiaId={`resolution-radio-${resolution_id}`}
           className="resolution-radio"
-          id={resolution_id}
+          id={`${hit_id}_${resolution_id}`}
           isChecked={resolution_id === checkedID}
           onChange={() =>
             setResolutions(stateRes =>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Modify the `id` for the `Radio` component inside `<Resolutions>` so that it's unique on the page. Not having a unique ID was causing a weird behavior: Because a Radio is composed of an `<input>` with `id`, and a `<label>` with `for=` attribute referencing the `id` of the `<input>`, clicking the label of the radio was causing the wrong input to change state.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Get 2 hosts with the same available remediation - chmod 777 /etc/ssh/sshd_config
Run insights-client on the hosts and then sync recommendations
Select both hosts and bring up the remediation modal
There will be two groups of radio buttons, one for each host.
On the second host, select the second radio __by clicking its label__. (You won't reproduce by clicking the radio button / circle directly.)

Before: The radio state changes for the first host, which is incorrect.
After: The radio state changes for the radio whose label you clicked.

## Summary by Sourcery

Make radio input IDs in the Resolutions component unique by including the host identifier, fixing incorrect input selection when clicking labels across multiple radio groups.

Bug Fixes:
- Prevent label clicks from toggling the wrong radio input when multiple hosts share the same remediation options.

Enhancements:
- Prefix each resolution radio’s id with its host’s hit_id to ensure uniqueness on the page.