### PR TITLE
Drop scoped_search extensions

### DIFF
--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -83,27 +83,6 @@ module ForemanRhCloud
         :description => N_('Configure Cloud Connector on given hosts'),
         :proxy_selector_override => ::RemoteExecutionProxySelector::INTERNAL_PROXY
       )
-
-      ScopedSearch::AutoCompleteBuilder.class_eval do
-        # Insights rule IDs always contain a pipe character.
-        # example: hardening_ssh_config_perms|OPENSSH_HARDENING_CONFIG_PERMS
-        # We need to override this method of scoped_search so that autocomplete
-        # will correctly put the value in quotes (otherwise the "|" will be
-        # interpreted as an OR.)
-        # The only change from scoped_search code is adding the | to the regex in the final map.
-        def complete_value_from_db(field, special_values, val)
-          count = 20 - special_values.count
-          completer_scope(field)
-            .where(@options[:value_filter])
-            .where(value_conditions(field.quoted_field, val))
-            .select(field.quoted_field)
-            .limit(count)
-            .distinct
-            .map(&field.field)
-            .compact
-            .map { |v| v.to_s =~ /\s|\|/ ? "\"#{v.gsub('"', '\"')}\"" : v }
-        end
-      end
     end
 
     # Ideally this code belongs to an initializer. The problem is that Katello controllers are not initialized completely until after the end of the to_prepare blocks

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -6,7 +6,7 @@ module ForemanRhCloud
       return if Foreman::Plugin.find(:foreman_rh_cloud)
 
       Foreman::Plugin.register :foreman_rh_cloud do
-        requires_foreman '>= 3.13'
+        requires_foreman '>= 3.17'
         register_gettext
 
         apipie_documented_controllers ["#{ForemanRhCloud::Engine.root}/app/controllers/api/v2/**/*.rb"]


### PR DESCRIPTION
It was implemented in scoped_search itself, newer scoped_search will be pulled in by foreman-3.17 (dependency being bumped in https://github.com/theforeman/foreman/pull/10677).

Fixes b2ffab5 (#1083)

## Summary by Sourcery

Remove the custom scoped_search autocomplete override and update the Foreman plugin requirement to use scoped_search’s built-in implementation.

Enhancements:
- Drop the ScopedSearch::AutoCompleteBuilder.complete_value_from_db monkey patch now implemented upstream
- Raise the Foreman requirement from 3.13 to 3.17 to pull in the updated scoped_search dependency