### PR TITLE
Release 12.2.12

### DIFF
--- a/lib/foreman_inventory_upload/scripts/uploader.sh.erb
+++ b/lib/foreman_inventory_upload/scripts/uploader.sh.erb
@@ -30,7 +30,7 @@ fi
 ORG_HEADER=()
 if [ -n "$ORG_ID" ]
 then
-+        ORG_HEADER=("-H" "X-Org-Id: $ORG_ID")
+        ORG_HEADER=("-H" "X-Org-Id: $ORG_ID")
 fi
 
 # /tmp/a b/x.pem

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.2.11'.freeze
+  VERSION = '12.2.12'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.2.11",
+  "version": "12.2.12",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Prepare release 12.2.12 by bumping versions and fixing uploader script.

Bug Fixes:
- Remove stray '+' in uploader.sh.erb that broke the ORG_HEADER assignment.

Chores:
- Bump gem version and package.json version to 12.2.12.