### PR TITLE
SAT-35237 Add message on report upload to check the uploading tab

### DIFF
--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -45,6 +45,7 @@ namespace :rh_cloud_inventory do
           archived_report_generator = ForemanInventoryUpload::Generators::ArchivedReport.new(target, Logger.new(STDOUT))
           archived_report_generator.render(organization: organization, filter: filter)
           puts "Successfully generated #{target} for organization id #{organization}"
+          puts "Check the Uploading tab for report uploading status." if Setting[:subscription_connection_enabled]
 
           next unless ForemanRhCloud.with_iop_smart_proxy?
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* UX improvement requested by QE @LadislavVasina1 to let the user know if they have a Satellite with subscription_connection_enabled that the report will not stay in `generated_reports` and check the Uploading tab to see that the report uploaded and what location it's in after the upload is finished. 

#### What are the testing steps for this pull request?
* Check out PR
* Import a manifest
* Kick off a report inventory upload task and see if you see this message:
```bash
Successfully generated /home/vagrant/foreman/red_hat_inventory/generated_reports/report_for_1.tar.xz for organization id 1. Check the uploading tab for further updates.
```
* Turn off subscription_connection_enabled in settings
* Run the report generation and see that the message says:
```bash
Successfully generated /home/vagrant/foreman/red_hat_inventory/generated_reports/report_for_1.tar.xz for organization id 1.
```

## Summary by Sourcery

Enhancements:
- Show an extra instruction to check the uploading tab if subscription_connection_enabled is turned on during report generation