### PR TITLE
Add VMaaS reposcan sync task for repository sync

### DIFF
--- a/lib/insights_cloud.rb
+++ b/lib/insights_cloud.rb
@@ -44,4 +44,8 @@ module InsightsCloud
   def self.enable_cloud_remediations_param
     'enable_cloud_remediations'
   end
+
+  def self.vmaas_reposcan_sync_url
+    ForemanRhCloud.iop_smart_proxy.url + '/api/vmaas-reposcan/sync'
+  end
 end

--- a/lib/insights_cloud/async/vmaas_reposcan_sync.rb
+++ b/lib/insights_cloud/async/vmaas_reposcan_sync.rb
@@ -1,0 +1,71 @@
+require 'rest-client'
+
+module InsightsCloud
+  module Async
+    # Triggers VMaaS reposcan sync via IoP gateway when repositories are synced
+    class VmaasReposcanSync < ::Actions::EntryAction
+      include ::ForemanRhCloud::CertAuth
+
+      # Subscribe to Katello repository sync hook action, if available
+      def self.subscribe
+        'Actions::Katello::Repository::SyncHook'.constantize
+      rescue NameError
+        Rails.logger.debug('VMaaS reposcan sync: Repository::SyncHook action not found')
+        nil
+      end
+
+      def plan(repo, *_args)
+        return unless ::ForemanRhCloud.with_iop_smart_proxy?
+
+        repo_id = repo.is_a?(Hash) ? (repo[:id] || repo['id']) : nil
+        unless repo_id
+          logger.error("VMaaS reposcan sync: missing repository id in SyncHook plan parameters: #{repo.inspect}")
+          return
+        end
+
+        plan_self
+      end
+
+      def run
+        url = ::InsightsCloud.vmaas_reposcan_sync_url
+
+        response = execute_cloud_request(
+          method: :put,
+          url: url,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+        if response.code >= 200 && response.code < 300
+          message = "VMaaS reposcan sync triggered successfully: #{response.code}"
+          logger.info(message)
+        else
+          message = "VMaaS reposcan sync failed with status: #{response.code}, body: #{response.body}"
+          logger.error(message)
+        end
+        output[:message] = message
+
+        response
+      rescue RestClient::ExceptionWithResponse => e
+        message = "VMaaS reposcan sync failed: #{e.response&.code} - #{e.response&.body}"
+        logger.error(message)
+        output[:message] = message
+        raise
+      rescue StandardError => e
+        message = "Error triggering VMaaS reposcan sync: #{e.message}, response: #{e.respond_to?(:response) ? e.response : nil}"
+        logger.error(message)
+        output[:message] = message
+        raise
+      end
+
+      def rescue_strategy_for_self
+        Dynflow::Action::Rescue::Skip
+      end
+
+      private
+
+      def logger
+        action_logger
+      end
+    end
+  end
+end

--- a/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
+++ b/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
@@ -1,0 +1,137 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class VmaasReposcanSyncTest < ActiveSupport::TestCase
+  include ForemanTasks::TestHelpers::WithInThreadExecutor
+
+  setup do
+    @repo_payload = { id: 123 }
+    @expected_url = 'https://example.com/api/v1/vmaas/reposcan/sync'
+    InsightsCloud.stubs(:vmaas_reposcan_sync_url).returns(@expected_url)
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+  end
+
+  # Planning behavior
+  test 'plan plans_self when repo payload has id and IoP is available' do
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).once
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+  end
+
+  test 'plan does not plan_self when repo payload is missing id' do
+    payload_without_id = {}
+
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with { |msg| msg =~ /missing repository id/i }
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).never
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, payload_without_id)
+  end
+
+  test 'plan does not plan_self when IoP smart proxy is not available' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).never
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+  end
+
+  test 'plan skips repo_id validation when IoP smart proxy is not available' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+    payload_without_id = {}
+
+    # Logger should not be called since IoP check returns early
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:logger).never
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).never
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, payload_without_id)
+  end
+
+  test 'plan does not plan_self when repository is nil' do
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with { |msg| msg =~ /missing repository id/i }
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).never
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, nil)
+  end
+
+  # Run behavior
+  test 'run triggers VMaaS reposcan sync successfully' do
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(200)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .expects(:execute_cloud_request)
+                                           .with do |params|
+      params[:method] == :put &&
+        params[:url] == @expected_url &&
+        params[:headers].is_a?(Hash) &&
+        params[:headers]['Content-Type'] == 'application/json'
+    end
+                                           .returns(mock_response)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync triggered successfully: 200', task.output[:message]
+  end
+
+  test 'run sets error message in task output for failed response' do
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(500)
+    mock_response.stubs(:body).returns('Internal Server Error')
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .returns(mock_response)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync failed with status: 500, body: Internal Server Error', task.output[:message]
+  end
+
+  test 'run sets error message in task output for RestClient exception' do
+    error_response = mock('error_response')
+    error_response.stubs(:code).returns(500)
+    error_response.stubs(:body).returns('Server Error')
+    exception = RestClient::ExceptionWithResponse.new(error_response)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    error = assert_raises(ForemanTasks::TaskError) do
+      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+    end
+
+    assert_equal 'VMaaS reposcan sync failed: 500 - Server Error', error.task.output[:message]
+  end
+
+  test 'run sets error message in task output for StandardError exception' do
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(StandardError.new('Network timeout'))
+
+    error = assert_raises(ForemanTasks::TaskError) do
+      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+    end
+
+    # The task is available via main_action
+    assert_match(/Error triggering VMaaS reposcan sync: Network timeout, response: /,
+      error.task.main_action.output[:message])
+  end
+
+  test 'run logs and re-raises when cloud request returns error response' do
+    error_response = mock('error_response', code: 500, body: 'error')
+    exception = RestClient::ExceptionWithResponse.new(error_response)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    assert_raises(ForemanTasks::TaskError) do
+      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+    end
+  end
+end


### PR DESCRIPTION
Triggers VMaaS vulnerability scanning updates when Katello repositories are synchronized.

#### What are the changes introduced in this pull request?
Added VMaaS reposcan sync functionality that automatically triggers vulnerability scanning updates when Katello repositories are synchronized.

#### Considerations taken when implementing this change?
The sync is needed only when the content actually hosted by Satellite changes. Therefore, the existing trigger in the PR for Repository Sync should be sufficient, and you don't need a second trigger for Repository Sets.

#### What are the testing steps for this pull request?

1. Enable IoP Smart Proxy
2. Sync a Katello repository (Content → Products → (Choose Product) → Sync Now)
3. Check logs for VMaaS sync trigger

## Summary by Sourcery

Introduce an asynchronous VMaaS reposcan sync task that triggers vulnerability scanning updates via the IoP Smart Proxy when a Katello repository is synchronized

New Features:
- Add Async::VmaasReposcanSyncTask to automatically trigger VMaaS vulnerability scanning updates on Katello repository sync

Enhancements:
- Add vmaas_reposcan_sync_url helper to construct the VMaaS reposcan sync API endpoint