### PR TITLE
SAT-37395 - Don't make API call for cveColumn if non-iop

### DIFF
--- a/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
@@ -3,24 +3,30 @@ import PropTypes from 'prop-types';
 import { UnknownIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
-
 import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
+import { useAdvisorEngineConfig } from '../common/Hooks/ConfigHooks';
 
 const vulnerabilityApiPath = path =>
   insightsCloudUrl(`api/vulnerability/v1/${path}`);
 
 export const CVECountCell = ({ hostDetails }) => {
+  const isIopEnabled = useAdvisorEngineConfig();
+
   // eslint-disable-next-line camelcase
   const uuid = hostDetails?.subscription_facet_attributes?.uuid;
 
   const key = `HOST_CVE_COUNT_${uuid}`;
   const response = useAPI(
-    uuid ? 'get' : null,
+    isIopEnabled && uuid ? 'get' : null,
     vulnerabilityApiPath(`systems?uuid=${uuid}`),
     {
       key,
     }
   );
+
+  if (!isIopEnabled) {
+    return <UnknownIcon />;
+  }
 
   if (uuid === undefined) {
     return <UnknownIcon />;

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
@@ -2,8 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { API } from 'foremanReact/redux/API';
 import { CVECountCell } from '../CVECountCell';
+import * as ConfigHooks from '../../common/Hooks/ConfigHooks';
 
 jest.mock('foremanReact/redux/API');
+jest.mock('../../common/Hooks/ConfigHooks');
+
 API.get.mockImplementation(async () => ({
   data: [
     {
@@ -14,15 +17,58 @@ API.get.mockImplementation(async () => ({
   ],
 }));
 
+const hostDetailsMock = {
+      name: 'test-host.example.com',
+      subscription_facet_attributes: {
+        uuid: 'test-uuid-123',
+      },
+    };
+
 describe('CVECountCell', () => {
-  it('renders an empty cves count column', () => {
-    const hostDetailsMock = {
+  beforeEach(() => {
+    ConfigHooks.useAdvisorEngineConfig.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders an empty cves count column when no subscription UUID', () => {
+    const hostDetailsMockIoP = {
       name: 'test-host.example.com',
       subscription_facet_attributes: {
         uuid: null, // no subscription
       },
     };
+    render(<CVECountCell hostDetails={hostDetailsMockIoP} />);
+    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+  });
+
+  it('renders UnknownIcon when IoP is not enabled', () => {
+    ConfigHooks.useAdvisorEngineConfig.mockReturnValue(false);
     render(<CVECountCell hostDetails={hostDetailsMock} />);
     expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    expect(ConfigHooks.useAdvisorEngineConfig).toHaveBeenCalled();
+  });
+
+  it('renders UnknownIcon when IoP is enabled but CVE API call fails', () => {
+    // Mock successful IoP config
+    ConfigHooks.useAdvisorEngineConfig.mockReturnValue(true);
+    // Mock CVE API failure - override the global mock for this test
+    API.get.mockImplementationOnce(async () => {
+      throw new Error('CVE API call failed');
+    });
+
+    render(<CVECountCell hostDetails={hostDetailsMock} />);
+    // Should render UnknownIcon when CVE API fails
+    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    expect(ConfigHooks.useAdvisorEngineConfig).toHaveBeenCalled();
+  });
+
+  it('renders UnknownIcon when IoP is undefined (API call pending)', () => {
+    ConfigHooks.useAdvisorEngineConfig.mockReturnValue(undefined);
+    render(<CVECountCell hostDetails={hostDetailsMock} />);
+    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    expect(ConfigHooks.useAdvisorEngineConfig).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Used useAdvisorEngineConfig hook to check for iop status and add it to the conditional for the api call with uuid
* Added tests

#### Considerations taken when implementing this change?
* Made sure it works on an iop and non-iop box
* This is going into 6.18.0, the real fix are the following pr's that will fix it in 6.18.z/6.19
https://github.com/theforeman/foreman_rh_cloud/pull/1107
https://github.com/theforeman/foreman/pull/10713
* Follow up Jira - https://issues.redhat.com/browse/SAT-38943#

#### What are the testing steps for this pull request?
* Check out PR on a iop-box
* Register a client with sub-man and insights-client
* Verify you see the API call
<img width="1639" height="201" alt="Screenshot 2025-10-02 163732" src="https://github.com/user-attachments/assets/1ae70b01-3517-4059-af41-807f8174a4f4" />
* Check out pr on a non-iop box
* Register a client with sub-man and insights-client
* Verify you see don't the API call

## Summary by Sourcery

Gate CVECountCell API calls on IoP enablement by using the useAdvisorEngineConfig hook and update tests to cover IoP-enabled, IoP-disabled, and API pending scenarios

Enhancements:
- Add IoP status check in CVECountCell to only fetch CVE counts when IoP is enabled
- Return UnknownIcon early for non-IoP setups to avoid unnecessary API calls

Tests:
- Mock useAdvisorEngineConfig in CVECountCell tests and clear mocks between each test
- Add tests to verify UnknownIcon rendering and omission of API calls when IoP is disabled or undefined