### PR TITLE
Release 12.2.8

### DIFF
--- a/foreman_rh_cloud.gemspec
+++ b/foreman_rh_cloud.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'foreman_ansible', '>= 15.0.0'
   s.add_dependency 'foreman-tasks', '>= 10.0.0'
-  s.add_runtime_dependency 'katello', '>= 4.14.0.rc1.1'
+  s.add_runtime_dependency 'katello', '>= 4.18'
 
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -115,23 +115,20 @@ module ForemanRhCloud
       if defined?(Katello) && !Foreman.in_setup_db_rake?
         Katello::Api::V2::OrganizationsController.include Foreman::Controller::SmartProxyAuth
         # patch the callbacks order for :download_debug_certificate, since local_find_taxonomy has to run after the user is already initialized
-        Katello::Api::V2::OrganizationsController.skip_before_action(:local_find_taxonomy, only: :download_debug_certificate)
-        Katello::Api::V2::OrganizationsController.add_smart_proxy_filters(
-          [:index, :download_debug_certificate],
-          features: ForemanRhCloud.on_prem_smart_proxy_features
-        )
-        Katello::Api::V2::OrganizationsController.before_action(:local_find_taxonomy, only: :download_debug_certificate)
-
+        Katello::Api::V2::OrganizationsController.before_find_taxonomy_actions do
+          Katello::Api::V2::OrganizationsController.add_smart_proxy_filters(
+            [:index, :download_debug_certificate],
+            features: ForemanRhCloud.on_prem_smart_proxy_features
+          )
+        end
         Katello::Api::V2::RepositoriesController.include Foreman::Controller::SmartProxyAuth
         # patch the callbacks order for :index, since find_product has to run after the user is already initialized
-        Katello::Api::V2::RepositoriesController.skip_before_action(:find_product, only: :index)
-        Katello::Api::V2::RepositoriesController.skip_before_action(:find_optional_organization, only: :index)
-        Katello::Api::V2::RepositoriesController.add_smart_proxy_filters(
-          :index,
-          features: ForemanRhCloud.on_prem_smart_proxy_features
-        )
-        Katello::Api::V2::RepositoriesController.before_action(:find_product, only: :index)
-        Katello::Api::V2::RepositoriesController.before_action(:find_optional_organization, only: :index)
+        Katello::Api::V2::RepositoriesController.before_index_actions do
+          Katello::Api::V2::RepositoriesController.add_smart_proxy_filters(
+            :index,
+            features: ForemanRhCloud.on_prem_smart_proxy_features
+          )
+        end
       end
     end
 

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.2.7'.freeze
+  VERSION = '12.2.8'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.2.7",
+  "version": "12.2.8",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Prepare 12.2.8 release by bumping version and Katello dependency, and refactor smart proxy filter callbacks registration

Enhancements:
- Refactor OrganizationsController to use before_find_taxonomy_actions for smart proxy filters
- Refactor RepositoriesController to use before_index_actions for smart proxy filters

Build:
- Update Katello runtime dependency to >= 4.18
- Bump foreman_rh_cloud version to 12.2.8 in version.rb and package.json