### PR TITLE
SAT-37809 - Add IoP support to Total risks card

### DIFF
--- a/webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js
+++ b/webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js
@@ -18,36 +18,67 @@ import SkeletonLoader from 'foremanReact/components/common/SkeletonLoader';
 import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
 import { getInitialRisks, theme } from './InsightsTabConstants';
 
-const InsightsTotalRiskCard = ({ hostDetails: { id } }) => {
+const InsightsTotalRiskCard = ({ hostDetails }) => {
+  const { id, insights_attributes: insightsFacet } = hostDetails;
+  const uuid = insightsFacet?.uuid;
+  // eslint-disable-next-line camelcase
+  const isIop = insightsFacet?.use_iop_mode;
   const [totalRisks, setTotalRisks] = useState(getInitialRisks());
   const hashHistory = useHistory();
   const dispatch = useDispatch();
   const API_KEY = `HOST_${id}_RECOMMENDATIONS`;
   const API_OPTIONS = useMemo(() => ({ key: API_KEY }), [API_KEY]);
-  const url = id && insightsCloudUrl(`hits/${id}`); // This will keep the API call from being triggered if there's no host id.
-  const {
-    status = STATUS.PENDING,
-    response: { hits = [] },
-  } = useAPI('get', url, API_OPTIONS);
 
-  useEffect(() => {
-    if (status === STATUS.RESOLVED) {
-      const risks = getInitialRisks();
+  // This will keep the API call from being triggered if there's no host id.
+  const url = isIop
+    ? uuid && insightsCloudUrl(`api/insights/v1/system/${uuid}`)
+    : id && insightsCloudUrl(`hits/${id}`);
+  const { status = STATUS.PENDING, response } = useAPI('get', url, API_OPTIONS);
+
+  const checkRisks = useMemo(() => {
+    if (!response || status !== STATUS.RESOLVED) {
+      return getInitialRisks();
+    }
+
+    const risks = getInitialRisks();
+    if (isIop) {
+      const {
+        low_hits: lowHits = 0,
+        moderate_hits: moderateHits = 0,
+        important_hits: importantHits = 0,
+        critical_hits: criticalHits = 0,
+        hits = 0,
+      } = response;
+
+      risks[1].value += lowHits;
+      risks[2].value += moderateHits;
+      risks[3].value += importantHits;
+      risks[4].value += criticalHits;
+      risks.total = hits;
+    } else {
+      const { hits = [] } = response;
       hits.forEach(({ total_risk: risk }) => {
         risks[risk].value += 1;
       });
       risks.total = hits.length;
-      setTotalRisks(risks);
     }
-  }, [hits, status]);
+    return risks;
+  }, [response, status, isIop]);
+
+  useEffect(() => {
+    setTotalRisks(checkRisks);
+  }, [checkRisks]);
+
+  if (!insightsFacet) return null;
 
   const onChartClick = (evt, { index }) => {
     hashHistory.push(`/Insights`);
-    dispatch(
-      push({
-        search: `search=total_risk+%3D+${index + 1}`,
-      })
-    );
+    !isIop &&
+      dispatch(
+        push({
+          search: `search=total_risk+%3D+${index + 1}`,
+        })
+      );
   };
 
   const onChartHover = (evt, { index }) => [
@@ -61,11 +92,16 @@ const InsightsTotalRiskCard = ({ hostDetails: { id } }) => {
   const { 1: low, 2: moderate, 3: important, 4: critical, total } = totalRisks;
 
   // eslint-disable-next-line react/prop-types
-  const LegendLabel = ({ index, ...rest }) => (
-    <a key={index} onClick={() => onChartClick(null, { index })}>
-      <ChartLabel {...rest} />
-    </a>
-  );
+  const LegendLabel = ({ index, ...rest }) => {
+    if (isIop) {
+      return <ChartLabel {...rest} />;
+    }
+    return (
+      <a key={index} onClick={() => onChartClick(null, { index })}>
+        <ChartLabel {...rest} />
+      </a>
+    );
+  };
 
   const legend = (
     <ChartLegend

--- a/webpack/InsightsHostDetailsTab/__tests__/InsightsTotalRiskChart.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/InsightsTotalRiskChart.test.js
@@ -1,0 +1,194 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import { ConnectedRouter } from 'connected-react-router';
+import { createMemoryHistory } from 'history';
+import configureMockStore from 'redux-mock-store';
+import { STATUS } from 'foremanReact/constants';
+import * as APIHooks from 'foremanReact/common/hooks/API/APIHooks';
+import InsightsTotalRiskCard from '../InsightsTotalRiskChart';
+
+jest.mock('foremanReact/common/hooks/API/APIHooks');
+jest.mock('foremanReact/common/I18n', () => ({
+  translate: jest.fn(str => str),
+}));
+
+const mockStore = configureMockStore();
+const history = createMemoryHistory();
+const store = mockStore({
+  router: {
+    location: {
+      pathname: '/',
+      search: '',
+      hash: '',
+      state: null,
+    },
+    action: 'POP',
+  },
+});
+
+const defaultHostDetails = {
+  id: 1,
+  insights_attributes: {
+    uuid: 'test-uuid',
+    use_iop_mode: false,
+  },
+};
+
+const renderComponent = (props = {}) => {
+  const allProps = {
+    hostDetails: defaultHostDetails,
+    ...props,
+  };
+
+  return render(
+    <Provider store={store}>
+      <ConnectedRouter history={history}>
+        <InsightsTotalRiskCard {...allProps} />
+      </ConnectedRouter>
+    </Provider>
+  );
+};
+
+describe('InsightsTotalRiskChart', () => {
+  beforeEach(() => {
+    store.clearActions();
+    jest.clearAllMocks();
+  });
+
+  it('should show loading state initially', () => {
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.PENDING,
+      response: null,
+    });
+
+    renderComponent();
+    // SkeletonLoader shows loading state when status is PENDING
+    expect(screen.queryByText('No results found')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('rh-cloud-total-risk-card')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display error state when API fails', async () => {
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.ERROR,
+      response: null,
+    });
+
+    renderComponent();
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('rh-cloud-total-risk-card')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should handle non-IoP mode API response correctly', async () => {
+    const mockResponse = {
+      hits: [
+        { total_risk: 1 },
+        { total_risk: 2 },
+        { total_risk: 2 },
+        { total_risk: 3 },
+        { total_risk: 4 },
+      ],
+    };
+
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.RESOLVED,
+      response: mockResponse,
+    });
+
+    renderComponent();
+
+    await waitFor(() => {
+      // Check if total number of recommendations is displayed
+      expect(screen.getByText('5')).toBeInTheDocument();
+      // Check if risk levels are displayed correctly
+      expect(screen.getByText(/Low: 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Moderate: 2/)).toBeInTheDocument();
+      expect(screen.getByText(/Important: 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Critical: 1/)).toBeInTheDocument();
+    });
+  });
+
+  it('should handle IOP mode API response correctly', async () => {
+    const mockResponse = {
+      low_hits: 2,
+      moderate_hits: 3,
+      important_hits: 1,
+      critical_hits: 2,
+      hits: 8,
+    };
+
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.RESOLVED,
+      response: mockResponse,
+    });
+
+    renderComponent({
+      hostDetails: {
+        ...defaultHostDetails,
+        insights_attributes: {
+          ...defaultHostDetails.insights_attributes,
+          use_iop_mode: true,
+        },
+      },
+    });
+
+    await waitFor(() => {
+      // Check if total number of recommendations is displayed
+      expect(screen.getByText('8')).toBeInTheDocument();
+      // Check if risk levels are displayed correctly
+      expect(screen.getByText(/Low: 2/)).toBeInTheDocument();
+      expect(screen.getByText(/Moderate: 3/)).toBeInTheDocument();
+      expect(screen.getByText(/Important: 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Critical: 2/)).toBeInTheDocument();
+    });
+  });
+
+  it('should show empty state when no recommendations exist', async () => {
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.RESOLVED,
+      response: { hits: [] },
+    });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Low: 0/)).toBeInTheDocument();
+      expect(screen.getByText(/Moderate: 0/)).toBeInTheDocument();
+      expect(screen.getByText(/Important: 0/)).toBeInTheDocument();
+      expect(screen.getByText(/Critical: 0/)).toBeInTheDocument();
+    });
+  });
+
+  it('should use correct API endpoint based on IOP mode', () => {
+    renderComponent({
+      hostDetails: {
+        ...defaultHostDetails,
+        insights_attributes: {
+          ...defaultHostDetails.insights_attributes,
+          use_iop_mode: true,
+        },
+      },
+    });
+
+    expect(APIHooks.useAPI).toHaveBeenCalledWith(
+      'get',
+      expect.stringContaining('/api/insights/v1/system/test-uuid'),
+      expect.any(Object)
+    );
+
+    jest.clearAllMocks();
+
+    renderComponent();
+
+    expect(APIHooks.useAPI).toHaveBeenCalledWith(
+      'get',
+      expect.stringContaining('/hits/1'),
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fetched hits are back in different format between hosted and IoP. 
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Check Total risks card populated with data in IoP and non-IoP server.

## Summary by Sourcery

Add IoP support to the Total Risks card by detecting IoP mode, switching to the new system API endpoint using host UUID, and correctly aggregating risk counts from the IoP response format.

New Features:
- Detect IoP mode in InsightsTotalRiskCard and choose the API endpoint accordingly
- Fetch and aggregate risk counts from the IoP server response using individual hit counters

Enhancements:
- Generalize useAPI response handling by removing direct hits destructuring
- Update effect dependencies to watch the unified response object instead of hits