### PR TITLE
Wrap scoped search autocomplete values in quotes when they contain a pipe character

### DIFF
--- a/app/models/insights_hit.rb
+++ b/app/models/insights_hit.rb
@@ -1,6 +1,6 @@
 class InsightsHit < ApplicationRecord
   include ::Authorizable
-  belongs_to :host
+  belongs_to :host, class_name: 'Host::Base'
   # since the facet is one-to-one association with a host, we can connect
   # through host_id column on both this model and facet.
   belongs_to :insights_facet, foreign_key: 'host_id', primary_key: 'host_id', counter_cache: :hits_count

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -83,6 +83,27 @@ module ForemanRhCloud
         :description => N_('Configure Cloud Connector on given hosts'),
         :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
       )
+
+      ScopedSearch::AutoCompleteBuilder.class_eval do
+        # Insights rule IDs always contain a pipe character.
+        # example: hardening_ssh_config_perms|OPENSSH_HARDENING_CONFIG_PERMS
+        # We need to override this method of scoped_search so that autocomplete
+        # will correctly put the value in quotes (otherwise the "|" will be
+        # interpreted as an OR.)
+        # The only change from scoped_search code is adding the | to the regex in the final map.
+        def complete_value_from_db(field, special_values, val)
+          count = 20 - special_values.count
+          completer_scope(field)
+            .where(@options[:value_filter])
+            .where(value_conditions(field.quoted_field, val))
+            .select(field.quoted_field)
+            .limit(count)
+            .distinct
+            .map(&field.field)
+            .compact
+            .map { |v| v.to_s =~ /\s|\|/ ? "\"#{v.gsub('"', '\"')}\"" : v }
+        end
+      end
     end
 
     # Ideally this code belongs to an initializer. The problem is that Katello controllers are not initialized completely until after the end of the to_prepare blocks


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Insights rule IDs frequently (almost always) contain the pipe character, `|`. This causes problems when using scoped search to perform a search like

```
rule_id = dnf_install_update_issue|DNF_INSTALL_UPDATE_ISSUE_INFO 
```

because scoped search would take the pipe character as an "OR", and do separate searches for the keywords on each side of the pipe. This means that you don't get any results unless you put the keyword in quotes:
```
rule_id = "dnf_install_update_issue|DNF_INSTALL_UPDATE_ISSUE_INFO"
```

Which is fine, except that scoped search autocomplete _suggests_ the search without the quotes.


```
# Without quotes around the rule id
[1] pry(main)> puts InsightsHit.search_for("rule_id = dnf_install_update_issue|DNF_INSTALL_UPDATE_ISSUE_INFO").to_sql
SELECT ... FROM "insights_hits" ...  WHERE ((("insights_hits"."rule_id" = 'dnf_install_update_issue') OR ("insights_hits"."title" ILIKE '%DNF_INSTALL_UPDATE_ISSUE_INFO%' OR "hosts"."name" ILIKE '%DNF_INSTALL_UPDATE_ISSUE_INFO%')))
=> nil

# With quotes around the rule id
[2] pry(main)> puts InsightsHit.search_for("rule_id = \"dnf_install_update_issue|DNF_INSTALL_UPDATE_ISSUE_INFO\"").to_sql
SELECT "insights_hits".* FROM "insights_hits" WHERE (("insights_hits"."rule_id" = 'dnf_install_update_issue|DNF_INSTALL_UPDATE_ISSUE_INFO'))
=> nil
```


I tried various ways of modifying scoped_search to add the quotes, including external search methods and `value_translation`. But the problem there was that these receive the search keyword values _after_ scoped search already split up the values on either side of the pipe.

The solution here is to have the scoped search autocomplete builder _suggest_ the quotes. This requires redefining a method.

#### Considerations taken when implementing this change?

This will affect the behavior of scoped_search application-wide, not just for InsightsHit or foreman_rh_cloud. Ideally scoped_search itself can be updated with this change eventually, and the change would apply to all special operators and not just pipe. For now, I have it only affecting pipe.

#### What are the testing steps for this pull request?

Non-IoP
get a host with recommendations
Insights > Recommendations
Perform a search for "rule_id = "
Accept one of the autocomplete suggestions

Before: You get 0 search results. If you put the rule ID in quotes, it works.
Now: Autocomplete suggested values are already in quotes, so it works.

## Summary by Sourcery

Fix scoped_search to correctly handle Insights rule IDs containing '|' and update the InsightsHit host association to use an explicit class name

Bug Fixes:
- Remove '|' from scoped_search tokenizer regex to prevent splitting Insights rule IDs on pipe symbol

Enhancements:
- Specify class_name 'Host::Base' for the host association in InsightsHit model