### PR TITLE
Release 12.2.9

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.2.8'.freeze
+  VERSION = '12.2.9'.freeze
 end

--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -45,6 +45,7 @@ namespace :rh_cloud_inventory do
           archived_report_generator = ForemanInventoryUpload::Generators::ArchivedReport.new(target, Logger.new(STDOUT))
           archived_report_generator.render(organization: organization, filter: filter)
           puts "Successfully generated #{target} for organization id #{organization}"
+          puts "Check the Uploading tab for report uploading status." if Setting[:subscription_connection_enabled]
 
           next unless ForemanRhCloud.with_iop_smart_proxy?
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.2.8",
+  "version": "12.2.9",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {

--- a/webpack/ForemanRhCloudFills.js
+++ b/webpack/ForemanRhCloudFills.js
@@ -4,7 +4,11 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import InventoryAutoUploadSwitcher from './ForemanInventoryUpload/SubscriptionsPageExtension/InventoryAutoUpload';
 import NewHostDetailsTab from './InsightsHostDetailsTab/NewHostDetailsTab';
 import { InsightsTotalRiskChartWrapper } from './InsightsHostDetailsTab/InsightsTotalRiskChartWrapper';
-import { isNotRhelHost, vulnerabilityDisabled } from './ForemanRhCloudHelpers';
+import {
+  isNotRhelHost,
+  vulnerabilityDisabled,
+  hasNoInsightsFacet,
+} from './ForemanRhCloudHelpers';
 import CVEsHostDetailsTabWrapper from './CVEsHostDetailsTab/CVEsHostDetailsTab';
 
 const fills = [
@@ -20,7 +24,7 @@ const fills = [
     component: props => <NewHostDetailsTab {...props} />,
     weight: 400,
     metadata: {
-      hideTab: isNotRhelHost,
+      hideTab: props => isNotRhelHost(props) || hasNoInsightsFacet(props),
       title: __('Recommendations'),
     },
   },

--- a/webpack/ForemanRhCloudHelpers.js
+++ b/webpack/ForemanRhCloudHelpers.js
@@ -14,3 +14,7 @@ export const isNotRhelHost = ({ hostDetails }) =>
 
 export const vulnerabilityDisabled = ({ hostDetails }) =>
   isNotRhelHost({ hostDetails }) || !hostDetails?.vulnerability?.enabled;
+
+export const hasNoInsightsFacet = ({ response, hostDetails }) =>
+  // eslint-disable-next-line camelcase
+  !(response?.insights_attributes || hostDetails?.insights_attributes);

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -131,28 +131,15 @@ const IopInsightsTabWrapped = props => (
 );
 
 const InsightsTab = props => {
-  const { response } = props;
-  const isLocalAdvisorEngine =
-    // eslint-disable-next-line camelcase
-    response?.insights_attributes?.use_iop_mode;
+  const isLocalIop = useAdvisorEngineConfig();
 
-  return isLocalAdvisorEngine ? (
+  return isLocalIop ? (
     <IopInsightsTabWrapped {...props} />
   ) : (
     <NewHostDetailsTab {...props} />
   );
 };
 
-InsightsTab.propTypes = {
-  response: PropTypes.shape({
-    insights_attributes: {
-      use_iop_mode: PropTypes.bool,
-    },
-  }),
-};
-
-InsightsTab.defaultProps = {
-  response: {},
-};
+InsightsTab.defaultProps = {};
 
 export default InsightsTab;

--- a/webpack/__tests__/ForemanRhCloudHelpers.test.js
+++ b/webpack/__tests__/ForemanRhCloudHelpers.test.js
@@ -1,5 +1,5 @@
 import { testSelectorsSnapshotWithFixtures } from '@theforeman/test';
-import { foremanUrl, vulnerabilityDisabled } from '../ForemanRhCloudHelpers';
+import { foremanUrl, vulnerabilityDisabled, hasNoInsightsFacet } from '../ForemanRhCloudHelpers';
 
 global.URL_PREFIX = 'MY_TEST_URL_PREFIX.example.com';
 
@@ -34,6 +34,21 @@ const fixtures = {
     }),
   'vulnerabilityDisabled returns true for missing hostDetails': () =>
     vulnerabilityDisabled({}),
+  'hasNoInsightsFacet returns false when insights_attributes is present': () =>
+    hasNoInsightsFacet({
+      response: {
+        insights_attributes: {
+          uuid: 'test-uuid',
+          insights_hits_count: 5,
+        },
+      },
+    }),
+  'hasNoInsightsFacet returns true when insights_attributes is missing': () =>
+    hasNoInsightsFacet({
+      response: {},
+    }),
+  'hasNoInsightsFacet returns true when response is missing': () =>
+    hasNoInsightsFacet({}),
 };
 
 describe('ForemanRhCloud helpers', () =>

--- a/webpack/__tests__/__snapshots__/ForemanRhCloudHelpers.test.js.snap
+++ b/webpack/__tests__/__snapshots__/ForemanRhCloudHelpers.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ForemanRhCloud helpers hasNoInsightsFacet returns false when insights_attributes is present 1`] = `false`;
+
+exports[`ForemanRhCloud helpers hasNoInsightsFacet returns true when insights_attributes is missing 1`] = `true`;
+
+exports[`ForemanRhCloud helpers hasNoInsightsFacet returns true when response is missing 1`] = `true`;
+
 exports[`ForemanRhCloud helpers should return foreman Url 1`] = `"MY_TEST_URL_PREFIX.example.com/test_path"`;
 
 exports[`ForemanRhCloud helpers vulnerabilityDisabled returns false for RHEL host with vulnerability enabled 1`] = `false`;


### PR DESCRIPTION
## Summary by Sourcery

Refactor the InsightsTab component to use a hook, introduce a helper to detect missing insights facets and update tab visibility logic, add corresponding tests, and bump the release version to 12.2.9

Enhancements:
- Refactor InsightsTab to use useAdvisorEngineConfig hook instead of response props and remove propTypes
- Add hasNoInsightsFacet helper and integrate it into the Recommendations tab hide logic
- Add informational log output in rh_cloud_inventory rake task when subscription connection is enabled

Tests:
- Add tests for hasNoInsightsFacet in ForemanRhCloudHelpers

Chores:
- Bump version to 12.2.9 in gemspec and package.json