### PR TITLE
Add breaks-robottelo workflow as per theforeman/foreman PR 10568

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -1,0 +1,15 @@
+name: Label a PR `breaks-robottelo` on appropriate comment
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  breaks-robottelo:
+    uses: theforeman/actions/.github/workflows/breaks-robottelo.yml@v0
+    permissions:
+      pull-requests: write
+    with:
+      repo: ${{ github.repository }}
+      issue: ${{ github.event.issue.number }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Before merging, `breaks-robottelo` label needs to be added to the repo manually by a maintainer

## Summary by Sourcery

Add a GitHub Actions workflow to automatically label pull requests with 'breaks-robottelo' when a comment is created, using theforeman/actions external workflow, and require maintainers to manually add the 'breaks-robottelo' label before enabling the workflow.

CI:
- Introduce .github/workflows/test-breaking.yaml to trigger the breaks-robottelo labeling workflow on issue_comment events
- Use theforeman/actions/.github/workflows/breaks-robottelo.yml@v0 with pull-requests write permissions to apply the label

Chores:
- Require manual creation of the 'breaks-robottelo' label in the repository before activating the workflow