### PR TITLE
Refs #38723 -  Updates rh cloud to correctly talk to katello controllers to delay actions for RH Cloud

### DIFF
--- a/foreman_rh_cloud.gemspec
+++ b/foreman_rh_cloud.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'foreman_ansible', '>= 15.0.0'
   s.add_dependency 'foreman-tasks', '>= 10.0.0'
-  s.add_runtime_dependency 'katello', '>= 4.14.0.rc1.1'
+  s.add_runtime_dependency 'katello', '>= 4.18'
 
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -115,23 +115,20 @@ module ForemanRhCloud
       if defined?(Katello) && !Foreman.in_setup_db_rake?
         Katello::Api::V2::OrganizationsController.include Foreman::Controller::SmartProxyAuth
         # patch the callbacks order for :download_debug_certificate, since local_find_taxonomy has to run after the user is already initialized
-        Katello::Api::V2::OrganizationsController.skip_before_action(:local_find_taxonomy, only: :download_debug_certificate)
-        Katello::Api::V2::OrganizationsController.add_smart_proxy_filters(
-          [:index, :download_debug_certificate],
-          features: ForemanRhCloud.on_prem_smart_proxy_features
-        )
-        Katello::Api::V2::OrganizationsController.before_action(:local_find_taxonomy, only: :download_debug_certificate)
-
+        Katello::Api::V2::OrganizationsController.before_find_taxonomy_actions do
+          Katello::Api::V2::OrganizationsController.add_smart_proxy_filters(
+            [:index, :download_debug_certificate],
+            features: ForemanRhCloud.on_prem_smart_proxy_features
+          )
+        end
         Katello::Api::V2::RepositoriesController.include Foreman::Controller::SmartProxyAuth
         # patch the callbacks order for :index, since find_product has to run after the user is already initialized
-        Katello::Api::V2::RepositoriesController.skip_before_action(:find_product, only: :index)
-        Katello::Api::V2::RepositoriesController.skip_before_action(:find_optional_organization, only: :index)
-        Katello::Api::V2::RepositoriesController.add_smart_proxy_filters(
-          :index,
-          features: ForemanRhCloud.on_prem_smart_proxy_features
-        )
-        Katello::Api::V2::RepositoriesController.before_action(:find_product, only: :index)
-        Katello::Api::V2::RepositoriesController.before_action(:find_optional_organization, only: :index)
+        Katello::Api::V2::RepositoriesController.before_index_actions do
+          Katello::Api::V2::RepositoriesController.add_smart_proxy_filters(
+            :index,
+            features: ForemanRhCloud.on_prem_smart_proxy_features
+          )
+        end
       end
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This PR works with https://github.com/Katello/katello/pull/11490

Basically makes use of the updated katello controllers to delay index and organization related actions for properly loading the rh cloud engine.

#### What are the testing steps for this pull request?

Check https://github.com/Katello/katello/pull/11490

## Summary by Sourcery

Use updated Katello controller callbacks to defer taxonomy and product lookup when adding smart proxy filters for RH Cloud actions

Enhancements:
- Replace manual skip_before_action and before_action calls in OrganizationsController with delay_find_taxonomy_actions to wrap index and download_debug_certificate filters
- Replace manual skip_before_action and before_action calls in RepositoriesController with delay_index_actions to wrap index filters