### PR TITLE
Reflect correct data shape in HostedRecommendationsCell

### DIFF
--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -6,7 +6,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import { CVECountCell } from '../InsightsVulnerabilityHostIndexExtensions/CVECountCell';
 
-const HostedRecommendationsCell = hostDetails => {
+const HostedRecommendationsCell = ({ hostDetails }) => {
   const insightsAttributes = propsToCamelCase(
     // eslint-disable-next-line camelcase
     hostDetails?.insights_attributes ?? {}
@@ -17,6 +17,10 @@ const HostedRecommendationsCell = hostDetails => {
   const encodedHostname = encodeURIComponent(hostname);
   const hitsUrl = `/foreman_rh_cloud/insights_cloud?search=hostname+%3D+${encodedHostname}`;
   return <a href={hitsUrl}>{hitsCount}</a>;
+};
+
+HostedRecommendationsCell.propTypes = {
+  hostDetails: PropTypes.object.isRequired,
 };
 
 const IopRecommendationsCell = ({ hostDetails }) => {


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The Recommendations cell was not properly ingesting the hostDetails prop, so was displaying "-" for every host. This change makes it stop doing that.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

get a non-IoP host with recommendations
Ensure that the number of recommendations in the column reflects the recommendations you see on the host details > Recommendations tab

## Summary by Sourcery

Fix recommendations cell to use correct data shape and add propTypes validation

Bug Fixes:
- Correct HostedRecommendationsCell to destructure hostDetails prop so it displays actual recommendation counts

Enhancements:
- Add propTypes requirement for hostDetails in HostedRecommendationsCell