### PR TITLE
Correct vmaas_reposcan_sync_url to include /v1 in the API path

### DIFF
--- a/lib/insights_cloud.rb
+++ b/lib/insights_cloud.rb
@@ -46,6 +46,6 @@ module InsightsCloud
   end
 
   def self.vmaas_reposcan_sync_url
-    ForemanRhCloud.iop_smart_proxy.url + '/api/vmaas-reposcan/sync'
+    ForemanRhCloud.iop_smart_proxy.url + '/api/vmaas-reposcan/v1/sync'
   end
 end


### PR DESCRIPTION
This PR is a follow-up to [#1078](https://github.com/theforeman/foreman_rh_cloud/pull/1078).

### Description of Problem

The `foreman_rh_cloud` plugin triggers a VMaaS reposcan after syncing Red Hat repositories. However, it currently calls a non-existent API endpoint:

```
PUT /api/vmaas-reposcan/sync
```

This results in a 404 error:

```
INFO:vmaas.common.middlewares:404 PUT /api/sync HTTP/1.0 0.001015s
"PUT /api/vmaas-reposcan/sync HTTP/1.1" 404 
```

The correct endpoint should be:

```
PUT /api/vmaas-reposcan/v1/sync
```

### Fix Introduced

Update the `vmaas_reposcan_sync_url` method to call the correct API endpoint:

```ruby
- ForemanRhCloud.iop_smart_proxy.url + '/api/vmaas-reposcan/sync'
+ ForemanRhCloud.iop_smart_proxy.url + '/api/vmaas-reposcan/v1/sync'
```

### Steps to Reproduce

1. Install IoP and sync Red Hat content repositories.
2. Verify that the sync completes successfully and no longer fails with a 404 error.

## Summary by Sourcery

Bug Fixes:
- Update vmaas_reposcan_sync_url to call /api/vmaas-reposcan/v1/sync instead of the non-existent endpoint to avoid 404 errors