### PR TITLE
Generate single-host reports without shell commands or rake task

### DIFF
--- a/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
@@ -15,11 +15,10 @@ module InsightsCloud
       logger.debug("Generating host-specific report for host #{@host.name}")
 
       ForemanTasks.async_task(
-        ForemanInventoryUpload::Async::GenerateReportJob,
+        ForemanInventoryUpload::Async::SingleHostReportJob,
         ForemanInventoryUpload.generated_reports_folder,
         @host.organization_id,
-        false,
-        "id=#{@host.id}"
+        @host.id
       )
 
       # in IoP case, the hosts are identified by the sub-man ID, and we can assume they already

--- a/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
+++ b/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
@@ -1,0 +1,29 @@
+module ForemanInventoryUpload
+  module Async
+    class CreateMissingInsightsFacets < ::Actions::EntryAction
+      def plan(organization_id)
+        plan_self(organization_id: organization_id)
+      end
+
+      def run
+        organization = ::Organization.find(input[:organization_id])
+        hosts_without_facets = ::ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: 'null? insights_uuid')
+        facet_count = hosts_without_facets.count
+        hosts_without_facets.each do |batch|
+          facets = batch.pluck(:id, 'katello_subscription_facets.uuid').map do |host_id, uuid|
+            {
+              host_id: host_id,
+              uuid: uuid,
+            }
+          end
+          # We don't need to validate the facets here as we create the necessary fields.
+          # rubocop:disable Rails/SkipsModelValidations
+          InsightsFacet.upsert_all(facets, unique_by: :host_id) unless facets.empty?
+          # rubocop:enable Rails/SkipsModelValidations
+        end
+        output[:result] = facet_count.zero? ? _("There were no missing Insights facets") : format(_("Missing Insights facets created: %s"), facet_count)
+        Rails.logger.info output[:result]
+      end
+    end
+  end
+end

--- a/lib/foreman_inventory_upload/async/generate_host_report.rb
+++ b/lib/foreman_inventory_upload/async/generate_host_report.rb
@@ -1,0 +1,20 @@
+module ForemanInventoryUpload
+  module Async
+    class GenerateHostReport < ::Actions::EntryAction
+      def plan(base_folder, organization_id, filter)
+        plan_self(
+          base_folder: base_folder,
+          organization_id: organization_id,
+          filter: filter
+        )
+        input[:target] = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(input[:organization_id], input[:filter]))
+      end
+
+      def run
+        archived_report_generator = ForemanInventoryUpload::Generators::ArchivedReport.new(input[:target])
+        archived_report_generator.render(organization: input[:organization_id], filter: input[:filter])
+        output[:result] = "Generated #{input[:target]} for organization id #{input[:organization_id]}"
+      end
+    end
+  end
+end

--- a/lib/foreman_inventory_upload/async/generate_report_job.rb
+++ b/lib/foreman_inventory_upload/async/generate_report_job.rb
@@ -5,7 +5,7 @@ module ForemanInventoryUpload
         "report_for_#{label}"
       end
 
-      def plan(base_folder, organization_id, disconnected, hosts_filter = nil)
+      def plan(base_folder, organization_id, disconnected = false, hosts_filter = nil)
         sequence do
           super(
             GenerateReportJob.output_label("#{organization_id}#{hosts_filter.empty? ? nil : "[#{hosts_filter.to_s.parameterize}]"}"),

--- a/lib/foreman_inventory_upload/async/host_inventory_report_job.rb
+++ b/lib/foreman_inventory_upload/async/host_inventory_report_job.rb
@@ -1,0 +1,39 @@
+module ForemanInventoryUpload
+  module Async
+    class HostInventoryReportJob < ::Actions::EntryAction
+      def plan(base_folder, organization_id, hosts_filter = "", upload = true)
+        sequence do
+          plan_action(
+            GenerateHostReport,
+            base_folder,
+            organization_id,
+            hosts_filter
+          )
+          if upload
+            plan_action(
+              QueueForUploadJob,
+              base_folder,
+              ForemanInventoryUpload.facts_archive_name(organization_id, hosts_filter),
+              organization_id
+            )
+          end
+
+          if ForemanRhCloud.with_iop_smart_proxy?
+            plan_action(
+              CreateMissingInsightsFacets,
+              organization_id
+            )
+          end
+        end
+      end
+
+      def humanized_name
+        _("Host inventory report job")
+      end
+
+      def organization_id
+        input[:organization_id]
+      end
+    end
+  end
+end

--- a/lib/foreman_inventory_upload/async/single_host_report_job.rb
+++ b/lib/foreman_inventory_upload/async/single_host_report_job.rb
@@ -1,0 +1,20 @@
+module ForemanInventoryUpload
+  module Async
+    class SingleHostReportJob < HostInventoryReportJob
+      def plan(base_folder, organization_id, host_id)
+        input[:host_id] = host_id
+        super(base_folder, organization_id, "id=#{input[:host_id]}")
+      end
+
+      def hostname(host_id)
+        host = ::Host.find_by(id: host_id)
+        host&.name
+      end
+
+      def humanized_name
+        hostname_result = hostname(input[:host_id])
+        hostname_result.present? ? format(_("Single-host report job for host %s"), hostname_result) : _("Single-host report job")
+      end
+    end
+  end
+end

--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -256,7 +256,7 @@ module ForemanInventoryUpload
 
         @stream.array_field('yum_repos') do
           host.content_facet.bound_repositories.each_with_index do |repo, index|
-            report_yum_repo(host.content_source.load_balancer_pulp_content_url, repo)
+            report_yum_repo(host.content_source&.load_balancer_pulp_content_url || ::SmartProxy.pulp_primary.pulp_content_url, repo)
             @stream.comma unless index == host.content_facet.bound_repositories.count - 1
           end
         end

--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -9,22 +9,20 @@ namespace :rh_cloud_inventory do
       else
         organizations = [Organization.where(:id => ENV['organization_id']).first]
       end
-      disconnected = ForemanRhCloud.with_iop_smart_proxy?
       User.as_anonymous_admin do
         organizations.each do |organization|
           ForemanTasks.async_task(
             ForemanInventoryUpload::Async::GenerateReportJob,
             ForemanInventoryUpload.generated_reports_folder,
-            organization.id,
-            disconnected
+            organization.id
           )
           puts "Generated and uploaded inventory report for organization '#{organization.name}'"
         end
       end
     end
     desc 'Generate inventory report to be sent to Red Hat cloud'
-    task generate: :environment do
-      organizations = [ENV['organization_id']]
+    task generate: [:environment, 'dynflow:client'] do
+      organization_ids = [ENV['organization_id']]
       base_folder = ENV['target'] || Dir.pwd
       filter = ENV['hosts_filter']
 
@@ -34,37 +32,22 @@ namespace :rh_cloud_inventory do
         puts "Using #{base_folder} for the output"
       end
 
-      if organizations.empty?
+      if organization_ids.empty?
         puts "Must specify organization_id"
         return
       end
 
       User.as_anonymous_admin do
-        organizations.each do |organization|
-          target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization, filter))
-          archived_report_generator = ForemanInventoryUpload::Generators::ArchivedReport.new(target, Logger.new(STDOUT))
-          archived_report_generator.render(organization: organization, filter: filter)
-          puts "Successfully generated #{target} for organization id #{organization}"
-          puts "Check the Uploading tab for report uploading status." if Setting[:subscription_connection_enabled]
-
-          next unless ForemanRhCloud.with_iop_smart_proxy?
-
-          puts 'Creating missing insights facets'
-          hosts_without_facets = ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: 'null? insights_uuid')
-          hosts_without_facets.each do |batch|
-            facets = batch.pluck(:id, 'katello_subscription_facets.uuid').map do |host_id, uuid|
-              {
-                host_id: host_id,
-                uuid: uuid,
-              }
-            end
-            # We don't need to validate the facets here as we create the necessary fields.
-            # rubocop:disable Rails/SkipsModelValidations
-            InsightsFacet.upsert_all(facets, unique_by: :host_id) unless facets.empty?
-            # rubocop:enable Rails/SkipsModelValidations
-          end
-          puts 'Missing Insights facets created'
+        organization_ids.each do |organization_id|
+          ForemanTasks.sync_task(
+            ForemanInventoryUpload::Async::HostInventoryReportJob,
+            base_folder,
+            organization_id,
+            filter,
+            false # don't upload; the user ran report:generate and not report:generate_upload
+          )
         end
+        puts "Check the Uploading tab for report uploading status." if Setting[:subscription_connection_enabled]
       end
     end
     desc 'Upload generated inventory report to Red Hat cloud'
@@ -72,8 +55,7 @@ namespace :rh_cloud_inventory do
       base_folder = ENV['target'] || ForemanInventoryUpload.generated_reports_folder
       organization_id = ENV['organization_id']
       report_file = ForemanInventoryUpload.facts_archive_name(organization_id)
-      disconnected = ForemanRhCloud.with_iop_smart_proxy?
-      ForemanTasks.sync_task(ForemanInventoryUpload::Async::QueueForUploadJob, base_folder, report_file, organization_id, disconnected)
+      ForemanTasks.sync_task(ForemanInventoryUpload::Async::QueueForUploadJob, base_folder, report_file, organization_id)
       puts "Uploaded #{report_file}"
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

As part of the IoP Vulnerability service, package profile upload triggers a single-host inventory report upload. Previously this was accomplished the same way as other inventory reports, meaning it was run in a shell process which ran a rake task, and report generation output was captured for display in the web UI. However, with hundreds or thousands of hosts it seems this caused large performance bottlenecks.

This change removes some of that overhead by extracting the report generation to a new Dynflow task and running it directly. This means no shell process and no rake task, hopefully eliminating that bloat and improving performance.

#### Considerations taken when implementing this change?

Both this and BulkGenerateApplicability are triggered by package profile upload and can run concurrently. But since inventory reports only require an updated package profile and not updated applicability calculation, I think this is fine.

I had to fix a line in slice.rb since my host didn't have a content source

#### What are the testing steps for this pull request?

yum -y upgrade jq or yum -y downgrade jq
Watch Foreman logs and verify that `ForemanInventoryUpload::Async::SingleHostReportJob` completes with success
Inspect Dynflow console inputs and outputs and make sure everything looks ok
Extract the report tar and make sure it looks ok.


## Summary by Sourcery

Support generating single-host inventory reports via a new async job pipeline, replace shell/rake-based approach, and improve yum repo URL handling.

New Features:
- Introduce SingleHostReportJob to orchestrate asynchronous single-host report generation and upload
- Add GenerateSingleHostReport action to render archived report for a specific host
- Update host report endpoint to invoke SingleHostReportJob instead of the generic GenerateReportJob

Enhancements:
- Provide fallback to SmartProxy primary pulp_content_url for yum repository reporting when content_source is unavailable