### PR TITLE
SAT-35237 - Add back report location to inventory rake task

### DIFF
--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -39,13 +39,23 @@ namespace :rh_cloud_inventory do
 
       User.as_anonymous_admin do
         organization_ids.each do |organization_id|
-          ForemanTasks.sync_task(
+          task = ForemanTasks.sync_task(
             ForemanInventoryUpload::Async::HostInventoryReportJob,
             base_folder,
             organization_id,
             filter,
             false # don't upload; the user ran report:generate and not report:generate_upload
           )
+
+          if task.result == 'success'
+            unless Setting[:subscription_connection_enabled]
+              target_file = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization_id, filter))
+              puts "Generated #{target_file} for organization id #{organization_id}"
+            end
+          else
+            puts "Failed to generate report for organization id #{organization_id}. Task result: #{task.result}"
+            puts "Check task #{task.id} in the Tasks dashboard for error details."
+          end
         end
         puts "Check the Uploading tab for report uploading status." if Setting[:subscription_connection_enabled]
       end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Pulled the task status sync it's not async and upon success report back the original message that was removed in this pr: https://github.com/theforeman/foreman_rh_cloud/pull/1102
* If the task is not successful then report back to the user in the shell process in the UI or in the rake task if running from the cli

#### What are the testing steps for this pull request?
* Run generate and upload inventory from the cli and the UI and see that it does not say anything about the report location just check the uploading tab.
* Check out PR
* Run generate and upload inventory from the cli and the UI and see that it reports the message like it did before PR 1102
```ruby
13:14:48 rails.1   | 2025-10-13T13:14:48 [I|app|] Report archived successfully
13:14:48 rails.1   | Successfully11 generated /home/vagrant/foreman/red_hat_inventory/generated_reports/report_for_1.tar.xz for organization id 1
```

## Summary by Sourcery

Enhancements:
- Restore report file location messaging in the inventory rake task, printing the generated report path on success and providing error details on failure