### PR TITLE
Enable test_existing_database after Katello fixes

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -28,5 +28,4 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
     with:
       plugin: foreman_rh_cloud
-      test_existing_database: false
       foreman_version: ${{ matrix.foreman }}


### PR DESCRIPTION
https://github.com/Katello/katello/commit/07fdfc359faade860fc0254e406063a163681043 was the last fix required for this to work

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

CI:
- Remove the test_existing_database: false setting in the ruby_tests GitHub Actions workflow to allow running tests against an existing database