### PR TITLE
SAT-37810 - Update Total risks card dropdown for PF5

### DIFF
--- a/webpack/InsightsHostDetailsTab/InsightsTab.scss
+++ b/webpack/InsightsHostDetailsTab/InsightsTab.scss
@@ -88,3 +88,7 @@
 #new_host_details_insights_tab {
   padding: 24px;
 }
+
+#total-risks-dropdown-container ul.pf-v5-c-menu__list {
+  margin-bottom: 0px;
+}

--- a/webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js
+++ b/webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import { useHistory } from 'react-router-dom';
-import { Bullseye, Title } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { Bullseye, DropdownItem, Title } from '@patternfly/react-core';
 import {
   ChartDonut,
   ChartLegend,
@@ -127,6 +126,7 @@ const InsightsTotalRiskCard = ({ hostDetails: { id } }) => {
   return (
     <CardTemplate
       header={__('Total risks')}
+      overrideDropdownProps={{ id: 'total-risks-dropdown-container' }}
       dropdownItems={[
         <DropdownItem
           key="insights-tab"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Depends on https://github.com/theforeman/foreman/pull/10685

<img width="387" height="333" alt="total-risk" src="https://github.com/user-attachments/assets/92ebd91b-0452-49ff-a364-402ea9daf534" />

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Migrate the Total Risks card dropdown in the host insights details tab to use PatternFly 5 components and styles, update its menu options and behavior for risk filtering

Enhancements:
- Migrate the dropdown in InsightsTotalRiskChart to PatternFly 5’s Dropdown component
- Update dropdown menu items and event handlers for selecting risk filters
- Adjust CSS classes and layout to match PF5 styling guidelines

Tests:
- Add tests for dropdown filter selection in the Total Risks chart