### PR TITLE
Register foreman_rh_cloud app metadata

### DIFF
--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -147,7 +147,7 @@ module ForemanRhCloud
         end
 
         ::Foreman::Plugin.app_metadata_registry.register(:foreman_rh_cloud, {
-          iop: ForemanRhCloud.with_iop_smart_proxy?
+          iop: ForemanRhCloud.with_iop_smart_proxy?,
         })
 
         extend_template_helpers ForemanRhCloud::TemplateRendererHelper

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -146,6 +146,10 @@ module ForemanRhCloud
           end
         end
 
+        ::Foreman::Plugin.app_metadata_registry.register(:foreman_rh_cloud, {
+          iop: ForemanRhCloud.with_iop_smart_proxy?
+        })
+
         extend_template_helpers ForemanRhCloud::TemplateRendererHelper
         allowed_template_helpers :remediations_playbook, :download_rh_playbook
       end

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -73,6 +73,7 @@ const hostsIndexColumnExtensions = [
   {
     columnName: 'cves_count',
     title: __('Total CVEs'),
+    isRelevant: context => context?.metadata?.foreman_rh_cloud.iop ?? true,
     wrapper: hostDetails => <CVECountCell hostDetails={hostDetails} />,
     weight: 2600,
     tableName: 'hosts',

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -73,6 +73,7 @@ const hostsIndexColumnExtensions = [
   {
     columnName: 'cves_count',
     title: __('Total CVEs'),
+    // eslint-disable-next-line camelcase
     isRelevant: context => context?.metadata?.foreman_rh_cloud.iop ?? true,
     wrapper: hostDetails => <CVECountCell hostDetails={hostDetails} />,
     weight: 2600,

--- a/webpack/InsightsCloudSync/Components/InsightsSettings/InsightsSettings.js
+++ b/webpack/InsightsCloudSync/Components/InsightsSettings/InsightsSettings.js
@@ -3,19 +3,19 @@ import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 import SwitcherPF4 from '../../../common/Switcher/SwitcherPF4';
 import './insightsSettings.scss';
-import { useAdvisorEngineConfig } from '../../../common/Hooks/ConfigHooks';
+import { useIopConfig } from '../../../common/Hooks/ConfigHooks';
 
 const InsightsSettings = ({
   insightsSyncEnabled,
   getInsightsSyncSettings,
   setInsightsSyncEnabled,
 }) => {
-  const isLocalAdvisorEngine = useAdvisorEngineConfig();
+  const isIop = useIopConfig();
   useEffect(() => {
     getInsightsSyncSettings();
   }, [getInsightsSyncSettings]);
 
-  if (isLocalAdvisorEngine) return null;
+  if (isIop) return null;
 
   return (
     <div className="insights_settings">

--- a/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTable.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTable.js
@@ -16,7 +16,7 @@ import TableEmptyState from '../../../common/table/EmptyState';
 import { modifySelectedRows, getSortColumnIndex } from './InsightsTableHelpers';
 import Pagination from './Pagination';
 import './table.scss';
-import { useAdvisorEngineConfig } from '../../../common/Hooks/ConfigHooks';
+import { useIopConfig } from '../../../common/Hooks/ConfigHooks';
 
 const InsightsTable = ({
   page,
@@ -48,7 +48,7 @@ const InsightsTable = ({
     fetchInsights({ page, perPage, query, sortBy, sortOrder });
   }, [hostname]);
 
-  const isLocalAdvisorEngine = useAdvisorEngineConfig();
+  const isIop = useIopConfig();
 
   useEffect(() => {
     setRows(
@@ -57,7 +57,7 @@ const InsightsTable = ({
         selectedIds,
         showSelectAllAlert,
         hideHost,
-        isLocalAdvisorEngine
+        isIop
       )
     );
 

--- a/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTable.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTable.js
@@ -52,13 +52,7 @@ const InsightsTable = ({
 
   useEffect(() => {
     setRows(
-      modifySelectedRows(
-        hits,
-        selectedIds,
-        showSelectAllAlert,
-        hideHost,
-        isIop
-      )
+      modifySelectedRows(hits, selectedIds, showSelectAllAlert, hideHost, isIop)
     );
 
     if (hideHost) setColumns(getColumnsWithoutHostname());

--- a/webpack/InsightsCloudSync/Components/RemediationModal/RemediationModal.js
+++ b/webpack/InsightsCloudSync/Components/RemediationModal/RemediationModal.js
@@ -16,7 +16,7 @@ import { modifyRows } from './RemediationHelpers';
 import ModalFooter from './RemediationModalFooter';
 import TableEmptyState from '../../../common/table/EmptyState';
 import './RemediationModal.scss';
-import { useAdvisorEngineConfig } from '../../../common/Hooks/ConfigHooks';
+import { useIopConfig } from '../../../common/Hooks/ConfigHooks';
 
 /* eslint-disable spellcheck/spell-checker */
 
@@ -82,7 +82,7 @@ const RemediationModal = ({
   const [rows, setRows] = React.useState([]);
   const toggleModal = () => setOpen(prevValue => !prevValue);
 
-  const isIop = useAdvisorEngineConfig();
+  const isIop = useIopConfig();
   useEffect(() => {
     // only fetch for Hosted. IoP provides via props.
     if (!isIop && open)

--- a/webpack/InsightsCloudSync/Components/ToolbarDropdown.js
+++ b/webpack/InsightsCloudSync/Components/ToolbarDropdown.js
@@ -8,12 +8,12 @@ import {
 } from '@patternfly/react-core/deprecated';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { redHatAdvisorSystems } from '../InsightsCloudSyncHelpers';
-import { useAdvisorEngineConfig } from '../../common/Hooks/ConfigHooks';
+import { useIopConfig } from '../../common/Hooks/ConfigHooks';
 
 const ToolbarDropdown = ({ onRecommendationSync }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const isLocalAdvisorEngine = useAdvisorEngineConfig();
-  if (isLocalAdvisorEngine) {
+  const isIop = useIopConfig();
+  if (isIop) {
     return null;
   }
   const dropdownItems = [

--- a/webpack/InsightsCloudSync/InsightsCloudSync.js
+++ b/webpack/InsightsCloudSync/InsightsCloudSync.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
 import InsightsTable from './Components/InsightsTable';
-import { useAdvisorEngineConfig } from '../common/Hooks/ConfigHooks';
+import { useIopConfig } from '../common/Hooks/ConfigHooks';
 import { foremanUrl } from '../ForemanRhCloudHelpers';
 import RemediationModal from './Components/RemediationModal';
 import {
@@ -85,9 +85,9 @@ const IopRecommendationsPageWrapped = props => (
 );
 
 const RecommendationsPage = props => {
-  const isLocalAdvisorEngine = useAdvisorEngineConfig();
+  const isIop = useIopConfig();
 
-  return isLocalAdvisorEngine ? (
+  return isIop ? (
     <IopRecommendationsPageWrapped {...props} />
   ) : (
     <InsightsCloudSync {...props} />

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -21,7 +21,7 @@ import {
   selectHits,
 } from '../InsightsCloudSync/Components/InsightsTable/InsightsTableSelectors';
 import { redHatAdvisorSystems } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
-import { useAdvisorEngineConfig } from '../common/Hooks/ConfigHooks';
+import { useIopConfig } from '../common/Hooks/ConfigHooks';
 import { generateRuleUrl } from '../InsightsCloudSync/InsightsCloudSync';
 import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
 
@@ -30,7 +30,7 @@ const NewHostDetailsTab = ({ hostName, router }) => {
   const dispatch = useDispatch();
   const query = useSelector(selectSearch);
   const hits = useSelector(selectHits);
-  const isLocalAdvisorEngine = useAdvisorEngineConfig();
+  const isIop = useIopConfig();
 
   useEffect(() => () => router.replace({ search: null }), [router]);
 
@@ -46,7 +46,7 @@ const NewHostDetailsTab = ({ hostName, router }) => {
     </DropdownItem>,
   ];
 
-  if (hits.length && !isLocalAdvisorEngine) {
+  if (hits.length && !isIop) {
     const { host_uuid: uuid } = hits[0];
     dropdownItems.push(
       <DropdownItem key="insights-advisor-link" ouiaId="insights-advisor-link">
@@ -131,9 +131,9 @@ const IopInsightsTabWrapped = props => (
 );
 
 const InsightsTab = props => {
-  const isLocalIop = useAdvisorEngineConfig();
+  const isIop = useIopConfig();
 
-  return isLocalIop ? (
+  return isIop ? (
     <IopInsightsTabWrapped {...props} />
   ) : (
     <NewHostDetailsTab {...props} />

--- a/webpack/common/Hooks/ConfigHooks.js
+++ b/webpack/common/Hooks/ConfigHooks.js
@@ -1,11 +1,12 @@
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { useForemanContext } from 'foremanReact/Root/Context/ForemanContext';
 import {
   ADVISOR_ENGINE_CONFIG_KEY,
   ADVISOR_ENGINE_CONFIG_PATH,
 } from '../../InsightsCloudSync/Components/InsightsTable/InsightsTableConstants';
-import { useForemanContext } from 'foremanReact/Root/Context/ForemanContext';
 
 export const useIopConfig = () => {
+  // eslint-disable-next-line camelcase
   const result = useForemanContext().metadata?.foreman_rh_cloud?.iop;
   const skipApiRequest = result !== undefined;
   const { response: advisorEngineConfig } = useAPI(

--- a/webpack/common/Hooks/ConfigHooks.js
+++ b/webpack/common/Hooks/ConfigHooks.js
@@ -3,10 +3,13 @@ import {
   ADVISOR_ENGINE_CONFIG_KEY,
   ADVISOR_ENGINE_CONFIG_PATH,
 } from '../../InsightsCloudSync/Components/InsightsTable/InsightsTableConstants';
+import { useForemanContext } from 'foremanReact/Root/Context/ForemanContext';
 
-export const useAdvisorEngineConfig = () => {
+export const useIopConfig = () => {
+  const result = useForemanContext().metadata?.foreman_rh_cloud?.iop;
+  const skipApiRequest = result !== undefined;
   const { response: advisorEngineConfig } = useAPI(
-    'get',
+    skipApiRequest ? null : 'get',
     ADVISOR_ENGINE_CONFIG_PATH,
     {
       key: ADVISOR_ENGINE_CONFIG_KEY,
@@ -14,5 +17,5 @@ export const useAdvisorEngineConfig = () => {
   );
 
   // eslint-disable-next-line camelcase
-  return advisorEngineConfig?.use_iop_mode;
+  return skipApiRequest ? result : advisorEngineConfig?.use_iop_mode;
 };


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Requires https://github.com/theforeman/foreman/pull/10713

In foreman_rh_cloud there are a quite many places where we need to know if it's an IoP setup or not. On the backend this is easy: we'd just call `ForemanRhCloud.with_iop_smart_proxy?`. But from React/JS, it's a bit tricky and there are a couple methods:

1. Include this value inside an existing API response and use it
2. Make an XHR request to a special API endpoint

Neither of these is ideal, for various reasons

1. While the request is pending, we're in a state of "don't know" rather than true/false - what do we display on screen at this moment?
2. In certain cases (like when a host doesn't have an insights facet) it's not possible to use the API response

With this change, the `.with_iop_smart_proxy?` value is added to `ForemanContext` and we can use it anywhere without making an API call.

Additionally, since IoP is now more than just Advisor engine, I've taken the liberty of renaming our React hook.

#### Considerations taken when implementing this change?

I didn't remove the endpoint completely. IoP services may still need to call it some day..?

#### What are the testing steps for this pull request?

get an IoP setup
Load pages that make this request and observe lack of request with the PR checked out

## Summary by Sourcery

Register the foreman_rh_cloud iop flag in the plugin metadata registry and refactor the configuration hook and related components to use the new useIopConfig hook for conditional rendering and API request skipping

New Features:
- Register foreman_rh_cloud iop flag in the Foreman plugin metadata registry

Enhancements:
- Introduce useIopConfig hook to read IoP mode from app metadata or fallback to API
- Replace useAdvisorEngineConfig with useIopConfig across multiple Insights and host details components
- Conditionally render Insights components and toolbar items based on IoP mode
- Add isRelevant check for CVE count column using the IoP metadata flag