### PR TITLE
SAT-37817 - Hide Recommendations page for non-registered hosts

### DIFF
--- a/webpack/ForemanRhCloudFills.js
+++ b/webpack/ForemanRhCloudFills.js
@@ -4,7 +4,11 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import InventoryAutoUploadSwitcher from './ForemanInventoryUpload/SubscriptionsPageExtension/InventoryAutoUpload';
 import NewHostDetailsTab from './InsightsHostDetailsTab/NewHostDetailsTab';
 import { InsightsTotalRiskChartWrapper } from './InsightsHostDetailsTab/InsightsTotalRiskChartWrapper';
-import { isNotRhelHost, vulnerabilityDisabled } from './ForemanRhCloudHelpers';
+import {
+  isNotRhelHost,
+  vulnerabilityDisabled,
+  hasNoInsightsFacet,
+} from './ForemanRhCloudHelpers';
 import CVEsHostDetailsTabWrapper from './CVEsHostDetailsTab/CVEsHostDetailsTab';
 
 const fills = [
@@ -20,7 +24,7 @@ const fills = [
     component: props => <NewHostDetailsTab {...props} />,
     weight: 400,
     metadata: {
-      hideTab: isNotRhelHost,
+      hideTab: props => isNotRhelHost(props) || hasNoInsightsFacet(props),
       title: __('Recommendations'),
     },
   },

--- a/webpack/ForemanRhCloudHelpers.js
+++ b/webpack/ForemanRhCloudHelpers.js
@@ -14,3 +14,7 @@ export const isNotRhelHost = ({ hostDetails }) =>
 
 export const vulnerabilityDisabled = ({ hostDetails }) =>
   isNotRhelHost({ hostDetails }) || !hostDetails?.vulnerability?.enabled;
+
+export const hasNoInsightsFacet = ({ response, hostDetails }) =>
+  // eslint-disable-next-line camelcase
+  !(response?.insights_attributes || hostDetails?.insights_attributes);

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -131,28 +131,15 @@ const IopInsightsTabWrapped = props => (
 );
 
 const InsightsTab = props => {
-  const { response } = props;
-  const isLocalAdvisorEngine =
-    // eslint-disable-next-line camelcase
-    response?.insights_attributes?.use_iop_mode;
+  const isLocalIop = useAdvisorEngineConfig();
 
-  return isLocalAdvisorEngine ? (
+  return isLocalIop ? (
     <IopInsightsTabWrapped {...props} />
   ) : (
     <NewHostDetailsTab {...props} />
   );
 };
 
-InsightsTab.propTypes = {
-  response: PropTypes.shape({
-    insights_attributes: {
-      use_iop_mode: PropTypes.bool,
-    },
-  }),
-};
-
-InsightsTab.defaultProps = {
-  response: {},
-};
+InsightsTab.defaultProps = {};
 
 export default InsightsTab;

--- a/webpack/__tests__/ForemanRhCloudHelpers.test.js
+++ b/webpack/__tests__/ForemanRhCloudHelpers.test.js
@@ -1,5 +1,5 @@
 import { testSelectorsSnapshotWithFixtures } from '@theforeman/test';
-import { foremanUrl, vulnerabilityDisabled } from '../ForemanRhCloudHelpers';
+import { foremanUrl, vulnerabilityDisabled, hasNoInsightsFacet } from '../ForemanRhCloudHelpers';
 
 global.URL_PREFIX = 'MY_TEST_URL_PREFIX.example.com';
 
@@ -34,6 +34,21 @@ const fixtures = {
     }),
   'vulnerabilityDisabled returns true for missing hostDetails': () =>
     vulnerabilityDisabled({}),
+  'hasNoInsightsFacet returns false when insights_attributes is present': () =>
+    hasNoInsightsFacet({
+      response: {
+        insights_attributes: {
+          uuid: 'test-uuid',
+          insights_hits_count: 5,
+        },
+      },
+    }),
+  'hasNoInsightsFacet returns true when insights_attributes is missing': () =>
+    hasNoInsightsFacet({
+      response: {},
+    }),
+  'hasNoInsightsFacet returns true when response is missing': () =>
+    hasNoInsightsFacet({}),
 };
 
 describe('ForemanRhCloud helpers', () =>

--- a/webpack/__tests__/__snapshots__/ForemanRhCloudHelpers.test.js.snap
+++ b/webpack/__tests__/__snapshots__/ForemanRhCloudHelpers.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ForemanRhCloud helpers hasNoInsightsFacet returns false when insights_attributes is present 1`] = `false`;
+
+exports[`ForemanRhCloud helpers hasNoInsightsFacet returns true when insights_attributes is missing 1`] = `true`;
+
+exports[`ForemanRhCloud helpers hasNoInsightsFacet returns true when response is missing 1`] = `true`;
+
 exports[`ForemanRhCloud helpers should return foreman Url 1`] = `"MY_TEST_URL_PREFIX.example.com/test_path"`;
 
 exports[`ForemanRhCloud helpers vulnerabilityDisabled returns false for RHEL host with vulnerability enabled 1`] = `false`;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Remove the dependency on host-specific response data
* This approach is consistent with how other components in the codebase handle this configuration and ensures that all hosts (with or without insights_facet) properly determine which advisor engine to display based on the global system settings.
* Now the Insights/Recommendations tab will be hidden if either:
  * The host is not a RHEL host (existing logic), OR
  * The host doesn't have an insights_facet (new logic)

* This means that for a host to show the Recommendations tab, it must be:
  * A RHEL host (Red Hat Enterprise Linux), AND
  * Have an insights_facet (indicated by the presence of insights_attributes in the response)

#### Considerations taken when implementing this change?
* Made sure it still works on non-iop systems

#### What are the testing steps for this pull request?
* Setup a devel box with IOP
* Click on the devel box hostname since that should not have a subscription/insights_facet and see that it pulls up the non-iop recommendations page
<img width="1920" height="1033" alt="Screenshot 2025-09-19 at 14-53-42 ip-10-0-168-128 rhos-01 prod psi rdu2 redhat com" src="https://github.com/user-attachments/assets/9b11df92-b89a-48f3-ab67-6f4c95c0a789" />

* Check out PR
* Clear your browser cache
* Visit the same host and see we have don't have a recommendations page