### PR TITLE
Fix typo in the uploader.sh.erb from a previous commit

### DIFF
--- a/lib/foreman_inventory_upload/scripts/uploader.sh.erb
+++ b/lib/foreman_inventory_upload/scripts/uploader.sh.erb
@@ -30,7 +30,7 @@ fi
 ORG_HEADER=()
 if [ -n "$ORG_ID" ]
 then
-+        ORG_HEADER=("-H" "X-Org-Id: $ORG_ID")
+        ORG_HEADER=("-H" "X-Org-Id: $ORG_ID")
 fi
 
 # /tmp/a b/x.pem


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes a typo from the previous uploader sh script 
[Previous Commit => ](https://github.com/theforeman/foreman_rh_cloud/pull/1092/files#diff-801ad8320b384f51d1384166850424e97e0a5ad134efc92dd153c99e2b85c778R33
)

#### What are the testing steps for this pull request?
- Have a IoP setup with a few hosts
- Apply pr
- rm /var/lib/foreman/redhat_inventory/uploads/uploader.sh
- Administer -> Inventory Upload -> Generate report
- This should complete successfully
- Then run the following query (assuming you are in default org you should see something like this.) 
```
$ sudo -u postgres psql -d advisor_db -c "select id, org_id from inventory.hosts"
                  id                  |        org_id        
--------------------------------------+----------------------
 86870b59-e45c-4f4e-9b15-914a44af4dbd | Default_Organization
(1 row)
```

Note the same behavior can be reproduced by just registering a new host in a iop setup since the report upload runs on package profile upload

## Summary by Sourcery

Bug Fixes:
- Remove stray '+' from the ORG_HEADER assignment line in uploader.sh.erb