### PR TITLE
Don't skip authentication when adding smart proxy filters

### DIFF
--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -97,7 +97,8 @@ module ForemanRhCloud
         Katello::Api::V2::OrganizationsController.before_find_taxonomy_actions do
           Katello::Api::V2::OrganizationsController.add_smart_proxy_filters(
             [:index, :download_debug_certificate],
-            features: ForemanRhCloud.on_prem_smart_proxy_features
+            features: ForemanRhCloud.on_prem_smart_proxy_features,
+            ensure_session_expiry: true
           )
         end
         Katello::Api::V2::RepositoriesController.include Foreman::Controller::SmartProxyAuth
@@ -105,7 +106,8 @@ module ForemanRhCloud
         Katello::Api::V2::RepositoriesController.before_index_actions do
           Katello::Api::V2::RepositoriesController.add_smart_proxy_filters(
             :index,
-            features: ForemanRhCloud.on_prem_smart_proxy_features
+            features: ForemanRhCloud.on_prem_smart_proxy_features,
+            ensure_session_expiry: true
           )
         end
       end


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman/pull/10727

#### What are the changes introduced in this pull request?

Pass `:ensure_session_expiry => true` to `add_smart_proxy_filters`. This should prevent sessions from living past their expiry time.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Enforce session expiry in Smart Proxy filters to prevent authentication bypass when adding filters

Bug Fixes:
- Add ensure_session_expiry option to smart proxy filters for OrganizationsController to enforce authentication session expiry
- Add ensure_session_expiry option to smart proxy filters for RepositoriesController to enforce authentication session expiry