### PR TITLE
Fix the upload URL to follow the iop scheme if present

### DIFF
--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -58,7 +58,7 @@ module ForemanInventoryUpload
 
   def self.upload_url
     # for testing set ENV to 'https://ci.cloud.redhat.com/api/ingress/v1/upload'
-    @upload_url ||= ENV['SATELLITE_INVENTORY_UPLOAD_URL'] || 'https://cert.cloud.redhat.com/api/ingress/v1/upload'
+    ENV['SATELLITE_INVENTORY_UPLOAD_URL'] || "#{ForemanRhCloud.cert_base_url}/api/ingress/v1/upload"
   end
 
   def self.slice_size


### PR DESCRIPTION
Make sure the upload URL follows the IoP endpoint, if present

## Summary by Sourcery

Enhancements:
- Update upload_url to use ForemanRhCloud.cert_base_url for the default endpoint instead of a hardcoded URL and remove memoization