### PR TITLE
Release 12.2.11

### DIFF
--- a/app/assets/javascripts/foreman_rh_cloud/locale/fr/foreman_rh_cloud.js
+++ b/app/assets/javascripts/foreman_rh_cloud/locale/fr/foreman_rh_cloud.js
@@ -3,10 +3,10 @@
   "locale_data": {
     "foreman_rh_cloud": {
       "": {
-        "Project-Id-Version": "foreman_rh_cloud 11.1.0",
+        "Project-Id-Version": "foreman_rh_cloud 13.0.5",
         "Report-Msgid-Bugs-To": "",
         "PO-Revision-Date": "2023-01-20 13:26+0000",
-        "Last-Translator": "Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2025",
+        "Last-Translator": "Ondřej Gajdušek, 2025",
         "Language-Team": "French (https://app.transifex.com/foreman/teams/114/fr/)",
         "MIME-Version": "1.0",
         "Content-Type": "text/plain; charset=UTF-8",
@@ -36,7 +36,7 @@
         "Toutes les recommandations sont maintenant sélectionnées."
       ],
       "Analytics data collection": [
-        ""
+        "Collecte de données analytiques"
       ],
       "Any Organization": [
         "Toute Organisation"
@@ -119,11 +119,17 @@
       "Enable automatic deletion of mismatched host records from the Red Hat cloud": [
         "Activer la suppression automatique des enregistrements d'hôtes incompatibles du cloud Red Hat"
       ],
+      "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
       "Enable automatic synchronization of Insights recommendations from the Red Hat cloud": [
         "Activer la synchronisation automatique des recommandations Insights à partir de Red Hat Cloud"
       ],
-      "Enable automatic upload of your host inventory to the Red Hat cloud": [
-        "Activer le téléchargement automatique de votre inventaire d'hôtes dans Red Hat Cloud"
+      "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
+      "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights.": [
+        ""
       ],
       "Enable automatic upload of your hosts inventory to the Red Hat cloud": [
         "Activer le téléchargement automatique de l'inventaire de vos hôtes dans Red Hat Cloud"
@@ -138,12 +144,12 @@
         "Une erreur s'est produite lors de l'accès au serveur :"
       ],
       "Exclude installed packages": [
-        ""
+        "Exclure les paquets installés"
       ],
       "Exclude installed packages from being uploaded to the Red Hat cloud": [
         "Exclure les paquets installés du téléchargement dans Red Hat Cloud"
       ],
-      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)": [
+      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights.": [
         ""
       ],
       "Exit Code: %s": [
@@ -180,7 +186,7 @@
         "Générer et télécharger un rapport"
       ],
       "Generate report": [
-        ""
+        "Générer un rapport"
       ],
       "Generate the report, but do not upload": [
         "Générer le rapport, mais ne pas le télécharger"
@@ -208,6 +214,9 @@
       ],
       "Host Insights recommendations": [
         "Recommandations de Host Insights"
+      ],
+      "Host inventory report job": [
+        ""
       ],
       "Host was not uploaded to your RH cloud inventory": [
         "L'hôte n'a pas été téléchargé dans votre inventaire RH Cloud."
@@ -252,7 +261,7 @@
         "Article de base de connaissances"
       ],
       "Learn more about {minimalDataCollectionSetting}.": [
-        ""
+        "En savoir plus sur{minimalDataCollectionSetting} ."
       ],
       "List of host UUIDs": [
         "Liste des UUID d'hôtes"
@@ -270,6 +279,9 @@
         "Manuelle"
       ],
       "Minimal data collection": [
+        "Collecte minimale de données"
+      ],
+      "Missing Insights facets created: %s": [
         ""
       ],
       "Moderate": [
@@ -306,28 +318,28 @@
         "Obfusquer les adresses ipv4 des hôtes"
       ],
       "Obfuscate host ipv4 addresses.": [
-        ""
+        "Masquer les adresses IPv4 des hôtes."
       ],
       "Obfuscate host names": [
-        "Obfusquer les noms d'hôtes"
+        "Masquer les noms d'hôtes"
       ],
       "Obfuscate host names sent to the Red Hat cloud": [
         "Obfusquer les noms d'hôtes envoyés à Red Hat Cloud"
       ],
-      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)": [
+      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
       "Obfuscate ipv4 addresses sent to the Red Hat cloud": [
         "Obfusquer les adresses ipv4 envoyées à Red Hat Cloud"
       ],
-      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)": [
+      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
-      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings.": [
+      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights.": [
         ""
       ],
       "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled": [
-        ""
+        "Envoyez uniquement les données minimales requises au cloud Red Hat, les paramètres d'obfuscation (masquage) sont désactivés"
       ],
       "Oops! Couldn't find organization that matches your query": [
         "Oups ! Nous n'avons pas trouvé d'organisation correspondant à votre demande."
@@ -344,8 +356,8 @@
       "RH Cloud": [
         "RH Cloud"
       ],
-      "RHC daemon id": [
-        "Id du démon RHC"
+      "RHC daemon id. Ignored when using local Insights.": [
+        ""
       ],
       "Read more about it in RH cloud insights": [
         "Plus d'informations dans RH cloud insights"
@@ -405,7 +417,7 @@
         "Exécuter le playbook RH Cloud"
       ],
       "Run playbook generated by Red Hat remediations app": [
-        ""
+        "Exécuter le playbook généré par l'app de remédiations de Red Hat"
       ],
       "Run remediation playbook generated by Insights": [
         "Exécuter le playbook de remédiation généré par Insights"
@@ -420,7 +432,7 @@
         "Sélectionner des recommandations sur toutes les pages"
       ],
       "Send additional data to enhance Insights services, as per the settings": [
-        ""
+        "Envoyer des données supplémentaires pour améliorer les services Insights, conformément aux paramètres"
       ],
       "Set the current organization context for the request": [
         "Définir le contexte organisationnel actuel de la demande"
@@ -428,14 +440,20 @@
       "Settings": [
         "Paramètres de configuration"
       ],
-      "Should import include parameter tags from Foreman?": [
-        "L'importation doit-elle inclure les balises de paramètres de Foreman ?"
+      "Should import include parameter tags from Foreman? Ignored when using local Insights.": [
+        ""
       ],
       "Show Advanced Settings": [
         "Afficher les paramètres avancés"
       ],
       "Show if system is configured to use local iop-advisor-engine.": [
         "Indique si le système est configuré pour utiliser le moteur iop-advisor local."
+      ],
+      "Single-host report job": [
+        ""
+      ],
+      "Single-host report job for host %s": [
+        ""
       ],
       "Start inventory synchronization": [
         "Démarrer la synchronisation de l'inventaire"
@@ -468,7 +486,7 @@
         "Le fichier de rapport %{filename} n'existe pas"
       ],
       "The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy.": [
-        ""
+        "Le processus planifié est désactivé car ce Foreman est configuré avec un proxy intelligent IoP local."
       ],
       "The server returned the following error: %s": [
         "Le serveur a renvoyé l'erreur suivante : %s"
@@ -478,6 +496,9 @@
       ],
       "There are no recommendations for your hosts": [
         "Il n'y a aucune recommandation pour vos hôtes"
+      ],
+      "There were no missing Insights facets": [
+        ""
       ],
       "This action will also enable automatic reports upload": [
         "Cette action permettra également le téléchargement automatique des rapports"
@@ -489,7 +510,7 @@
         "Pour télécharger manuellement les données d'une organisation spécifique, sélectionnez une organisation et cliquez sur{restartButtonName} ."
       ],
       "Total CVEs": [
-        ""
+        "Total des CVE"
       ],
       "Total risk": [
         "Risque total"
@@ -519,10 +540,10 @@
         "Afficher Red Hat Insights."
       ],
       "Vulnerabilities": [
-        ""
+        "Vulnérabilités"
       ],
       "Vulnerability": [
-        ""
+        "Vulnérabilité"
       ],
       "Wait and %s": [
         "Attendez et %s"
@@ -591,7 +612,7 @@
         "titre de la règle"
       ],
       "setting minimal data collection": [
-        ""
+        "définir une collecte minimale de données"
       ],
       "solution url": [
         "URL de la solution"

--- a/app/assets/javascripts/foreman_rh_cloud/locale/ja/foreman_rh_cloud.js
+++ b/app/assets/javascripts/foreman_rh_cloud/locale/ja/foreman_rh_cloud.js
@@ -3,10 +3,10 @@
   "locale_data": {
     "foreman_rh_cloud": {
       "": {
-        "Project-Id-Version": "foreman_rh_cloud 11.1.0",
+        "Project-Id-Version": "foreman_rh_cloud 13.0.5",
         "Report-Msgid-Bugs-To": "",
         "PO-Revision-Date": "2023-01-20 13:26+0000",
-        "Last-Translator": "Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2025",
+        "Last-Translator": "Ondřej Gajdušek, 2025",
         "Language-Team": "Japanese (https://app.transifex.com/foreman/teams/114/ja/)",
         "MIME-Version": "1.0",
         "Content-Type": "text/plain; charset=UTF-8",
@@ -36,7 +36,7 @@
         "すべての推奨事項が選択されました。"
       ],
       "Analytics data collection": [
-        ""
+        "分析データの収集"
       ],
       "Any Organization": [
         "任意の組織"
@@ -119,11 +119,17 @@
       "Enable automatic deletion of mismatched host records from the Red Hat cloud": [
         "不一致のホストレコードを Red Hat クラウドから自動的に削除できるようにする"
       ],
+      "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
       "Enable automatic synchronization of Insights recommendations from the Red Hat cloud": [
         "Red Hat クラウドから Insights の推奨事項の自動同期を有効にする"
       ],
-      "Enable automatic upload of your host inventory to the Red Hat cloud": [
-        "ホストインベントリーの Red Hat クラウドに対して自動アップロードを有効にする"
+      "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
+      "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights.": [
+        ""
       ],
       "Enable automatic upload of your hosts inventory to the Red Hat cloud": [
         "ホストインベントリーの Red Hat クラウドに対して自動アップロードを有効にする"
@@ -138,12 +144,12 @@
         "サーバーへのアクセス時にエラーが発生しました:"
       ],
       "Exclude installed packages": [
-        ""
+        "インストール済みパッケージの除外"
       ],
       "Exclude installed packages from being uploaded to the Red Hat cloud": [
         "Red Hat クラウドにアップロードされないようにインストール済みパッケージを除外する"
       ],
-      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)": [
+      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights.": [
         ""
       ],
       "Exit Code: %s": [
@@ -180,7 +186,7 @@
         "レポートの生成およびアップロード"
       ],
       "Generate report": [
-        ""
+        "レポートを生成します。"
       ],
       "Generate the report, but do not upload": [
         "レポートを生成するがアップロードしない"
@@ -208,6 +214,9 @@
       ],
       "Host Insights recommendations": [
         "ホストに関する Insights の推奨事項"
+      ],
+      "Host inventory report job": [
+        ""
       ],
       "Host was not uploaded to your RH cloud inventory": [
         "ホストが RH クラウドインベントリーにアップロードされませんでした"
@@ -252,7 +261,7 @@
         "ナレッジベースアーティクル"
       ],
       "Learn more about {minimalDataCollectionSetting}.": [
-        ""
+        "{minimalDataCollectionSetting} の詳細を確認してください。"
       ],
       "List of host UUIDs": [
         "ホスト UUID のリスト"
@@ -270,6 +279,9 @@
         "手動"
       ],
       "Minimal data collection": [
+        "最小限のデータ収集"
+      ],
+      "Missing Insights facets created: %s": [
         ""
       ],
       "Moderate": [
@@ -306,7 +318,7 @@
         "ホストの ipv4 アドレスの難読化"
       ],
       "Obfuscate host ipv4 addresses.": [
-        ""
+        "ホストの IPv4 アドレスを難読化します。"
       ],
       "Obfuscate host names": [
         "ホスト名の難読化"
@@ -314,20 +326,20 @@
       "Obfuscate host names sent to the Red Hat cloud": [
         "Red Hat クラウドに送信するホスト名を難読化する"
       ],
-      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)": [
+      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
       "Obfuscate ipv4 addresses sent to the Red Hat cloud": [
         "Red Hat クラウドに送信する ipv4 アドレスを難読化する"
       ],
-      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)": [
+      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
-      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings.": [
+      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights.": [
         ""
       ],
       "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled": [
-        ""
+        "必要最小限のデータのみを Red Hat クラウドに送信します。難読化設定は無効化されます"
       ],
       "Oops! Couldn't find organization that matches your query": [
         "クエリーに合致する組織が見つかりませんでした"
@@ -344,8 +356,8 @@
       "RH Cloud": [
         "RH Cloud"
       ],
-      "RHC daemon id": [
-        "RHC デーモン ID"
+      "RHC daemon id. Ignored when using local Insights.": [
+        ""
       ],
       "Read more about it in RH cloud insights": [
         "詳細は、RH cloud insights を参照してください。"
@@ -405,7 +417,7 @@
         "RH Cloud Playbook の実行"
       ],
       "Run playbook generated by Red Hat remediations app": [
-        ""
+        "Red Hat 修復アプリケーションによって生成された Playbook の実行"
       ],
       "Run remediation playbook generated by Insights": [
         "Insights で生成された修復 Playbook の実行"
@@ -420,7 +432,7 @@
         "すべてのページから推奨事項を選択する"
       ],
       "Send additional data to enhance Insights services, as per the settings": [
-        ""
+        "Insights サービスの強化のために、設定に従って追加データを送信する"
       ],
       "Set the current organization context for the request": [
         "要求に現在の組織コンテキストを設定します"
@@ -428,14 +440,20 @@
       "Settings": [
         "設定"
       ],
-      "Should import include parameter tags from Foreman?": [
-        "インポートには Foreman からのパラメータータグを含める必要がありますか?"
+      "Should import include parameter tags from Foreman? Ignored when using local Insights.": [
+        ""
       ],
       "Show Advanced Settings": [
         "詳細設定の表示"
       ],
       "Show if system is configured to use local iop-advisor-engine.": [
         "システムがローカル iop-advisor-engine を使用するように設定されているかどうかを表示します。"
+      ],
+      "Single-host report job": [
+        ""
+      ],
+      "Single-host report job for host %s": [
+        ""
       ],
       "Start inventory synchronization": [
         "インベントリー同期の開始"
@@ -468,7 +486,7 @@
         "%{filename} レポートファイルがありません"
       ],
       "The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy.": [
-        ""
+        "この Foreman はローカルの IoP Smart Proxy で設定されているため、スケジュールされたプロセスが無効になっています。"
       ],
       "The server returned the following error: %s": [
         "サーバーは以下のエラーを返しました: %s"
@@ -478,6 +496,9 @@
       ],
       "There are no recommendations for your hosts": [
         "ホストに関する推奨事項はありません"
+      ],
+      "There were no missing Insights facets": [
+        ""
       ],
       "This action will also enable automatic reports upload": [
         "このアクションを実行すると、自動レポートのアップロードも有効になります。"
@@ -489,7 +510,7 @@
         "特定の組織のデータを手動でアップロードするには、組織を選択して {restartButtonName} をクリックします。"
       ],
       "Total CVEs": [
-        ""
+        "CVE の総数"
       ],
       "Total risk": [
         "リスクの総数"
@@ -519,10 +540,10 @@
         "Red Hat Insights での表示"
       ],
       "Vulnerabilities": [
-        ""
+        "脆弱性"
       ],
       "Vulnerability": [
-        ""
+        "脆弱性"
       ],
       "Wait and %s": [
         "待機して %s"
@@ -591,7 +612,7 @@
         "ルールタイトル"
       ],
       "setting minimal data collection": [
-        ""
+        "最小限のデータ収集の設定"
       ],
       "solution url": [
         "ソリューション URL"

--- a/app/assets/javascripts/foreman_rh_cloud/locale/ka/foreman_rh_cloud.js
+++ b/app/assets/javascripts/foreman_rh_cloud/locale/ka/foreman_rh_cloud.js
@@ -3,7 +3,7 @@
   "locale_data": {
     "foreman_rh_cloud": {
       "": {
-        "Project-Id-Version": "foreman_rh_cloud 11.1.0",
+        "Project-Id-Version": "foreman_rh_cloud 13.0.5",
         "Report-Msgid-Bugs-To": "",
         "PO-Revision-Date": "2023-01-20 13:26+0000",
         "Last-Translator": "Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023",
@@ -119,11 +119,17 @@
       "Enable automatic deletion of mismatched host records from the Red Hat cloud": [
         ""
       ],
+      "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
       "Enable automatic synchronization of Insights recommendations from the Red Hat cloud": [
         "Red Hat Cloud-დან Insight-ის რეკომენდაციების ავტომატური სინქრონიზაციების ჩართვა"
       ],
-      "Enable automatic upload of your host inventory to the Red Hat cloud": [
-        "თქვენი ჰოსტების ინვენტარის Red Hat Cloud-ში ავტომატური ატვირთვის ჩართვა"
+      "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
+      "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights.": [
+        ""
       ],
       "Enable automatic upload of your hosts inventory to the Red Hat cloud": [
         "თქვენი ჰოსტების ინვენტარის Red Hat Cloud-ში ავტომატური ატვირთვის ჩართვა"
@@ -143,7 +149,7 @@
       "Exclude installed packages from being uploaded to the Red Hat cloud": [
         "Red Hat cloud-ში ატვირთული პაკეტების სიიდან დაყენებული პაკეტების ამოღება"
       ],
-      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)": [
+      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights.": [
         ""
       ],
       "Exit Code: %s": [
@@ -209,6 +215,9 @@
       "Host Insights recommendations": [
         "ჰოსტის Insights-ის რეკომენდაციები"
       ],
+      "Host inventory report job": [
+        ""
+      ],
       "Host was not uploaded to your RH cloud inventory": [
         "ჰოსტის თქვენი RH-ის ღრუბლოვან ინვენტარში არ ატვირთულა"
       ],
@@ -272,6 +281,9 @@
       "Minimal data collection": [
         ""
       ],
+      "Missing Insights facets created: %s": [
+        ""
+      ],
       "Moderate": [
         "საშუალო"
       ],
@@ -314,16 +326,16 @@
       "Obfuscate host names sent to the Red Hat cloud": [
         "Red Hat cloud-ში გაგზავნილი ჰოსტის სახელების დამახინჯება"
       ],
-      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)": [
+      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
       "Obfuscate ipv4 addresses sent to the Red Hat cloud": [
         "Red Hat cloud-ში გაგზავნილი IPv4 მისამართების დამახინჯება"
       ],
-      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)": [
+      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
-      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings.": [
+      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights.": [
         ""
       ],
       "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled": [
@@ -344,8 +356,8 @@
       "RH Cloud": [
         "RH Cloud"
       ],
-      "RHC daemon id": [
-        "RHC დემონის ID"
+      "RHC daemon id. Ignored when using local Insights.": [
+        ""
       ],
       "Read more about it in RH cloud insights": [
         "გაიგეთ მეტი RH Cloud insights-ის შესახებ"
@@ -428,13 +440,19 @@
       "Settings": [
         "მორგება"
       ],
-      "Should import include parameter tags from Foreman?": [
-        "უნდა შეიცავდეს შემოტანა პარამეტრის ჭდეებს Foreman-დან?"
+      "Should import include parameter tags from Foreman? Ignored when using local Insights.": [
+        ""
       ],
       "Show Advanced Settings": [
         "დამატებითი პარამეტრების ცვენება"
       ],
       "Show if system is configured to use local iop-advisor-engine.": [
+        ""
+      ],
+      "Single-host report job": [
+        ""
+      ],
+      "Single-host report job for host %s": [
         ""
       ],
       "Start inventory synchronization": [
@@ -477,6 +495,9 @@
         "დავალება შემდეგი შეცდომით დასრულდა:"
       ],
       "There are no recommendations for your hosts": [
+        ""
+      ],
+      "There were no missing Insights facets": [
         ""
       ],
       "This action will also enable automatic reports upload": [

--- a/app/assets/javascripts/foreman_rh_cloud/locale/ko/foreman_rh_cloud.js
+++ b/app/assets/javascripts/foreman_rh_cloud/locale/ko/foreman_rh_cloud.js
@@ -3,10 +3,10 @@
   "locale_data": {
     "foreman_rh_cloud": {
       "": {
-        "Project-Id-Version": "foreman_rh_cloud 11.1.0",
+        "Project-Id-Version": "foreman_rh_cloud 13.0.5",
         "Report-Msgid-Bugs-To": "",
         "PO-Revision-Date": "2023-01-20 13:26+0000",
-        "Last-Translator": "Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2025",
+        "Last-Translator": "Ondřej Gajdušek, 2025",
         "Language-Team": "Korean (https://app.transifex.com/foreman/teams/114/ko/)",
         "MIME-Version": "1.0",
         "Content-Type": "text/plain; charset=UTF-8",
@@ -36,7 +36,7 @@
         "모든 권장 사항이 선택되었습니다."
       ],
       "Analytics data collection": [
-        ""
+        "분석 데이터 수집"
       ],
       "Any Organization": [
         "모든 조직 "
@@ -119,11 +119,17 @@
       "Enable automatic deletion of mismatched host records from the Red Hat cloud": [
         "Red Hat 클라우드에서 일치하지 않는 호스트 기록의 자동 삭제를 활성화하십시오."
       ],
+      "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
       "Enable automatic synchronization of Insights recommendations from the Red Hat cloud": [
         "Red Hat 클라우드에서 Insights 권장 사항의 자동 동기화를 활성화합니다."
       ],
-      "Enable automatic upload of your host inventory to the Red Hat cloud": [
-        "호스트 인벤토리를 Red Hat 클라우드에 자동으로 업로드하도록 설정"
+      "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
+      "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights.": [
+        ""
       ],
       "Enable automatic upload of your hosts inventory to the Red Hat cloud": [
         "호스트 인벤토리를 Red Hat 클라우드에 자동으로 업로드하도록 설정"
@@ -138,12 +144,12 @@
         "서버에 접근하는 동안 오류가 발생했습니다:"
       ],
       "Exclude installed packages": [
-        ""
+        "설치된 패키지 제외"
       ],
       "Exclude installed packages from being uploaded to the Red Hat cloud": [
         "설치된 패키지가 Red Hat 클라우드에 업로드되는 것을 제외합니다."
       ],
-      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)": [
+      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights.": [
         ""
       ],
       "Exit Code: %s": [
@@ -180,7 +186,7 @@
         "보고서 생성 및 업로드"
       ],
       "Generate report": [
-        ""
+        "보고서 생성"
       ],
       "Generate the report, but do not upload": [
         "보고서를 생성하되 업로드하지 마십시오."
@@ -208,6 +214,9 @@
       ],
       "Host Insights recommendations": [
         "호스트 Insights 추천"
+      ],
+      "Host inventory report job": [
+        ""
       ],
       "Host was not uploaded to your RH cloud inventory": [
         "호스트가 RH 클라우드 인벤토리에 업로드되지 않았습니다."
@@ -252,7 +261,7 @@
         "지식베이스 문서"
       ],
       "Learn more about {minimalDataCollectionSetting}.": [
-        ""
+        "{minimalDataCollectionSetting}에 대해 자세히 알아보세요."
       ],
       "List of host UUIDs": [
         "호스트 UUID 목록"
@@ -270,6 +279,9 @@
         "수동"
       ],
       "Minimal data collection": [
+        "최소한의 데이터 수집"
+      ],
+      "Missing Insights facets created: %s": [
         ""
       ],
       "Moderate": [
@@ -306,7 +318,7 @@
         "호스트 ipv4 주소 난독화"
       ],
       "Obfuscate host ipv4 addresses.": [
-        ""
+        "호스트 ipv4 주소 난독화"
       ],
       "Obfuscate host names": [
         "호스트 이름 난독화"
@@ -314,20 +326,20 @@
       "Obfuscate host names sent to the Red Hat cloud": [
         "Red Hat 클라우드로 전송된 호스트 이름을 난독화합니다."
       ],
-      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)": [
+      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
       "Obfuscate ipv4 addresses sent to the Red Hat cloud": [
         "Red Hat 클라우드로 전송된 ipv4 주소 난독화"
       ],
-      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)": [
+      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
-      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings.": [
+      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights.": [
         ""
       ],
       "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled": [
-        ""
+        "Red Hat 클라우드에 필요한 최소한의 데이터만 전송하고 난독화 설정은 비활성화됩니다."
       ],
       "Oops! Couldn't find organization that matches your query": [
         "죄송합니다! 귀하의 쿼리와 일치하는 조직을 찾을 수 없습니다."
@@ -344,8 +356,8 @@
       "RH Cloud": [
         "RH 클라우드"
       ],
-      "RHC daemon id": [
-        "RHC 데몬 ID"
+      "RHC daemon id. Ignored when using local Insights.": [
+        ""
       ],
       "Read more about it in RH cloud insights": [
         "RH 클라우드 Insights에서 이에 대해 자세히 알아보세요."
@@ -405,7 +417,7 @@
         "RH Cloud playbook 실행"
       ],
       "Run playbook generated by Red Hat remediations app": [
-        ""
+        "Red Hat Remediations 앱에서 생성된 playbook 실행"
       ],
       "Run remediation playbook generated by Insights": [
         "Insights에서 생성된 수정 playbook 실행"
@@ -420,7 +432,7 @@
         "모든 페이지에서 추천을 선택하세요"
       ],
       "Send additional data to enhance Insights services, as per the settings": [
-        ""
+        "설정에 따라 Insights 서비스를 향상시키기 위해 추가 데이터를 보냅니다."
       ],
       "Set the current organization context for the request": [
         "요청에 대한 현재 조직 컨텍스트 설정"
@@ -428,14 +440,20 @@
       "Settings": [
         "설정 "
       ],
-      "Should import include parameter tags from Foreman?": [
-        "Foreman의 매개변수 태그를 가져와야 합니까?"
+      "Should import include parameter tags from Foreman? Ignored when using local Insights.": [
+        ""
       ],
       "Show Advanced Settings": [
         "고급 설정 표시"
       ],
       "Show if system is configured to use local iop-advisor-engine.": [
         "시스템이 로컬 iop-advisor-engine을 사용하도록 구성되어 있는지 표시하십시오."
+      ],
+      "Single-host report job": [
+        ""
+      ],
+      "Single-host report job for host %s": [
+        ""
       ],
       "Start inventory synchronization": [
         "인벤토리 동기화 시작"
@@ -468,7 +486,7 @@
         "보고서 파일%{filename}이/가 존재하지 않습니다"
       ],
       "The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy.": [
-        ""
+        "이 Foreman이 로컬 IoP Smart Proxy로 구성되어 있어 예정된 프로세스가 비활성화되었습니다."
       ],
       "The server returned the following error: %s": [
         "서버에서 다음 오류가 반환되었습니다. %s"
@@ -478,6 +496,9 @@
       ],
       "There are no recommendations for your hosts": [
         "호스트에 대한 권장 사항이 없음"
+      ],
+      "There were no missing Insights facets": [
+        ""
       ],
       "This action will also enable automatic reports upload": [
         "이 작업을 수행하면 자동 보고서 업로드도 활성화됩니다."
@@ -489,7 +510,7 @@
         "특정 조직에 대한 데이터를 수동으로 업로드하려면 조직을 선택하고 {restartButtonName}를 클릭하십시오."
       ],
       "Total CVEs": [
-        ""
+        "총 CVE"
       ],
       "Total risk": [
         "총 위험"
@@ -519,10 +540,10 @@
         "Red Hat Insights에서 보기"
       ],
       "Vulnerabilities": [
-        ""
+        "취약점"
       ],
       "Vulnerability": [
-        ""
+        "취약성"
       ],
       "Wait and %s": [
         "대기 및 %s"
@@ -591,7 +612,7 @@
         "규칙 제목"
       ],
       "setting minimal data collection": [
-        ""
+        "최소 데이터 수집 설정"
       ],
       "solution url": [
         "솔루션 URL"

--- a/app/assets/javascripts/foreman_rh_cloud/locale/zh_CN/foreman_rh_cloud.js
+++ b/app/assets/javascripts/foreman_rh_cloud/locale/zh_CN/foreman_rh_cloud.js
@@ -3,10 +3,10 @@
   "locale_data": {
     "foreman_rh_cloud": {
       "": {
-        "Project-Id-Version": "foreman_rh_cloud 11.1.0",
+        "Project-Id-Version": "foreman_rh_cloud 13.0.5",
         "Report-Msgid-Bugs-To": "",
         "PO-Revision-Date": "2023-01-20 13:26+0000",
-        "Last-Translator": "Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2025",
+        "Last-Translator": "Ondřej Gajdušek, 2025",
         "Language-Team": "Chinese (China) (https://app.transifex.com/foreman/teams/114/zh_CN/)",
         "MIME-Version": "1.0",
         "Content-Type": "text/plain; charset=UTF-8",
@@ -36,7 +36,7 @@
         "现在选择了所有建议。"
       ],
       "Analytics data collection": [
-        ""
+        "数据收集分析"
       ],
       "Any Organization": [
         "任意机构"
@@ -119,11 +119,17 @@
       "Enable automatic deletion of mismatched host records from the Red Hat cloud": [
         "启用自动删除来自红帽云的主机记录"
       ],
+      "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
       "Enable automatic synchronization of Insights recommendations from the Red Hat cloud": [
         "启用来自红帽云的 Insights 建议自动同步"
       ],
-      "Enable automatic upload of your host inventory to the Red Hat cloud": [
-        "启用自动将主机清单上传到红帽云"
+      "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights.": [
+        ""
+      ],
+      "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights.": [
+        ""
       ],
       "Enable automatic upload of your hosts inventory to the Red Hat cloud": [
         "启用自动将主机清单上传到红帽云"
@@ -138,12 +144,12 @@
         "在尝试访问服务器时遇到错误："
       ],
       "Exclude installed packages": [
-        ""
+        "排除安装的软件包"
       ],
       "Exclude installed packages from being uploaded to the Red Hat cloud": [
         "将安装的软件包上传到红帽云"
       ],
-      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)": [
+      "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights.": [
         ""
       ],
       "Exit Code: %s": [
@@ -180,7 +186,7 @@
         "生成并上传报告"
       ],
       "Generate report": [
-        ""
+        "生成报告"
       ],
       "Generate the report, but do not upload": [
         "生成报告，但不上传"
@@ -208,6 +214,9 @@
       ],
       "Host Insights recommendations": [
         "主机 Insights 建议"
+      ],
+      "Host inventory report job": [
+        ""
       ],
       "Host was not uploaded to your RH cloud inventory": [
         "主机没有上传到您的 RH 云清单"
@@ -252,7 +261,7 @@
         "知识库文章"
       ],
       "Learn more about {minimalDataCollectionSetting}.": [
-        ""
+        "了解有关 {minimalDataCollectionSetting} 的更多信息。"
       ],
       "List of host UUIDs": [
         "主机 UUID 列表"
@@ -270,6 +279,9 @@
         "手册"
       ],
       "Minimal data collection": [
+        "最小数据收集"
+      ],
+      "Missing Insights facets created: %s": [
         ""
       ],
       "Moderate": [
@@ -306,7 +318,7 @@
         "模糊的主机 ipv4 地址"
       ],
       "Obfuscate host ipv4 addresses.": [
-        ""
+        "对主机 ipv4 地址进行模糊化处理"
       ],
       "Obfuscate host names": [
         "模糊主机名"
@@ -314,20 +326,20 @@
       "Obfuscate host names sent to the Red Hat cloud": [
         "发送到红帽云的模糊主机名"
       ],
-      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)": [
+      "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
       "Obfuscate ipv4 addresses sent to the Red Hat cloud": [
         "发送到红帽云的模糊 ipv4 地址"
       ],
-      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)": [
+      "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights.": [
         ""
       ],
-      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings.": [
+      "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights.": [
         ""
       ],
       "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled": [
-        ""
+        "仅将最低所需的数据发送到红帽云，禁用模糊设置"
       ],
       "Oops! Couldn't find organization that matches your query": [
         "未找到与您的查询匹配的机构"
@@ -344,8 +356,8 @@
       "RH Cloud": [
         "RH Cloud"
       ],
-      "RHC daemon id": [
-        "RHC 守护进程 ID"
+      "RHC daemon id. Ignored when using local Insights.": [
+        ""
       ],
       "Read more about it in RH cloud insights": [
         "在 RH Cloud insights 中了解更多有关它的信息"
@@ -405,7 +417,7 @@
         "运行 RH Cloud playbook"
       ],
       "Run playbook generated by Red Hat remediations app": [
-        ""
+        "运行由红帽补救应用生成的 playbook"
       ],
       "Run remediation playbook generated by Insights": [
         "运行 Insights 生成的补救 playbook"
@@ -420,7 +432,7 @@
         "在所有页面中选择建议"
       ],
       "Send additional data to enhance Insights services, as per the settings": [
-        ""
+        "根据设置，发送额外数据以增强 Insights 服务"
       ],
       "Set the current organization context for the request": [
         "设置请求的当前机构上下文"
@@ -428,14 +440,20 @@
       "Settings": [
         "设置"
       ],
-      "Should import include parameter tags from Foreman?": [
-        "应从 Foreman 导入包含参数标签？"
+      "Should import include parameter tags from Foreman? Ignored when using local Insights.": [
+        ""
       ],
       "Show Advanced Settings": [
         "显示高级设置"
       ],
       "Show if system is configured to use local iop-advisor-engine.": [
         "显示系统是否被配置为使用本地 iop-advisor-engine。"
+      ],
+      "Single-host report job": [
+        ""
+      ],
+      "Single-host report job for host %s": [
+        ""
       ],
       "Start inventory synchronization": [
         "启动清单同步"
@@ -468,7 +486,7 @@
         "报告文件 %{filename} 不存在"
       ],
       "The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy.": [
-        ""
+        "调度的进程被禁用，因为此 Foreman 配置了一个本地 IoP Smart Proxy。"
       ],
       "The server returned the following error: %s": [
         "服务器返回以下错误：%s"
@@ -478,6 +496,9 @@
       ],
       "There are no recommendations for your hosts": [
         "没有适用于您的主机的建议"
+      ],
+      "There were no missing Insights facets": [
+        ""
       ],
       "This action will also enable automatic reports upload": [
         "此操作还会启用自动报告上传"
@@ -489,7 +510,7 @@
         "要手动上传特定机构的数据，请选择机构并点 {restartButtonName}。"
       ],
       "Total CVEs": [
-        ""
+        "CVE 总数"
       ],
       "Total risk": [
         "总风险"
@@ -519,10 +540,10 @@
         "禁用 Red Hat Insights"
       ],
       "Vulnerabilities": [
-        ""
+        "安全漏洞"
       ],
       "Vulnerability": [
-        ""
+        "安全漏洞"
       ],
       "Wait and %s": [
         "等待和 %s"
@@ -591,7 +612,7 @@
         "rule 标题"
       ],
       "setting minimal data collection": [
-        ""
+        "设置最小数据收集"
       ],
       "solution url": [
         "solution url"

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.2.10'.freeze
+  VERSION = '12.2.11'.freeze
 end

--- a/locale/foreman_rh_cloud.pot
+++ b/locale/foreman_rh_cloud.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: foreman_rh_cloud 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-12 13:20+0200\n"
-"PO-Revision-Date: 2025-09-12 13:20+0200\n"
+"POT-Creation-Date: 2025-10-07 11:44-0400\n"
+"PO-Revision-Date: 2025-10-07 11:44-0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -189,7 +189,7 @@ msgstr ""
 #: ../app/helpers/foreman_insights_host_helper.rb:7
 #: ../lib/foreman_rh_cloud/plugin.rb:93 ../lib/foreman_rh_cloud/plugin.rb:143
 #: ../webpack/ForemanColumnExtensions/index.js:65
-#: ../webpack/ForemanRhCloudFills.js:24
+#: ../webpack/ForemanRhCloudFills.js:28
 #: ../webpack/InsightsHostDetailsTab/InsightsTab.js:46
 msgid "Recommendations"
 msgstr ""
@@ -234,6 +234,14 @@ msgstr ""
 msgid "Satellite server has %{hits_count} recommendations by Red Hat"
 msgstr ""
 
+#: ../lib/foreman_inventory_upload/async/create_missing_insights_facets.rb:24
+msgid "There were no missing Insights facets"
+msgstr ""
+
+#: ../lib/foreman_inventory_upload/async/create_missing_insights_facets.rb:24
+msgid "Missing Insights facets created: %s"
+msgstr ""
+
 #: ../lib/foreman_inventory_upload/async/delayed_start.rb:22
 msgid "Wait and %s"
 msgstr ""
@@ -244,6 +252,18 @@ msgstr ""
 msgid ""
 "The scheduled process is disabled because this Foreman is configured with a lo"
 "cal IoP Smart Proxy."
+msgstr ""
+
+#: ../lib/foreman_inventory_upload/async/host_inventory_report_job.rb:31
+msgid "Host inventory report job"
+msgstr ""
+
+#: ../lib/foreman_inventory_upload/async/single_host_report_job.rb:16
+msgid "Single-host report job for host %s"
+msgstr ""
+
+#: ../lib/foreman_inventory_upload/async/single_host_report_job.rb:16
+msgid "Single-host report job"
 msgstr ""
 
 #: ../lib/foreman_inventory_upload/generators/fact_helpers.rb:188
@@ -276,7 +296,9 @@ msgid "Configure Cloud Connector on given hosts"
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:16
-msgid "Enable automatic upload of your host inventory to the Red Hat cloud"
+msgid ""
+"Enable automatic upload of your host inventory to the Red Hat cloud. Ignored w"
+"hen using local Insights."
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:16
@@ -286,10 +308,9 @@ msgid "Automatic inventory upload"
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:17
-#: ../webpack/InsightsCloudSync/Components/InsightsSettings/InsightsSettings.js:25
 msgid ""
 "Enable automatic synchronization of Insights recommendations from the Red Hat "
-"cloud"
+"cloud. Ignored when using local Insights."
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:17
@@ -297,8 +318,9 @@ msgid "Synchronize recommendations Automatically"
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:18
-#: ../webpack/ForemanInventoryUpload/Components/InventorySettings/AdvancedSetting/AdvancedSettingsConstants.js:14
-msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud"
+msgid ""
+"Enable automatic deletion of mismatched host records from the Red Hat cloud. I"
+"gnored when using local Insights."
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:18
@@ -310,7 +332,7 @@ msgstr ""
 msgid ""
 "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_coll"
 "ection is set to true, this setting is ignored because host names are not incl"
-"uded in the report.)"
+"uded in the report.) Ignored when using local Insights."
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:19
@@ -322,7 +344,7 @@ msgstr ""
 msgid ""
 "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data"
 "_collection is set to true, this setting is ignored because host IPv4 addresse"
-"s are not included in the report.)"
+"s are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:20
@@ -333,7 +355,7 @@ msgstr ""
 msgid ""
 "Exclude installed packages from being uploaded to the Red Hat cloud. (If insig"
 "hts_minimal_data_collection is set to true, this setting is ignored and instal"
-"led packages are always excluded.)"
+"led packages are always excluded.) Ignored when using local Insights."
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:21
@@ -342,7 +364,9 @@ msgid "Exclude installed packages"
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:22
-msgid "Should import include parameter tags from Foreman?"
+msgid ""
+"Should import include parameter tags from Foreman? Ignored when using local In"
+"sights."
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:22
@@ -350,7 +374,7 @@ msgid "Include parameters in insights-client reports"
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:23
-msgid "RHC daemon id"
+msgid "RHC daemon id. Ignored when using local Insights."
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:23
@@ -368,7 +392,8 @@ msgid ""
 "Only include the minimum required data in inventory reports for uploading to R"
 "ed Hat cloud. When this is true, installed packages are excluded from the repo"
 "rt regardless of the exclude_installed_packages setting, and host names and IP"
-"v4 addresses are excluded from the report regardless of obfuscation settings."
+"v4 addresses are excluded from the report regardless of obfuscation settings. "
+"Ignored when using local Insights."
 msgstr ""
 
 #: ../lib/foreman_rh_cloud/plugin.rb:88 ../lib/foreman_rh_cloud/plugin.rb:106
@@ -457,6 +482,11 @@ msgstr ""
 #: ../webpack/ForemanInventoryUpload/Components/InventorySettings/AdvancedSetting/AdvancedSettingsConstants.js:7
 #: ../webpack/ForemanInventoryUpload/SubscriptionsPageExtension/InventoryAutoUpload/InventoryAutoUpload.js:34
 msgid "Enable automatic upload of your hosts inventory to the Red Hat cloud"
+msgstr ""
+
+#:
+#: ../webpack/ForemanInventoryUpload/Components/InventorySettings/AdvancedSetting/AdvancedSettingsConstants.js:14
+msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud"
 msgstr ""
 
 #:
@@ -753,13 +783,20 @@ msgstr ""
 msgid "Configure"
 msgstr ""
 
-#: ../webpack/ForemanRhCloudFills.js:40
+#: ../webpack/ForemanRhCloudFills.js:44
 msgid "Vulnerabilities"
 msgstr ""
 
 #:
 #: ../webpack/InsightsCloudSync/Components/InsightsSettings/InsightsSettings.js:24
 msgid "Sync automatically"
+msgstr ""
+
+#:
+#: ../webpack/InsightsCloudSync/Components/InsightsSettings/InsightsSettings.js:25
+msgid ""
+"Enable automatic synchronization of Insights recommendations from the Red Hat "
+"cloud"
 msgstr ""
 
 #:
@@ -951,15 +988,15 @@ msgstr ""
 msgid "Critical"
 msgstr ""
 
-#: ../webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js:129
+#: ../webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js:164
 msgid "Total risks"
 msgstr ""
 
-#: ../webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js:136
+#: ../webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js:172
 msgid "View all recommendations"
 msgstr ""
 
-#: ../webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js:145
+#: ../webpack/InsightsHostDetailsTab/InsightsTotalRiskChart.js:181
 msgid "No results found"
 msgstr ""
 

--- a/locale/fr/foreman_rh_cloud.po
+++ b/locale/fr/foreman_rh_cloud.po
@@ -10,14 +10,14 @@
 # Claer <transiblu@claer.hammock.fr>, 2023
 # Amit Upadhye <aupadhye@redhat.com>, 2023
 # Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2025
+# Ondřej Gajdušek, 2025
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: foreman_rh_cloud 11.1.0\n"
+"Project-Id-Version: foreman_rh_cloud 13.0.5\n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: 2023-01-20 13:26+0000\n"
-"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarde"
-"n.nl>, 2025\n"
+"Last-Translator: Ondřej Gajdušek, 2025\n"
 "Language-Team: French (https://app.transifex.com/foreman/teams/114/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -45,7 +45,7 @@ msgid "All recommendations are now selected."
 msgstr "Toutes les recommandations sont maintenant sélectionnées."
 
 msgid "Analytics data collection"
-msgstr ""
+msgstr "Collecte de données analytiques"
 
 msgid "Any Organization"
 msgstr "Toute Organisation"
@@ -128,11 +128,17 @@ msgstr "Télécharger le dernier rapport"
 msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud"
 msgstr "Activer la suppression automatique des enregistrements d'hôtes incompatibles du cloud Red Hat"
 
+msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
 msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud"
 msgstr "Activer la synchronisation automatique des recommandations Insights à partir de Red Hat Cloud"
 
-msgid "Enable automatic upload of your host inventory to the Red Hat cloud"
-msgstr "Activer le téléchargement automatique de votre inventaire d'hôtes dans Red Hat Cloud"
+msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
+msgid "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
 
 msgid "Enable automatic upload of your hosts inventory to the Red Hat cloud"
 msgstr "Activer le téléchargement automatique de l'inventaire de vos hôtes dans Red Hat Cloud"
@@ -147,12 +153,12 @@ msgid "Encountered an error while trying to access the server:"
 msgstr "Une erreur s'est produite lors de l'accès au serveur :"
 
 msgid "Exclude installed packages"
-msgstr ""
+msgstr "Exclure les paquets installés"
 
 msgid "Exclude installed packages from being uploaded to the Red Hat cloud"
 msgstr "Exclure les paquets installés du téléchargement dans Red Hat Cloud"
 
-msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)"
+msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Exit Code: %s"
@@ -189,7 +195,7 @@ msgid "Generate and upload report"
 msgstr "Générer et télécharger un rapport"
 
 msgid "Generate report"
-msgstr ""
+msgstr "Générer un rapport"
 
 msgid "Generate the report, but do not upload"
 msgstr "Générer le rapport, mais ne pas le télécharger"
@@ -217,6 +223,9 @@ msgstr "Récupérer les hôtes manquants dans RH Cloud"
 
 msgid "Host Insights recommendations"
 msgstr "Recommandations de Host Insights"
+
+msgid "Host inventory report job"
+msgstr ""
 
 msgid "Host was not uploaded to your RH cloud inventory"
 msgstr "L'hôte n'a pas été téléchargé dans votre inventaire RH Cloud."
@@ -261,7 +270,7 @@ msgid "Knowledgebase article"
 msgstr "Article de base de connaissances"
 
 msgid "Learn more about {minimalDataCollectionSetting}."
-msgstr ""
+msgstr "En savoir plus sur{minimalDataCollectionSetting} ."
 
 msgid "List of host UUIDs"
 msgstr "Liste des UUID d'hôtes"
@@ -279,6 +288,9 @@ msgid "Manual"
 msgstr "Manuelle"
 
 msgid "Minimal data collection"
+msgstr "Collecte minimale de données"
+
+msgid "Missing Insights facets created: %s"
 msgstr ""
 
 msgid "Moderate"
@@ -315,28 +327,28 @@ msgid "Obfuscate host ipv4 addresses"
 msgstr "Obfusquer les adresses ipv4 des hôtes"
 
 msgid "Obfuscate host ipv4 addresses."
-msgstr ""
+msgstr "Masquer les adresses IPv4 des hôtes."
 
 msgid "Obfuscate host names"
-msgstr "Obfusquer les noms d'hôtes"
+msgstr "Masquer les noms d'hôtes"
 
 msgid "Obfuscate host names sent to the Red Hat cloud"
 msgstr "Obfusquer les noms d'hôtes envoyés à Red Hat Cloud"
 
-msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)"
+msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud"
 msgstr "Obfusquer les adresses ipv4 envoyées à Red Hat Cloud"
 
-msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)"
+msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
-msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings."
+msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights."
 msgstr ""
 
 msgid "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled"
-msgstr ""
+msgstr "Envoyez uniquement les données minimales requises au cloud Red Hat, les paramètres d'obfuscation (masquage) sont désactivés"
 
 msgid "Oops! Couldn't find organization that matches your query"
 msgstr "Oups ! Nous n'avons pas trouvé d'organisation correspondant à votre demande."
@@ -353,8 +365,8 @@ msgstr "Playbook"
 msgid "RH Cloud"
 msgstr "RH Cloud"
 
-msgid "RHC daemon id"
-msgstr "Id du démon RHC"
+msgid "RHC daemon id. Ignored when using local Insights."
+msgstr ""
 
 msgid "Read more about it in RH cloud insights"
 msgstr "Plus d'informations dans RH cloud insights"
@@ -414,7 +426,7 @@ msgid "Run RH Cloud playbook"
 msgstr "Exécuter le playbook RH Cloud"
 
 msgid "Run playbook generated by Red Hat remediations app"
-msgstr ""
+msgstr "Exécuter le playbook généré par l'app de remédiations de Red Hat"
 
 msgid "Run remediation playbook generated by Insights"
 msgstr "Exécuter le playbook de remédiation généré par Insights"
@@ -429,7 +441,7 @@ msgid "Select recommendations from all pages"
 msgstr "Sélectionner des recommandations sur toutes les pages"
 
 msgid "Send additional data to enhance Insights services, as per the settings"
-msgstr ""
+msgstr "Envoyer des données supplémentaires pour améliorer les services Insights, conformément aux paramètres"
 
 msgid "Set the current organization context for the request"
 msgstr "Définir le contexte organisationnel actuel de la demande"
@@ -437,14 +449,20 @@ msgstr "Définir le contexte organisationnel actuel de la demande"
 msgid "Settings"
 msgstr "Paramètres de configuration"
 
-msgid "Should import include parameter tags from Foreman?"
-msgstr "L'importation doit-elle inclure les balises de paramètres de Foreman ?"
+msgid "Should import include parameter tags from Foreman? Ignored when using local Insights."
+msgstr ""
 
 msgid "Show Advanced Settings"
 msgstr "Afficher les paramètres avancés"
 
 msgid "Show if system is configured to use local iop-advisor-engine."
 msgstr "Indique si le système est configuré pour utiliser le moteur iop-advisor local."
+
+msgid "Single-host report job"
+msgstr ""
+
+msgid "Single-host report job for host %s"
+msgstr ""
 
 msgid "Start inventory synchronization"
 msgstr "Démarrer la synchronisation de l'inventaire"
@@ -477,7 +495,7 @@ msgid "The report file %{filename} doesn't exist"
 msgstr "Le fichier de rapport %{filename} n'existe pas"
 
 msgid "The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy."
-msgstr ""
+msgstr "Le processus planifié est désactivé car ce Foreman est configuré avec un proxy intelligent IoP local."
 
 msgid "The server returned the following error: %s"
 msgstr "Le serveur a renvoyé l'erreur suivante : %s"
@@ -487,6 +505,9 @@ msgstr "La tâche a échoué avec l'erreur suivante :"
 
 msgid "There are no recommendations for your hosts"
 msgstr "Il n'y a aucune recommandation pour vos hôtes"
+
+msgid "There were no missing Insights facets"
+msgstr ""
 
 msgid "This action will also enable automatic reports upload"
 msgstr "Cette action permettra également le téléchargement automatique des rapports"
@@ -498,7 +519,7 @@ msgid "To manually upload the data for a specific organization, select an organi
 msgstr "Pour télécharger manuellement les données d'une organisation spécifique, sélectionnez une organisation et cliquez sur{restartButtonName} ."
 
 msgid "Total CVEs"
-msgstr ""
+msgstr "Total des CVE"
 
 msgid "Total risk"
 msgstr "Risque total"
@@ -528,10 +549,10 @@ msgid "View in Red Hat Insights"
 msgstr "Afficher Red Hat Insights."
 
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "Vulnérabilités"
 
 msgid "Vulnerability"
-msgstr ""
+msgstr "Vulnérabilité"
 
 msgid "Wait and %s"
 msgstr "Attendez et %s"
@@ -600,7 +621,7 @@ msgid "rule title"
 msgstr "titre de la règle"
 
 msgid "setting minimal data collection"
-msgstr ""
+msgstr "définir une collecte minimale de données"
 
 msgid "solution url"
 msgstr "URL de la solution"

--- a/locale/ja/foreman_rh_cloud.po
+++ b/locale/ja/foreman_rh_cloud.po
@@ -5,14 +5,14 @@
 #
 # Translators:
 # Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2025
+# Ondřej Gajdušek, 2025
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: foreman_rh_cloud 11.1.0\n"
+"Project-Id-Version: foreman_rh_cloud 13.0.5\n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: 2023-01-20 13:26+0000\n"
-"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarde"
-"n.nl>, 2025\n"
+"Last-Translator: Ondřej Gajdušek, 2025\n"
 "Language-Team: Japanese (https://app.transifex.com/foreman/teams/114/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -39,7 +39,7 @@ msgid "All recommendations are now selected."
 msgstr "すべての推奨事項が選択されました。"
 
 msgid "Analytics data collection"
-msgstr ""
+msgstr "分析データの収集"
 
 msgid "Any Organization"
 msgstr "任意の組織"
@@ -122,11 +122,17 @@ msgstr "最新レポートのダウンロード"
 msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud"
 msgstr "不一致のホストレコードを Red Hat クラウドから自動的に削除できるようにする"
 
+msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
 msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud"
 msgstr "Red Hat クラウドから Insights の推奨事項の自動同期を有効にする"
 
-msgid "Enable automatic upload of your host inventory to the Red Hat cloud"
-msgstr "ホストインベントリーの Red Hat クラウドに対して自動アップロードを有効にする"
+msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
+msgid "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
 
 msgid "Enable automatic upload of your hosts inventory to the Red Hat cloud"
 msgstr "ホストインベントリーの Red Hat クラウドに対して自動アップロードを有効にする"
@@ -141,12 +147,12 @@ msgid "Encountered an error while trying to access the server:"
 msgstr "サーバーへのアクセス時にエラーが発生しました:"
 
 msgid "Exclude installed packages"
-msgstr ""
+msgstr "インストール済みパッケージの除外"
 
 msgid "Exclude installed packages from being uploaded to the Red Hat cloud"
 msgstr "Red Hat クラウドにアップロードされないようにインストール済みパッケージを除外する"
 
-msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)"
+msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Exit Code: %s"
@@ -183,7 +189,7 @@ msgid "Generate and upload report"
 msgstr "レポートの生成およびアップロード"
 
 msgid "Generate report"
-msgstr ""
+msgstr "レポートを生成します。"
 
 msgid "Generate the report, but do not upload"
 msgstr "レポートを生成するがアップロードしない"
@@ -211,6 +217,9 @@ msgstr "RH Cloud にないホストを取得する"
 
 msgid "Host Insights recommendations"
 msgstr "ホストに関する Insights の推奨事項"
+
+msgid "Host inventory report job"
+msgstr ""
 
 msgid "Host was not uploaded to your RH cloud inventory"
 msgstr "ホストが RH クラウドインベントリーにアップロードされませんでした"
@@ -255,7 +264,7 @@ msgid "Knowledgebase article"
 msgstr "ナレッジベースアーティクル"
 
 msgid "Learn more about {minimalDataCollectionSetting}."
-msgstr ""
+msgstr "{minimalDataCollectionSetting} の詳細を確認してください。"
 
 msgid "List of host UUIDs"
 msgstr "ホスト UUID のリスト"
@@ -273,6 +282,9 @@ msgid "Manual"
 msgstr "手動"
 
 msgid "Minimal data collection"
+msgstr "最小限のデータ収集"
+
+msgid "Missing Insights facets created: %s"
 msgstr ""
 
 msgid "Moderate"
@@ -309,7 +321,7 @@ msgid "Obfuscate host ipv4 addresses"
 msgstr "ホストの ipv4 アドレスの難読化"
 
 msgid "Obfuscate host ipv4 addresses."
-msgstr ""
+msgstr "ホストの IPv4 アドレスを難読化します。"
 
 msgid "Obfuscate host names"
 msgstr "ホスト名の難読化"
@@ -317,20 +329,20 @@ msgstr "ホスト名の難読化"
 msgid "Obfuscate host names sent to the Red Hat cloud"
 msgstr "Red Hat クラウドに送信するホスト名を難読化する"
 
-msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)"
+msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud"
 msgstr "Red Hat クラウドに送信する ipv4 アドレスを難読化する"
 
-msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)"
+msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
-msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings."
+msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights."
 msgstr ""
 
 msgid "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled"
-msgstr ""
+msgstr "必要最小限のデータのみを Red Hat クラウドに送信します。難読化設定は無効化されます"
 
 msgid "Oops! Couldn't find organization that matches your query"
 msgstr "クエリーに合致する組織が見つかりませんでした"
@@ -347,8 +359,8 @@ msgstr "Playbook"
 msgid "RH Cloud"
 msgstr "RH Cloud"
 
-msgid "RHC daemon id"
-msgstr "RHC デーモン ID"
+msgid "RHC daemon id. Ignored when using local Insights."
+msgstr ""
 
 msgid "Read more about it in RH cloud insights"
 msgstr "詳細は、RH cloud insights を参照してください。"
@@ -408,7 +420,7 @@ msgid "Run RH Cloud playbook"
 msgstr "RH Cloud Playbook の実行"
 
 msgid "Run playbook generated by Red Hat remediations app"
-msgstr ""
+msgstr "Red Hat 修復アプリケーションによって生成された Playbook の実行"
 
 msgid "Run remediation playbook generated by Insights"
 msgstr "Insights で生成された修復 Playbook の実行"
@@ -423,7 +435,7 @@ msgid "Select recommendations from all pages"
 msgstr "すべてのページから推奨事項を選択する"
 
 msgid "Send additional data to enhance Insights services, as per the settings"
-msgstr ""
+msgstr "Insights サービスの強化のために、設定に従って追加データを送信する"
 
 msgid "Set the current organization context for the request"
 msgstr "要求に現在の組織コンテキストを設定します"
@@ -431,14 +443,20 @@ msgstr "要求に現在の組織コンテキストを設定します"
 msgid "Settings"
 msgstr "設定"
 
-msgid "Should import include parameter tags from Foreman?"
-msgstr "インポートには Foreman からのパラメータータグを含める必要がありますか?"
+msgid "Should import include parameter tags from Foreman? Ignored when using local Insights."
+msgstr ""
 
 msgid "Show Advanced Settings"
 msgstr "詳細設定の表示"
 
 msgid "Show if system is configured to use local iop-advisor-engine."
 msgstr "システムがローカル iop-advisor-engine を使用するように設定されているかどうかを表示します。"
+
+msgid "Single-host report job"
+msgstr ""
+
+msgid "Single-host report job for host %s"
+msgstr ""
 
 msgid "Start inventory synchronization"
 msgstr "インベントリー同期の開始"
@@ -471,7 +489,7 @@ msgid "The report file %{filename} doesn't exist"
 msgstr "%{filename} レポートファイルがありません"
 
 msgid "The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy."
-msgstr ""
+msgstr "この Foreman はローカルの IoP Smart Proxy で設定されているため、スケジュールされたプロセスが無効になっています。"
 
 msgid "The server returned the following error: %s"
 msgstr "サーバーは以下のエラーを返しました: %s"
@@ -481,6 +499,9 @@ msgstr "タスクは以下のエラーで失敗しました: "
 
 msgid "There are no recommendations for your hosts"
 msgstr "ホストに関する推奨事項はありません"
+
+msgid "There were no missing Insights facets"
+msgstr ""
 
 msgid "This action will also enable automatic reports upload"
 msgstr "このアクションを実行すると、自動レポートのアップロードも有効になります。"
@@ -492,7 +513,7 @@ msgid "To manually upload the data for a specific organization, select an organi
 msgstr "特定の組織のデータを手動でアップロードするには、組織を選択して {restartButtonName} をクリックします。"
 
 msgid "Total CVEs"
-msgstr ""
+msgstr "CVE の総数"
 
 msgid "Total risk"
 msgstr "リスクの総数"
@@ -522,10 +543,10 @@ msgid "View in Red Hat Insights"
 msgstr "Red Hat Insights での表示"
 
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "脆弱性"
 
 msgid "Vulnerability"
-msgstr ""
+msgstr "脆弱性"
 
 msgid "Wait and %s"
 msgstr "待機して %s"
@@ -594,7 +615,7 @@ msgid "rule title"
 msgstr "ルールタイトル"
 
 msgid "setting minimal data collection"
-msgstr ""
+msgstr "最小限のデータ収集の設定"
 
 msgid "solution url"
 msgstr "ソリューション URL"

--- a/locale/ka/foreman_rh_cloud.po
+++ b/locale/ka/foreman_rh_cloud.po
@@ -8,7 +8,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: foreman_rh_cloud 11.1.0\n"
+"Project-Id-Version: foreman_rh_cloud 13.0.5\n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: 2023-01-20 13:26+0000\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023\n"
@@ -121,11 +121,17 @@ msgstr "უახლესი ანგარიშის გადმოწე�
 msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud"
 msgstr ""
 
+msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
 msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud"
 msgstr "Red Hat Cloud-დან Insight-ის რეკომენდაციების ავტომატური სინქრონიზაციების ჩართვა"
 
-msgid "Enable automatic upload of your host inventory to the Red Hat cloud"
-msgstr "თქვენი ჰოსტების ინვენტარის Red Hat Cloud-ში ავტომატური ატვირთვის ჩართვა"
+msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
+msgid "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
 
 msgid "Enable automatic upload of your hosts inventory to the Red Hat cloud"
 msgstr "თქვენი ჰოსტების ინვენტარის Red Hat Cloud-ში ავტომატური ატვირთვის ჩართვა"
@@ -145,7 +151,7 @@ msgstr ""
 msgid "Exclude installed packages from being uploaded to the Red Hat cloud"
 msgstr "Red Hat cloud-ში ატვირთული პაკეტების სიიდან დაყენებული პაკეტების ამოღება"
 
-msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)"
+msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Exit Code: %s"
@@ -211,6 +217,9 @@ msgstr ""
 msgid "Host Insights recommendations"
 msgstr "ჰოსტის Insights-ის რეკომენდაციები"
 
+msgid "Host inventory report job"
+msgstr ""
+
 msgid "Host was not uploaded to your RH cloud inventory"
 msgstr "ჰოსტის თქვენი RH-ის ღრუბლოვან ინვენტარში არ ატვირთულა"
 
@@ -274,6 +283,9 @@ msgstr "ხელით"
 msgid "Minimal data collection"
 msgstr ""
 
+msgid "Missing Insights facets created: %s"
+msgstr ""
+
 msgid "Moderate"
 msgstr "საშუალო"
 
@@ -316,16 +328,16 @@ msgstr "ჰოსტის სახელების ობფუსკაც�
 msgid "Obfuscate host names sent to the Red Hat cloud"
 msgstr "Red Hat cloud-ში გაგზავნილი ჰოსტის სახელების დამახინჯება"
 
-msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)"
+msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud"
 msgstr "Red Hat cloud-ში გაგზავნილი IPv4 მისამართების დამახინჯება"
 
-msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)"
+msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
-msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings."
+msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights."
 msgstr ""
 
 msgid "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled"
@@ -346,8 +358,8 @@ msgstr "Playbook"
 msgid "RH Cloud"
 msgstr "RH Cloud"
 
-msgid "RHC daemon id"
-msgstr "RHC დემონის ID"
+msgid "RHC daemon id. Ignored when using local Insights."
+msgstr ""
 
 msgid "Read more about it in RH cloud insights"
 msgstr "გაიგეთ მეტი RH Cloud insights-ის შესახებ"
@@ -430,13 +442,19 @@ msgstr "მოთხოვნის მიმდინარე ორგან�
 msgid "Settings"
 msgstr "მორგება"
 
-msgid "Should import include parameter tags from Foreman?"
-msgstr "უნდა შეიცავდეს შემოტანა პარამეტრის ჭდეებს Foreman-დან?"
+msgid "Should import include parameter tags from Foreman? Ignored when using local Insights."
+msgstr ""
 
 msgid "Show Advanced Settings"
 msgstr "დამატებითი პარამეტრების ცვენება"
 
 msgid "Show if system is configured to use local iop-advisor-engine."
+msgstr ""
+
+msgid "Single-host report job"
+msgstr ""
+
+msgid "Single-host report job for host %s"
 msgstr ""
 
 msgid "Start inventory synchronization"
@@ -479,6 +497,9 @@ msgid "The task failed with the following error:"
 msgstr "დავალება შემდეგი შეცდომით დასრულდა:"
 
 msgid "There are no recommendations for your hosts"
+msgstr ""
+
+msgid "There were no missing Insights facets"
 msgstr ""
 
 msgid "This action will also enable automatic reports upload"

--- a/locale/ko/foreman_rh_cloud.po
+++ b/locale/ko/foreman_rh_cloud.po
@@ -8,14 +8,14 @@
 # Bryan Kearney <bryan.kearney@gmail.com>, 2023
 # 0868a4d1af5275b3f70b0a6dac4c99a4, 2023
 # Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2025
+# Ondřej Gajdušek, 2025
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: foreman_rh_cloud 11.1.0\n"
+"Project-Id-Version: foreman_rh_cloud 13.0.5\n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: 2023-01-20 13:26+0000\n"
-"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarde"
-"n.nl>, 2025\n"
+"Last-Translator: Ondřej Gajdušek, 2025\n"
 "Language-Team: Korean (https://app.transifex.com/foreman/teams/114/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -42,7 +42,7 @@ msgid "All recommendations are now selected."
 msgstr "모든 권장 사항이 선택되었습니다."
 
 msgid "Analytics data collection"
-msgstr ""
+msgstr "분석 데이터 수집"
 
 msgid "Any Organization"
 msgstr "모든 조직 "
@@ -125,11 +125,17 @@ msgstr "최신 보고서 다운로드"
 msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud"
 msgstr "Red Hat 클라우드에서 일치하지 않는 호스트 기록의 자동 삭제를 활성화하십시오."
 
+msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
 msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud"
 msgstr "Red Hat 클라우드에서 Insights 권장 사항의 자동 동기화를 활성화합니다."
 
-msgid "Enable automatic upload of your host inventory to the Red Hat cloud"
-msgstr "호스트 인벤토리를 Red Hat 클라우드에 자동으로 업로드하도록 설정"
+msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
+msgid "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
 
 msgid "Enable automatic upload of your hosts inventory to the Red Hat cloud"
 msgstr "호스트 인벤토리를 Red Hat 클라우드에 자동으로 업로드하도록 설정"
@@ -144,12 +150,12 @@ msgid "Encountered an error while trying to access the server:"
 msgstr "서버에 접근하는 동안 오류가 발생했습니다:"
 
 msgid "Exclude installed packages"
-msgstr ""
+msgstr "설치된 패키지 제외"
 
 msgid "Exclude installed packages from being uploaded to the Red Hat cloud"
 msgstr "설치된 패키지가 Red Hat 클라우드에 업로드되는 것을 제외합니다."
 
-msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)"
+msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Exit Code: %s"
@@ -186,7 +192,7 @@ msgid "Generate and upload report"
 msgstr "보고서 생성 및 업로드"
 
 msgid "Generate report"
-msgstr ""
+msgstr "보고서 생성"
 
 msgid "Generate the report, but do not upload"
 msgstr "보고서를 생성하되 업로드하지 마십시오."
@@ -214,6 +220,9 @@ msgstr "RH Cloud에 없는 호스트를 가져오십시오."
 
 msgid "Host Insights recommendations"
 msgstr "호스트 Insights 추천"
+
+msgid "Host inventory report job"
+msgstr ""
 
 msgid "Host was not uploaded to your RH cloud inventory"
 msgstr "호스트가 RH 클라우드 인벤토리에 업로드되지 않았습니다."
@@ -258,7 +267,7 @@ msgid "Knowledgebase article"
 msgstr "지식베이스 문서"
 
 msgid "Learn more about {minimalDataCollectionSetting}."
-msgstr ""
+msgstr "{minimalDataCollectionSetting}에 대해 자세히 알아보세요."
 
 msgid "List of host UUIDs"
 msgstr "호스트 UUID 목록"
@@ -276,6 +285,9 @@ msgid "Manual"
 msgstr "수동"
 
 msgid "Minimal data collection"
+msgstr "최소한의 데이터 수집"
+
+msgid "Missing Insights facets created: %s"
 msgstr ""
 
 msgid "Moderate"
@@ -312,7 +324,7 @@ msgid "Obfuscate host ipv4 addresses"
 msgstr "호스트 ipv4 주소 난독화"
 
 msgid "Obfuscate host ipv4 addresses."
-msgstr ""
+msgstr "호스트 ipv4 주소 난독화"
 
 msgid "Obfuscate host names"
 msgstr "호스트 이름 난독화"
@@ -320,20 +332,20 @@ msgstr "호스트 이름 난독화"
 msgid "Obfuscate host names sent to the Red Hat cloud"
 msgstr "Red Hat 클라우드로 전송된 호스트 이름을 난독화합니다."
 
-msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)"
+msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud"
 msgstr "Red Hat 클라우드로 전송된 ipv4 주소 난독화"
 
-msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)"
+msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
-msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings."
+msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights."
 msgstr ""
 
 msgid "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled"
-msgstr ""
+msgstr "Red Hat 클라우드에 필요한 최소한의 데이터만 전송하고 난독화 설정은 비활성화됩니다."
 
 msgid "Oops! Couldn't find organization that matches your query"
 msgstr "죄송합니다! 귀하의 쿼리와 일치하는 조직을 찾을 수 없습니다."
@@ -350,8 +362,8 @@ msgstr "Playbook"
 msgid "RH Cloud"
 msgstr "RH 클라우드"
 
-msgid "RHC daemon id"
-msgstr "RHC 데몬 ID"
+msgid "RHC daemon id. Ignored when using local Insights."
+msgstr ""
 
 msgid "Read more about it in RH cloud insights"
 msgstr "RH 클라우드 Insights에서 이에 대해 자세히 알아보세요."
@@ -411,7 +423,7 @@ msgid "Run RH Cloud playbook"
 msgstr "RH Cloud playbook 실행"
 
 msgid "Run playbook generated by Red Hat remediations app"
-msgstr ""
+msgstr "Red Hat Remediations 앱에서 생성된 playbook 실행"
 
 msgid "Run remediation playbook generated by Insights"
 msgstr "Insights에서 생성된 수정 playbook 실행"
@@ -426,7 +438,7 @@ msgid "Select recommendations from all pages"
 msgstr "모든 페이지에서 추천을 선택하세요"
 
 msgid "Send additional data to enhance Insights services, as per the settings"
-msgstr ""
+msgstr "설정에 따라 Insights 서비스를 향상시키기 위해 추가 데이터를 보냅니다."
 
 msgid "Set the current organization context for the request"
 msgstr "요청에 대한 현재 조직 컨텍스트 설정"
@@ -434,14 +446,20 @@ msgstr "요청에 대한 현재 조직 컨텍스트 설정"
 msgid "Settings"
 msgstr "설정 "
 
-msgid "Should import include parameter tags from Foreman?"
-msgstr "Foreman의 매개변수 태그를 가져와야 합니까?"
+msgid "Should import include parameter tags from Foreman? Ignored when using local Insights."
+msgstr ""
 
 msgid "Show Advanced Settings"
 msgstr "고급 설정 표시"
 
 msgid "Show if system is configured to use local iop-advisor-engine."
 msgstr "시스템이 로컬 iop-advisor-engine을 사용하도록 구성되어 있는지 표시하십시오."
+
+msgid "Single-host report job"
+msgstr ""
+
+msgid "Single-host report job for host %s"
+msgstr ""
 
 msgid "Start inventory synchronization"
 msgstr "인벤토리 동기화 시작"
@@ -474,7 +492,7 @@ msgid "The report file %{filename} doesn't exist"
 msgstr "보고서 파일%{filename}이/가 존재하지 않습니다"
 
 msgid "The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy."
-msgstr ""
+msgstr "이 Foreman이 로컬 IoP Smart Proxy로 구성되어 있어 예정된 프로세스가 비활성화되었습니다."
 
 msgid "The server returned the following error: %s"
 msgstr "서버에서 다음 오류가 반환되었습니다. %s"
@@ -484,6 +502,9 @@ msgstr "다음 오류로 인해 작업이 실패했습니다."
 
 msgid "There are no recommendations for your hosts"
 msgstr "호스트에 대한 권장 사항이 없음"
+
+msgid "There were no missing Insights facets"
+msgstr ""
 
 msgid "This action will also enable automatic reports upload"
 msgstr "이 작업을 수행하면 자동 보고서 업로드도 활성화됩니다."
@@ -495,7 +516,7 @@ msgid "To manually upload the data for a specific organization, select an organi
 msgstr "특정 조직에 대한 데이터를 수동으로 업로드하려면 조직을 선택하고 {restartButtonName}를 클릭하십시오."
 
 msgid "Total CVEs"
-msgstr ""
+msgstr "총 CVE"
 
 msgid "Total risk"
 msgstr "총 위험"
@@ -525,10 +546,10 @@ msgid "View in Red Hat Insights"
 msgstr "Red Hat Insights에서 보기"
 
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "취약점"
 
 msgid "Vulnerability"
-msgstr ""
+msgstr "취약성"
 
 msgid "Wait and %s"
 msgstr "대기 및 %s"
@@ -597,7 +618,7 @@ msgid "rule title"
 msgstr "규칙 제목"
 
 msgid "setting minimal data collection"
-msgstr ""
+msgstr "최소 데이터 수집 설정"
 
 msgid "solution url"
 msgstr "솔루션 URL"

--- a/locale/zh_CN/foreman_rh_cloud.po
+++ b/locale/zh_CN/foreman_rh_cloud.po
@@ -9,14 +9,14 @@
 # 0868a4d1af5275b3f70b0a6dac4c99a4, 2023
 # Amit Upadhye <aupadhye@redhat.com>, 2023
 # Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarden.nl>, 2025
+# Ondřej Gajdušek, 2025
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: foreman_rh_cloud 11.1.0\n"
+"Project-Id-Version: foreman_rh_cloud 13.0.5\n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: 2023-01-20 13:26+0000\n"
-"Last-Translator: Ewoud Kohl van Wijngaarden <ewoud+transifex@kohlvanwijngaarde"
-"n.nl>, 2025\n"
+"Last-Translator: Ondřej Gajdušek, 2025\n"
 "Language-Team: Chinese (China) (https://app.transifex.com/foreman/teams/114/zh"
 "_CN/)\n"
 "MIME-Version: 1.0\n"
@@ -44,7 +44,7 @@ msgid "All recommendations are now selected."
 msgstr "现在选择了所有建议。"
 
 msgid "Analytics data collection"
-msgstr ""
+msgstr "数据收集分析"
 
 msgid "Any Organization"
 msgstr "任意机构"
@@ -127,11 +127,17 @@ msgstr "下载最新的报告"
 msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud"
 msgstr "启用自动删除来自红帽云的主机记录"
 
+msgid "Enable automatic deletion of mismatched host records from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
 msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud"
 msgstr "启用来自红帽云的 Insights 建议自动同步"
 
-msgid "Enable automatic upload of your host inventory to the Red Hat cloud"
-msgstr "启用自动将主机清单上传到红帽云"
+msgid "Enable automatic synchronization of Insights recommendations from the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
+
+msgid "Enable automatic upload of your host inventory to the Red Hat cloud. Ignored when using local Insights."
+msgstr ""
 
 msgid "Enable automatic upload of your hosts inventory to the Red Hat cloud"
 msgstr "启用自动将主机清单上传到红帽云"
@@ -146,12 +152,12 @@ msgid "Encountered an error while trying to access the server:"
 msgstr "在尝试访问服务器时遇到错误："
 
 msgid "Exclude installed packages"
-msgstr ""
+msgstr "排除安装的软件包"
 
 msgid "Exclude installed packages from being uploaded to the Red Hat cloud"
 msgstr "将安装的软件包上传到红帽云"
 
-msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.)"
+msgid "Exclude installed packages from being uploaded to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored and installed packages are always excluded.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Exit Code: %s"
@@ -188,7 +194,7 @@ msgid "Generate and upload report"
 msgstr "生成并上传报告"
 
 msgid "Generate report"
-msgstr ""
+msgstr "生成报告"
 
 msgid "Generate the report, but do not upload"
 msgstr "生成报告，但不上传"
@@ -216,6 +222,9 @@ msgstr "获取 RH Cloud 中缺少的主机"
 
 msgid "Host Insights recommendations"
 msgstr "主机 Insights 建议"
+
+msgid "Host inventory report job"
+msgstr ""
 
 msgid "Host was not uploaded to your RH cloud inventory"
 msgstr "主机没有上传到您的 RH 云清单"
@@ -260,7 +269,7 @@ msgid "Knowledgebase article"
 msgstr "知识库文章"
 
 msgid "Learn more about {minimalDataCollectionSetting}."
-msgstr ""
+msgstr "了解有关 {minimalDataCollectionSetting} 的更多信息。"
 
 msgid "List of host UUIDs"
 msgstr "主机 UUID 列表"
@@ -278,6 +287,9 @@ msgid "Manual"
 msgstr "手册"
 
 msgid "Minimal data collection"
+msgstr "最小数据收集"
+
+msgid "Missing Insights facets created: %s"
 msgstr ""
 
 msgid "Moderate"
@@ -314,7 +326,7 @@ msgid "Obfuscate host ipv4 addresses"
 msgstr "模糊的主机 ipv4 地址"
 
 msgid "Obfuscate host ipv4 addresses."
-msgstr ""
+msgstr "对主机 ipv4 地址进行模糊化处理"
 
 msgid "Obfuscate host names"
 msgstr "模糊主机名"
@@ -322,20 +334,20 @@ msgstr "模糊主机名"
 msgid "Obfuscate host names sent to the Red Hat cloud"
 msgstr "发送到红帽云的模糊主机名"
 
-msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.)"
+msgid "Obfuscate host names sent to the Red Hat cloud. (If insights_minimal_data_collection is set to true, this setting is ignored because host names are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
 msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud"
 msgstr "发送到红帽云的模糊 ipv4 地址"
 
-msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.)"
+msgid "Obfuscate ipv4 addresses sent to the Red Hat cloud.  (If insights_minimal_data_collection is set to true, this setting is ignored because host IPv4 addresses are not included in the report.) Ignored when using local Insights."
 msgstr ""
 
-msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings."
+msgid "Only include the minimum required data in inventory reports for uploading to Red Hat cloud. When this is true, installed packages are excluded from the report regardless of the exclude_installed_packages setting, and host names and IPv4 addresses are excluded from the report regardless of obfuscation settings. Ignored when using local Insights."
 msgstr ""
 
 msgid "Only send the minimum required data to Red Hat cloud, obfuscation settings are disabled"
-msgstr ""
+msgstr "仅将最低所需的数据发送到红帽云，禁用模糊设置"
 
 msgid "Oops! Couldn't find organization that matches your query"
 msgstr "未找到与您的查询匹配的机构"
@@ -352,8 +364,8 @@ msgstr "运行 playbook"
 msgid "RH Cloud"
 msgstr "RH Cloud"
 
-msgid "RHC daemon id"
-msgstr "RHC 守护进程 ID"
+msgid "RHC daemon id. Ignored when using local Insights."
+msgstr ""
 
 msgid "Read more about it in RH cloud insights"
 msgstr "在 RH Cloud insights 中了解更多有关它的信息"
@@ -413,7 +425,7 @@ msgid "Run RH Cloud playbook"
 msgstr "运行 RH Cloud playbook"
 
 msgid "Run playbook generated by Red Hat remediations app"
-msgstr ""
+msgstr "运行由红帽补救应用生成的 playbook"
 
 msgid "Run remediation playbook generated by Insights"
 msgstr "运行 Insights 生成的补救 playbook"
@@ -428,7 +440,7 @@ msgid "Select recommendations from all pages"
 msgstr "在所有页面中选择建议"
 
 msgid "Send additional data to enhance Insights services, as per the settings"
-msgstr ""
+msgstr "根据设置，发送额外数据以增强 Insights 服务"
 
 msgid "Set the current organization context for the request"
 msgstr "设置请求的当前机构上下文"
@@ -436,14 +448,20 @@ msgstr "设置请求的当前机构上下文"
 msgid "Settings"
 msgstr "设置"
 
-msgid "Should import include parameter tags from Foreman?"
-msgstr "应从 Foreman 导入包含参数标签？"
+msgid "Should import include parameter tags from Foreman? Ignored when using local Insights."
+msgstr ""
 
 msgid "Show Advanced Settings"
 msgstr "显示高级设置"
 
 msgid "Show if system is configured to use local iop-advisor-engine."
 msgstr "显示系统是否被配置为使用本地 iop-advisor-engine。"
+
+msgid "Single-host report job"
+msgstr ""
+
+msgid "Single-host report job for host %s"
+msgstr ""
 
 msgid "Start inventory synchronization"
 msgstr "启动清单同步"
@@ -476,7 +494,7 @@ msgid "The report file %{filename} doesn't exist"
 msgstr "报告文件 %{filename} 不存在"
 
 msgid "The scheduled process is disabled because this Foreman is configured with a local IoP Smart Proxy."
-msgstr ""
+msgstr "调度的进程被禁用，因为此 Foreman 配置了一个本地 IoP Smart Proxy。"
 
 msgid "The server returned the following error: %s"
 msgstr "服务器返回以下错误：%s"
@@ -486,6 +504,9 @@ msgstr "任务失败，错误为:"
 
 msgid "There are no recommendations for your hosts"
 msgstr "没有适用于您的主机的建议"
+
+msgid "There were no missing Insights facets"
+msgstr ""
 
 msgid "This action will also enable automatic reports upload"
 msgstr "此操作还会启用自动报告上传"
@@ -497,7 +518,7 @@ msgid "To manually upload the data for a specific organization, select an organi
 msgstr "要手动上传特定机构的数据，请选择机构并点 {restartButtonName}。"
 
 msgid "Total CVEs"
-msgstr ""
+msgstr "CVE 总数"
 
 msgid "Total risk"
 msgstr "总风险"
@@ -527,10 +548,10 @@ msgid "View in Red Hat Insights"
 msgstr "禁用 Red Hat Insights"
 
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "安全漏洞"
 
 msgid "Vulnerability"
-msgstr ""
+msgstr "安全漏洞"
 
 msgid "Wait and %s"
 msgstr "等待和 %s"
@@ -599,7 +620,7 @@ msgid "rule title"
 msgstr "rule 标题"
 
 msgid "setting minimal data collection"
-msgstr ""
+msgstr "设置最小数据收集"
 
 msgid "solution url"
 msgstr "solution url"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.2.10",
+  "version": "12.2.11",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
@@ -3,24 +3,30 @@ import PropTypes from 'prop-types';
 import { UnknownIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
-
 import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
+import { useAdvisorEngineConfig } from '../common/Hooks/ConfigHooks';
 
 const vulnerabilityApiPath = path =>
   insightsCloudUrl(`api/vulnerability/v1/${path}`);
 
 export const CVECountCell = ({ hostDetails }) => {
+  const isIopEnabled = useAdvisorEngineConfig();
+
   // eslint-disable-next-line camelcase
   const uuid = hostDetails?.subscription_facet_attributes?.uuid;
 
   const key = `HOST_CVE_COUNT_${uuid}`;
   const response = useAPI(
-    uuid ? 'get' : null,
+    isIopEnabled && uuid ? 'get' : null,
     vulnerabilityApiPath(`systems?uuid=${uuid}`),
     {
       key,
     }
   );
+
+  if (!isIopEnabled) {
+    return <UnknownIcon />;
+  }
 
   if (uuid === undefined) {
     return <UnknownIcon />;

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
@@ -2,8 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { API } from 'foremanReact/redux/API';
 import { CVECountCell } from '../CVECountCell';
+import * as ConfigHooks from '../../common/Hooks/ConfigHooks';
 
 jest.mock('foremanReact/redux/API');
+jest.mock('../../common/Hooks/ConfigHooks');
+
 API.get.mockImplementation(async () => ({
   data: [
     {
@@ -14,15 +17,58 @@ API.get.mockImplementation(async () => ({
   ],
 }));
 
+const hostDetailsMock = {
+      name: 'test-host.example.com',
+      subscription_facet_attributes: {
+        uuid: 'test-uuid-123',
+      },
+    };
+
 describe('CVECountCell', () => {
-  it('renders an empty cves count column', () => {
-    const hostDetailsMock = {
+  beforeEach(() => {
+    ConfigHooks.useAdvisorEngineConfig.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders an empty cves count column when no subscription UUID', () => {
+    const hostDetailsMockIoP = {
       name: 'test-host.example.com',
       subscription_facet_attributes: {
         uuid: null, // no subscription
       },
     };
+    render(<CVECountCell hostDetails={hostDetailsMockIoP} />);
+    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+  });
+
+  it('renders UnknownIcon when IoP is not enabled', () => {
+    ConfigHooks.useAdvisorEngineConfig.mockReturnValue(false);
     render(<CVECountCell hostDetails={hostDetailsMock} />);
     expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    expect(ConfigHooks.useAdvisorEngineConfig).toHaveBeenCalled();
+  });
+
+  it('renders UnknownIcon when IoP is enabled but CVE API call fails', () => {
+    // Mock successful IoP config
+    ConfigHooks.useAdvisorEngineConfig.mockReturnValue(true);
+    // Mock CVE API failure - override the global mock for this test
+    API.get.mockImplementationOnce(async () => {
+      throw new Error('CVE API call failed');
+    });
+
+    render(<CVECountCell hostDetails={hostDetailsMock} />);
+    // Should render UnknownIcon when CVE API fails
+    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    expect(ConfigHooks.useAdvisorEngineConfig).toHaveBeenCalled();
+  });
+
+  it('renders UnknownIcon when IoP is undefined (API call pending)', () => {
+    ConfigHooks.useAdvisorEngineConfig.mockReturnValue(undefined);
+    render(<CVECountCell hostDetails={hostDetailsMock} />);
+    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    expect(ConfigHooks.useAdvisorEngineConfig).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary by Sourcery

Bump extension version and refresh translations across all locales; annotate many UI strings with “Ignored when using local Insights”; adjust CVECountCell to respect local Insights configuration by returning UnknownIcon when IoP is disabled or pending; and add tests covering the new conditional rendering logic.

Enhancements:
- Return UnknownIcon in CVECountCell when local Insights is disabled or pending and only call API when IoP and subscription UUID are present

Build:
- Bump foreman_rh_cloud gem and npm package version to 12.2.11

Tests:
- Add tests covering CVECountCell behavior when IoP is disabled, undefined, or when API call fails

Chores:
- Refresh Project-Id-Version metadata in all locale files to 13.0.5
- Fill in missing translations and append “Ignored when using local Insights” to numerous locale keys in fr, ja, ko, zh_CN, ka