### PR TITLE
Delete host from HBI on unregister

### DIFF
--- a/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
+++ b/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
@@ -13,7 +13,7 @@ module ForemanRhCloud
       host.reload
 
       # Only delete from HBI in IoP mode (hosted mode uses async job for cleanup)
-      hbi_host_destroy(host) if ForemanRhCloud.with_iop_smart_proxy? && !organization_destroy && host.insights_facet.try(:uuid)
+      hbi_host_destroy(host) if ForemanRhCloud.with_iop_smart_proxy? && !organization_destroy && host.insights_facet&.uuid&.presence
       host.insights&.destroy!
       super(host, options)
     end
@@ -33,7 +33,7 @@ module ForemanRhCloud
       Rails.logger.warn(_("Attempted to destroy HBI host %s, but host does not exist in HBI") % uuid)
     rescue StandardError => e
       # TODO: Improve error handling - don't break registration if HBI delete fails
-      Rails.logger.error(_("Failed to destroy HBI host %s: %s") % [uuid, e.message])
+      Rails.logger.error(format(_("Failed to destroy HBI host %s: %s"), uuid, e.message))
     end
   end
 end

--- a/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
+++ b/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
@@ -7,26 +7,33 @@ module ForemanRhCloud
     end
 
     def unregister_host(host, options = {})
-    organization_destroy = options.fetch(:organization_destroy, false)
-    
-    hbi_host_destroy(host) if !organization_destroy && host.insights_facet.try(:uuid)
-    host.insights_facet&.destroy!
-    super(host, options)
-  end
-  
-  def hbi_host_destroy(host)
-    uuid = host.insights_facet.uuid
+      organization_destroy = options.fetch(:organization_destroy, false)
+
+      # Reload to ensure we have fresh association data
+      host.reload
+
+      # Only delete from HBI in IoP mode (hosted mode uses async job for cleanup)
+      hbi_host_destroy(host) if ForemanRhCloud.with_iop_smart_proxy? && !organization_destroy && host.insights_facet.try(:uuid)
+      host.insights&.destroy!
+      super(host, options)
+    end
+
+    def hbi_host_destroy(host)
+      uuid = host.insights_facet.uuid
       logger.debug "Unregistering host #{uuid} from HBI"
       execute_cloud_request(
-          organization: host.organization,
-          method: :delete,
-          url: ForemanInventoryUpload.host_by_id_url(uuid),
-          headers: {
-            content_type: :json,
-          }
-        )
+        organization: host.organization,
+        method: :delete,
+        url: ForemanInventoryUpload.host_by_id_url(uuid),
+        headers: {
+          content_type: :json,
+        }
+      )
     rescue RestClient::NotFound
       Rails.logger.warn(_("Attempted to destroy HBI host %s, but host does not exist in HBI") % uuid)
+    rescue StandardError => e
+      # TODO: Improve error handling - don't break registration if HBI delete fails
+      Rails.logger.error(_("Failed to destroy HBI host %s: %s") % [uuid, e.message])
     end
   end
 end

--- a/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
+++ b/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
@@ -1,0 +1,32 @@
+module ForemanRhCloud
+  module RegistrationManagerExtensions
+    include ForemanRhCloud::CertAuth
+
+    def logger
+      Rails.logger
+    end
+
+    def unregister_host(host, options = {})
+    organization_destroy = options.fetch(:organization_destroy, false)
+    
+    hbi_host_destroy(host) if !organization_destroy && host.insights_facet.try(:uuid)
+    host.insights_facet&.destroy!
+    super(host, options)
+  end
+  
+  def hbi_host_destroy(host)
+    uuid = host.insights_facet.uuid
+      logger.debug "Unregistering host #{uuid} from HBI"
+      execute_cloud_request(
+          organization: host.organization,
+          method: :delete,
+          url: ForemanInventoryUpload.host_by_id_url(uuid),
+          headers: {
+            content_type: :json,
+          }
+        )
+    rescue RestClient::NotFound
+      Rails.logger.warn(_("Attempted to destroy HBI host %s, but host does not exist in HBI") % uuid)
+    end
+  end
+end

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -88,8 +88,12 @@ module ForemanInventoryUpload
     inventory_base_url + "?hostname_or_id=#{ForemanRhCloud.foreman_host.fqdn}"
   end
 
-  def self.hosts_by_ids_url(host_ids)
-    host_ids_string = host_ids.join(',')
+  def self.host_by_id_url(host_uuid)
+    "#{inventory_base_url}/#{host_uuid}"
+  end
+
+  def self.hosts_by_ids_url(host_uuids)
+    host_ids_string = host_uuids.join(',')
     "#{inventory_base_url}/#{host_ids_string}"
   end
 end

--- a/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
+++ b/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
@@ -23,7 +23,7 @@ module ForemanInventoryUpload
           facet_count += facets.size
         end
         output[:result] = facet_count.zero? ? _("There were no missing Insights facets") : format(_("Missing Insights facets created: %s"), facet_count)
-        Rails.logger.info output[:result]
+        Rails.logger.debug output[:result]
       end
     end
   end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -40,6 +40,7 @@ module ForemanRhCloud
         ::Host::Managed.include RhCloudHost
 
         ::Katello::Api::Rhsm::CandlepinDynflowProxyController.include InsightsCloud::PackageProfileUploadExtensions
+        ::Katello::RegistrationManager.singleton_class.prepend ::ForemanRhCloud::RegistrationManagerExtensions
       end
     end
 

--- a/test/jobs/create_missing_insights_facets_test.rb
+++ b/test/jobs/create_missing_insights_facets_test.rb
@@ -101,7 +101,7 @@ class CreateMissingInsightsFacetsTest < ActiveSupport::TestCase
   end
 
   test 'logs result message' do
-    Rails.logger.expects(:info).with(regexp_matches(/Missing Insights facets created/))
+    Rails.logger.expects(:debug).with(regexp_matches(/Missing Insights facets created/))
 
     action = create_and_plan_action(
       ForemanInventoryUpload::Async::CreateMissingInsightsFacets,

--- a/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
+++ b/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
@@ -1,0 +1,178 @@
+require 'test_plugin_helper'
+
+module ForemanRhCloud
+  class RegistrationManagerExtensionsTest < ActiveSupport::TestCase
+    setup do
+      @org = FactoryBot.create(:organization)
+      @host = FactoryBot.create(:host, :managed, organization: @org)
+      @insights_facet = ::InsightsFacet.create!(host: @host, uuid: 'test-uuid-123')
+
+      # Stub Candlepin interaction (from Katello)
+      ::Katello::Resources::Candlepin::Consumer.stubs(:destroy)
+
+      # Stub the cloud request to avoid actual HTTP calls
+      Katello::RegistrationManager.stubs(:execute_cloud_request).returns(true)
+    end
+
+    context 'unregister_host' do
+      test 'should call HBI delete in IoP mode when host has insights facet with UUID' do
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+        expected_url = ForemanInventoryUpload.host_by_id_url('test-uuid-123')
+
+        # Expect the cloud request to be made
+        Katello::RegistrationManager.expects(:execute_cloud_request).with do |params|
+          params[:organization] == @org &&
+            params[:method] == :delete &&
+            params[:url] == expected_url &&
+            params[:headers][:content_type] == :json
+        end.returns(true)
+
+        Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+
+        # Verify insights_facet was destroyed
+        assert_nil InsightsFacet.find_by(id: @insights_facet.id)
+      end
+
+      test 'should NOT call HBI delete in non-IoP mode' do
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+        # Should NOT attempt to delete from HBI
+        Katello::RegistrationManager.expects(:execute_cloud_request).never
+
+        Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+
+        # Verify insights_facet was still destroyed
+        assert_nil InsightsFacet.find_by(id: @insights_facet.id)
+      end
+
+      test 'should NOT call HBI delete when host has no insights_facet' do
+        host_without_facet = FactoryBot.create(:host, :managed, organization: @org)
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+        Katello::RegistrationManager.expects(:execute_cloud_request).never
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(host_without_facet, unregistering: true)
+        end
+      end
+
+      test 'should NOT call HBI delete when insights_facet has no UUID' do
+        facet_id = @insights_facet.id
+        @insights_facet.update(uuid: nil)
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+        Katello::RegistrationManager.expects(:execute_cloud_request).never
+
+        Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+
+        # Verify facet was still destroyed
+        assert_nil InsightsFacet.find_by(id: facet_id)
+      end
+
+      test 'should always destroy insights_facet regardless of IoP mode' do
+        facet_id = @insights_facet.id
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+        assert_not_nil InsightsFacet.find_by(id: facet_id)
+
+        Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+
+        assert_nil InsightsFacet.find_by(id: facet_id)
+      end
+    end
+
+    context 'hbi_host_destroy error handling' do
+      setup do
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+        @expected_url = ForemanInventoryUpload.host_by_id_url('test-uuid-123')
+        @facet_id = @insights_facet.id
+        # Unstub execute_cloud_request for error tests
+        Katello::RegistrationManager.unstub(:execute_cloud_request)
+      end
+
+      test 'should handle RestClient::NotFound gracefully' do
+        Katello::RegistrationManager.stubs(:execute_cloud_request).raises(RestClient::NotFound)
+
+        # Should log warning but not raise
+        Rails.logger.expects(:warn).with(regexp_matches(/host does not exist in HBI/))
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+
+        # Facet should still be destroyed
+        assert_nil InsightsFacet.find_by(id: @facet_id)
+      end
+
+      test 'should handle server errors gracefully' do
+        error = RestClient::InternalServerError.new
+        Katello::RegistrationManager.stubs(:execute_cloud_request).raises(error)
+
+        # Should log error but not raise
+        Rails.logger.expects(:error).with(regexp_matches(/Failed to destroy HBI host/))
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+
+        # Facet should still be destroyed
+        assert_nil InsightsFacet.find_by(id: @facet_id)
+      end
+
+      test 'should handle timeout errors gracefully' do
+        error = RestClient::Exceptions::ReadTimeout.new
+        Katello::RegistrationManager.stubs(:execute_cloud_request).raises(error)
+
+        # Should log error but not raise
+        Rails.logger.expects(:error).with(regexp_matches(/Failed to destroy HBI host/))
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+
+        # Facet should still be destroyed
+        assert_nil InsightsFacet.find_by(id: @facet_id)
+      end
+
+      test 'should handle connection errors gracefully' do
+        error = Errno::ECONNREFUSED.new
+        Katello::RegistrationManager.stubs(:execute_cloud_request).raises(error)
+
+        # Should log error but not raise
+        Rails.logger.expects(:error).with(regexp_matches(/Failed to destroy HBI host/))
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+
+        # Facet should still be destroyed
+        assert_nil InsightsFacet.find_by(id: @facet_id)
+      end
+    end
+
+    context 'integration' do
+      test 'should be properly prepended to RegistrationManager' do
+        assert_includes Katello::RegistrationManager.singleton_class.ancestors,
+                        ForemanRhCloud::RegistrationManagerExtensions
+      end
+
+      test 'should preserve original unregister_host behavior' do
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+        # Just verify the extension is properly integrated
+        # Detailed Katello behavior is tested in Katello's own tests
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+      end
+    end
+
+    context 'URL generation' do
+      test 'host_by_id_url should return correct format' do
+        url = ForemanInventoryUpload.host_by_id_url('test-uuid-123')
+
+        assert_match %r{/hosts/test-uuid-123$}, url
+      end
+    end
+  end
+end

--- a/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
+++ b/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
@@ -56,6 +56,20 @@ module ForemanRhCloud
         end
       end
 
+      test 'should NOT call HBI delete when host has insights_facet with empty UUID' do
+        host_with_empty_uuid_facet = FactoryBot.create(:host, :managed, organization: @org)
+        empty_uuid_facet = InsightsFacet.create!(host: host_with_empty_uuid_facet, uuid: '')
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+        Katello::RegistrationManager.expects(:execute_cloud_request).never
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(host_with_empty_uuid_facet, unregistering: true)
+        end
+
+        assert_nil InsightsFacet.find_by(id: empty_uuid_facet.id)
+      end
+
       test 'should NOT call HBI delete when insights_facet has no UUID' do
         facet_id = @insights_facet.id
         @insights_facet.update(uuid: nil)
@@ -153,7 +167,7 @@ module ForemanRhCloud
     context 'integration' do
       test 'should be properly prepended to RegistrationManager' do
         assert_includes Katello::RegistrationManager.singleton_class.ancestors,
-                        ForemanRhCloud::RegistrationManagerExtensions
+          ForemanRhCloud::RegistrationManagerExtensions
       end
 
       test 'should preserve original unregister_host behavior' do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Extends Katello's `RegistrationManager#unregister_host` method to clean up the host from HBI inventory as well.

#### Considerations taken when implementing this change?

see inline comment

#### What are the testing steps for this pull request?

```
sudo -u postgres psql -d inventory_db -c "select display_name, id, org_id from hbi.hosts"
```
or `select count(*) from hbi.hosts`

Note the hosts that are present. Now unregister a host (`subscription-manager unregister`)

Check again - the host should no longer be in the hbi inventory.

Also test with deleting a host - the same should be the case.

Duplicate hosts should not get created.

