### PR TITLE
Release 12.2.6 and cherry-picks

### DIFF
--- a/lib/foreman_inventory_upload/async/generate_report_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_report_job.rb
@@ -14,13 +14,14 @@ module ForemanInventoryUpload
             hosts_filter: hosts_filter
           )
 
-          plan_action(
-            QueueForUploadJob,
-            base_folder,
-            ForemanInventoryUpload.facts_archive_name(organization_id, hosts_filter),
-            organization_id,
-            disconnected
-          )
+          unless content_disconnected?(disconnected)
+            plan_action(
+              QueueForUploadJob,
+              base_folder,
+              ForemanInventoryUpload.facts_archive_name(organization_id, hosts_filter),
+              organization_id
+            )
+          end
         end
       end
 
@@ -38,6 +39,10 @@ module ForemanInventoryUpload
           'organization_id' => organization_id,
           'hosts_filter' => hosts_filter
         )
+      end
+
+      def content_disconnected?(disconnected)
+        disconnected || !Setting[:subscription_connection_enabled]
       end
 
       def base_folder

--- a/lib/foreman_inventory_upload/async/queue_for_upload_job.rb
+++ b/lib/foreman_inventory_upload/async/queue_for_upload_job.rb
@@ -1,9 +1,9 @@
 module ForemanInventoryUpload
   module Async
     class QueueForUploadJob < ::Actions::EntryAction
-      def plan(base_folder, report_file, organization_id, disconnected)
+      def plan(base_folder, report_file, organization_id)
         enqueue_task = plan_self(base_folder: base_folder, report_file: report_file)
-        plan_upload_report(enqueue_task.output[:enqueued_file_name], organization_id, disconnected)
+        plan_upload_report(enqueue_task.output[:enqueued_file_name], organization_id)
       end
 
       def run
@@ -59,8 +59,8 @@ module ForemanInventoryUpload
         input[:report_file]
       end
 
-      def plan_upload_report(enqueued_file_name, organization_id, disconnected)
-        plan_action(UploadReportJob, enqueued_file_name, organization_id, disconnected)
+      def plan_upload_report(enqueued_file_name, organization_id)
+        plan_action(UploadReportJob, enqueued_file_name, organization_id)
       end
     end
   end

--- a/lib/foreman_inventory_upload/async/upload_report_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_job.rb
@@ -7,15 +7,15 @@ module ForemanInventoryUpload
         "upload_for_#{label}"
       end
 
-      def plan(filename, organization_id, disconnected = false)
+      def plan(filename, organization_id)
         label = UploadReportJob.output_label(organization_id)
-        super(label, filename: filename, organization_id: organization_id, disconnected: disconnected)
+        super(label, filename: filename, organization_id: organization_id)
       end
 
       def try_execute
         if content_disconnected?
           progress_output do |progress_output|
-            progress_output.write_line('Upload canceled because connection to Insights is not enabled or the --no-upload option was passed.')
+            progress_output.write_line("Report was not moved and upload was canceled because connection to Insights is not enabled. Report location: #{filename}.")
             progress_output.status = "Task aborted, exit 1"
             done!
           end
@@ -89,7 +89,7 @@ module ForemanInventoryUpload
       end
 
       def content_disconnected?
-        input[:disconnected] || !Setting[:subscription_connection_enabled]
+        !Setting[:subscription_connection_enabled]
       end
     end
   end

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.2.5'.freeze
+  VERSION = '12.2.6'.freeze
 end

--- a/lib/insights_cloud.rb
+++ b/lib/insights_cloud.rb
@@ -44,4 +44,8 @@ module InsightsCloud
   def self.enable_cloud_remediations_param
     'enable_cloud_remediations'
   end
+
+  def self.vmaas_reposcan_sync_url
+    ForemanRhCloud.iop_smart_proxy.url + '/api/vmaas-reposcan/sync'
+  end
 end

--- a/lib/insights_cloud/async/vmaas_reposcan_sync.rb
+++ b/lib/insights_cloud/async/vmaas_reposcan_sync.rb
@@ -1,0 +1,71 @@
+require 'rest-client'
+
+module InsightsCloud
+  module Async
+    # Triggers VMaaS reposcan sync via IoP gateway when repositories are synced
+    class VmaasReposcanSync < ::Actions::EntryAction
+      include ::ForemanRhCloud::CertAuth
+
+      # Subscribe to Katello repository sync hook action, if available
+      def self.subscribe
+        'Actions::Katello::Repository::SyncHook'.constantize
+      rescue NameError
+        Rails.logger.debug('VMaaS reposcan sync: Repository::SyncHook action not found')
+        nil
+      end
+
+      def plan(repo, *_args)
+        return unless ::ForemanRhCloud.with_iop_smart_proxy?
+
+        repo_id = repo.is_a?(Hash) ? (repo[:id] || repo['id']) : nil
+        unless repo_id
+          logger.error("VMaaS reposcan sync: missing repository id in SyncHook plan parameters: #{repo.inspect}")
+          return
+        end
+
+        plan_self
+      end
+
+      def run
+        url = ::InsightsCloud.vmaas_reposcan_sync_url
+
+        response = execute_cloud_request(
+          method: :put,
+          url: url,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+        if response.code >= 200 && response.code < 300
+          message = "VMaaS reposcan sync triggered successfully: #{response.code}"
+          logger.info(message)
+        else
+          message = "VMaaS reposcan sync failed with status: #{response.code}, body: #{response.body}"
+          logger.error(message)
+        end
+        output[:message] = message
+
+        response
+      rescue RestClient::ExceptionWithResponse => e
+        message = "VMaaS reposcan sync failed: #{e.response&.code} - #{e.response&.body}"
+        logger.error(message)
+        output[:message] = message
+        raise
+      rescue StandardError => e
+        message = "Error triggering VMaaS reposcan sync: #{e.message}, response: #{e.respond_to?(:response) ? e.response : nil}"
+        logger.error(message)
+        output[:message] = message
+        raise
+      end
+
+      def rescue_strategy_for_self
+        Dynflow::Action::Rescue::Skip
+      end
+
+      private
+
+      def logger
+        action_logger
+      end
+    end
+  end
+end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.2.5",
+  "version": "12.2.6",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {

--- a/test/jobs/queue_for_upload_job_test.rb
+++ b/test/jobs/queue_for_upload_job_test.rb
@@ -1,0 +1,63 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class QueueForUploadJobTest < ActiveSupport::TestCase
+  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include FolderIsolation
+
+  let(:organization) { FactoryBot.create(:organization) }
+  let(:base_folder) { @tmpdir }
+  let(:report_file) { 'test_report.tar.xz' }
+  let(:report_path) { File.join(base_folder, report_file) }
+  let(:uploads_folder) { ForemanInventoryUpload.uploads_folder }
+  subject { ForemanTasks.sync_task(ForemanInventoryUpload::Async::QueueForUploadJob, base_folder, report_file, organization.id) }
+
+  setup do
+    # Stub the script template source
+    script_source = File.join(ForemanRhCloud::Engine.root, 'lib/foreman_inventory_upload/scripts/uploader.sh.erb')
+    File.stubs(:read).with(script_source).returns('#!/bin/bash\necho "Test script"')
+
+    # Stub template rendering
+    Foreman::Renderer.stubs(:render).returns('#!/bin/bash\necho "Rendered script"')
+
+    # Stub additional settings that are accessed
+    Setting.stubs(:[]).with(:content_default_http_proxy).returns(nil)
+    Setting.stubs(:[]).with(:http_proxy).returns(nil)
+    Setting.stubs(:[]).with("foreman_tasks_sync_task_timeout").returns(120)
+    FileUtils.touch(report_path)
+  end
+
+  teardown do
+    FileUtils.rm_rf(uploads_folder) if Dir.exist?(uploads_folder)
+  end
+
+  test 'plan method sets up the job correctly and calls plan_upload_report' do
+    # Mock plan_upload_report to verify it's called
+    ForemanInventoryUpload::Async::QueueForUploadJob.any_instance.expects(:plan_upload_report).once
+
+    assert_equal 'success', subject.result
+  end
+
+  test 'run method processes file and moves it to uploads folder' do
+    ForemanInventoryUpload::Async::QueueForUploadJob.any_instance.stubs(:plan_upload_report)
+
+    assert_equal 'success', subject.result
+
+    # Verify the file was moved
+    refute File.exist?(report_path), "Original file should be moved"
+    assert File.exist?(File.join(uploads_folder, report_file)), "File should exist in uploads folder"
+  end
+
+  test 'creates necessary folders and scripts' do
+    ForemanInventoryUpload::Async::QueueForUploadJob.any_instance.stubs(:plan_upload_report)
+
+    assert_equal 'success', subject.result
+
+    # Verify the uploads folder was created
+    assert Dir.exist?(uploads_folder), "Uploads folder should be created"
+
+    # Verify the script file was created
+    script_path = File.join(uploads_folder, ForemanInventoryUpload.upload_script_file)
+    assert File.exist?(script_path), "Upload script should be created"
+  end
+end

--- a/test/jobs/upload_report_job_test.rb
+++ b/test/jobs/upload_report_job_test.rb
@@ -18,7 +18,8 @@ class UploadReportJobTest < ActiveSupport::TestCase
 
     label = ForemanInventoryUpload::Async::UploadReportJob.output_label(organization.id)
     progress_output = ForemanInventoryUpload::Async::ProgressOutput.get(label)
-    assert_match(/Upload canceled/, progress_output.full_output)
+    assert_match(/upload was canceled because connection to Insights is not enabled/, progress_output.full_output)
+    assert_match(/Report location:/, progress_output.full_output)
     assert_match(/exit 1/, progress_output.status)
   end
 

--- a/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
+++ b/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
@@ -1,0 +1,137 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class VmaasReposcanSyncTest < ActiveSupport::TestCase
+  include ForemanTasks::TestHelpers::WithInThreadExecutor
+
+  setup do
+    @repo_payload = { id: 123 }
+    @expected_url = 'https://example.com/api/v1/vmaas/reposcan/sync'
+    InsightsCloud.stubs(:vmaas_reposcan_sync_url).returns(@expected_url)
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+  end
+
+  # Planning behavior
+  test 'plan plans_self when repo payload has id and IoP is available' do
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).once
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+  end
+
+  test 'plan does not plan_self when repo payload is missing id' do
+    payload_without_id = {}
+
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with { |msg| msg =~ /missing repository id/i }
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).never
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, payload_without_id)
+  end
+
+  test 'plan does not plan_self when IoP smart proxy is not available' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).never
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+  end
+
+  test 'plan skips repo_id validation when IoP smart proxy is not available' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+    payload_without_id = {}
+
+    # Logger should not be called since IoP check returns early
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:logger).never
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).never
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, payload_without_id)
+  end
+
+  test 'plan does not plan_self when repository is nil' do
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with { |msg| msg =~ /missing repository id/i }
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).never
+
+    ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, nil)
+  end
+
+  # Run behavior
+  test 'run triggers VMaaS reposcan sync successfully' do
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(200)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .expects(:execute_cloud_request)
+                                           .with do |params|
+      params[:method] == :put &&
+        params[:url] == @expected_url &&
+        params[:headers].is_a?(Hash) &&
+        params[:headers]['Content-Type'] == 'application/json'
+    end
+                                           .returns(mock_response)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync triggered successfully: 200', task.output[:message]
+  end
+
+  test 'run sets error message in task output for failed response' do
+    mock_response = mock('response')
+    mock_response.stubs(:code).returns(500)
+    mock_response.stubs(:body).returns('Internal Server Error')
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .returns(mock_response)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync failed with status: 500, body: Internal Server Error', task.output[:message]
+  end
+
+  test 'run sets error message in task output for RestClient exception' do
+    error_response = mock('error_response')
+    error_response.stubs(:code).returns(500)
+    error_response.stubs(:body).returns('Server Error')
+    exception = RestClient::ExceptionWithResponse.new(error_response)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    error = assert_raises(ForemanTasks::TaskError) do
+      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+    end
+
+    assert_equal 'VMaaS reposcan sync failed: 500 - Server Error', error.task.output[:message]
+  end
+
+  test 'run sets error message in task output for StandardError exception' do
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(StandardError.new('Network timeout'))
+
+    error = assert_raises(ForemanTasks::TaskError) do
+      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+    end
+
+    # The task is available via main_action
+    assert_match(/Error triggering VMaaS reposcan sync: Network timeout, response: /,
+      error.task.main_action.output[:message])
+  end
+
+  test 'run logs and re-raises when cloud request returns error response' do
+    error_response = mock('error_response', code: 500, body: 'error')
+    exception = RestClient::ExceptionWithResponse.new(error_response)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    assert_raises(ForemanTasks::TaskError) do
+      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+    end
+  end
+end


### PR DESCRIPTION
## Summary by Sourcery

Refactor async inventory upload flows to respect subscription connection settings, add a new VMaaS reposcan sync action with comprehensive tests, and bump the project version to 12.2.6

New Features:
- Implement InsightsCloud::Async::VmaasReposcanSync action to trigger VMaaS reposcan sync via IoP gateway

Enhancements:
- Refactor inventory upload jobs to remove explicit disconnected flags and centralize subscription connection checks
- Conditionally skip queuing and uploading reports when Insights subscription connection is disabled
- Update upload cancellation message to include report location
- Introduce InsightsCloud.vmaas_reposcan_sync_url for constructing the VMaaS sync endpoint

Tests:
- Add unit tests for VmaasReposcanSync covering plan logic and run success and error handling
- Add unit tests for QueueForUploadJob to verify file movement and script generation
- Update UploadReportJob test to assert the revised cancellation message and report location output

Chores:
- Bump foreman_rh_cloud version to 12.2.6 in version.rb and package.json