### PR TITLE
12.2.13

### DIFF
--- a/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
+++ b/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
@@ -1,0 +1,39 @@
+module ForemanRhCloud
+  module RegistrationManagerExtensions
+    include ForemanRhCloud::CertAuth
+
+    def logger
+      Rails.logger
+    end
+
+    def unregister_host(host, options = {})
+      organization_destroy = options.fetch(:organization_destroy, false)
+
+      # Reload to ensure we have fresh association data
+      host.reload
+
+      # Only delete from HBI in IoP mode (hosted mode uses async job for cleanup)
+      hbi_host_destroy(host) if ForemanRhCloud.with_iop_smart_proxy? && !organization_destroy && host.insights_facet&.uuid&.presence
+      host.insights&.destroy!
+      super(host, options)
+    end
+
+    def hbi_host_destroy(host)
+      uuid = host.insights_facet.uuid
+      logger.debug "Unregistering host #{uuid} from HBI"
+      execute_cloud_request(
+        organization: host.organization,
+        method: :delete,
+        url: ForemanInventoryUpload.host_by_id_url(uuid),
+        headers: {
+          content_type: :json,
+        }
+      )
+    rescue RestClient::NotFound
+      Rails.logger.warn(_("Attempted to destroy HBI host %s, but host does not exist in HBI") % uuid)
+    rescue StandardError => e
+      # TODO: Improve error handling - don't break registration if HBI delete fails
+      Rails.logger.error(format(_("Failed to destroy HBI host %s: %s"), uuid, e.message))
+    end
+  end
+end

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -88,8 +88,12 @@ module ForemanInventoryUpload
     inventory_base_url + "?hostname_or_id=#{ForemanRhCloud.foreman_host.fqdn}"
   end
 
-  def self.hosts_by_ids_url(host_ids)
-    host_ids_string = host_ids.join(',')
+  def self.host_by_id_url(host_uuid)
+    "#{inventory_base_url}/#{host_uuid}"
+  end
+
+  def self.hosts_by_ids_url(host_uuids)
+    host_ids_string = host_uuids.join(',')
     "#{inventory_base_url}/#{host_ids_string}"
   end
 end

--- a/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
+++ b/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
@@ -23,7 +23,7 @@ module ForemanInventoryUpload
           facet_count += facets.size
         end
         output[:result] = facet_count.zero? ? _("There were no missing Insights facets") : format(_("Missing Insights facets created: %s"), facet_count)
-        Rails.logger.info output[:result]
+        Rails.logger.debug output[:result]
       end
     end
   end

--- a/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
+++ b/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
@@ -8,7 +8,7 @@ module ForemanInventoryUpload
       def run
         organization = ::Organization.find(input[:organization_id])
         hosts_without_facets = ::ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: 'null? insights_uuid')
-        facet_count = hosts_without_facets.count
+        facet_count = 0
         hosts_without_facets.each do |batch|
           facets = batch.pluck(:id, 'katello_subscription_facets.uuid').map do |host_id, uuid|
             {
@@ -20,6 +20,7 @@ module ForemanInventoryUpload
           # rubocop:disable Rails/SkipsModelValidations
           InsightsFacet.upsert_all(facets, unique_by: :host_id) unless facets.empty?
           # rubocop:enable Rails/SkipsModelValidations
+          facet_count += facets.size
         end
         output[:result] = facet_count.zero? ? _("There were no missing Insights facets") : format(_("Missing Insights facets created: %s"), facet_count)
         Rails.logger.info output[:result]

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -40,6 +40,7 @@ module ForemanRhCloud
         ::Host::Managed.include RhCloudHost
 
         ::Katello::Api::Rhsm::CandlepinDynflowProxyController.include InsightsCloud::PackageProfileUploadExtensions
+        ::Katello::RegistrationManager.singleton_class.prepend ::ForemanRhCloud::RegistrationManagerExtensions
       end
     end
 

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.2.12'.freeze
+  VERSION = '12.2.13'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.2.12",
+  "version": "12.2.13",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {

--- a/test/jobs/cloud_connector_announce_task_test.rb
+++ b/test/jobs/cloud_connector_announce_task_test.rb
@@ -4,7 +4,7 @@ require 'foreman_tasks/test_helpers'
 require "#{ForemanTasks::Engine.root}/test/support/dummy_dynflow_action"
 
 class CloudConnectorAnnounceTaskTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
 
   setup do
     RemoteExecutionFeature.register(
@@ -23,7 +23,8 @@ class CloudConnectorAnnounceTaskTest < ActiveSupport::TestCase
   test 'It executes cloud presence announcer' do
     ForemanRhCloud::CloudPresence.any_instance.expects(:announce_to_sources).times(Organization.unscoped.count)
 
-    ForemanTasks.sync_task(InsightsCloud::Async::CloudConnectorAnnounceTask, @job_invocation)
+    action = create_and_plan_action(InsightsCloud::Async::CloudConnectorAnnounceTask, @job_invocation)
+    finalize_action(action)
   end
 
   private

--- a/test/jobs/connector_playbook_execution_reporter_task_test.rb
+++ b/test/jobs/connector_playbook_execution_reporter_task_test.rb
@@ -4,7 +4,7 @@ require 'foreman_tasks/test_helpers'
 require "#{ForemanTasks::Engine.root}/test/support/dummy_dynflow_action"
 
 class ConnectorPlaybookExecutionReporterTaskTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
 
   # override default send behavior for the test
   class TestConnectorPlaybookExecutionReporterTask < InsightsCloud::Async::ConnectorPlaybookExecutionReporterTask
@@ -35,17 +35,19 @@ class ConnectorPlaybookExecutionReporterTaskTest < ActiveSupport::TestCase
 
     TestConnectorPlaybookExecutionReporterTask.any_instance.stubs(:job_finished?).returns(true)
 
-    actual = ForemanTasks.sync_task(TestConnectorPlaybookExecutionReporterTask, @job_invocation)
+    action = create_and_plan_action(TestConnectorPlaybookExecutionReporterTask, @job_invocation)
+    action = run_action(action)
 
-    actual_report = actual.output[:saved_reports].first.to_s
+    saved_reports = action.output[:saved_reports]
+    actual_report = saved_reports.first.to_s
 
-    assert_equal 1, actual.output[:saved_reports].size
+    assert_equal 1, saved_reports.size
     assert_not_nil actual_report
     actual_jsonl = read_jsonl(actual_report)
 
-    assert_equal true, actual.output['task']['invocation_status']['task_state']['task_done_reported']
-    assert_equal 0, actual.output['task']['invocation_status']['hosts_state']['TEST_UUID1']['exit_status']
-    assert_equal 0, actual.output['task']['invocation_status']['hosts_state']['TEST_UUID2']['exit_status']
+    assert_equal true, action.output['task']['invocation_status']['task_state']['task_done_reported']
+    assert_equal 0, action.output['task']['invocation_status']['hosts_state']['TEST_UUID1']['exit_status']
+    assert_equal 0, action.output['task']['invocation_status']['hosts_state']['TEST_UUID2']['exit_status']
 
     assert_equal true, @job_invocation.finished?
     assert_equal 'stopped', @job_invocation.sub_task_for_host(Host.where(name: 'host1').first)['state']
@@ -77,20 +79,25 @@ class ConnectorPlaybookExecutionReporterTaskTest < ActiveSupport::TestCase
 
     ArrangeTestHost.any_instance.stubs(:job_finished?).returns(false, true)
 
-    actual = ForemanTasks.sync_task(ArrangeTestHost, @job_invocation)
+    action = create_and_plan_action(ArrangeTestHost, @job_invocation)
+    action = run_action(action)
 
-    actual_report1 = actual.output[:saved_reports].first.to_s
-    actual_report2 = actual.output[:saved_reports].second.to_s
+    # Process polling cycles - manually trigger Poll events until done
+    action = run_action(action, Dynflow::Action::Polling::Poll) until action.done?
 
-    assert_equal 2, actual.output[:saved_reports].size
+    saved_reports = action.output[:saved_reports]
+    actual_report1 = saved_reports.first.to_s
+    actual_report2 = saved_reports.second.to_s
+
+    assert_equal 2, saved_reports.size
     assert_not_nil actual_report1
     assert_not_nil actual_report2
 
     actual_json1 = read_jsonl(actual_report1)
     actual_json2 = read_jsonl(actual_report2)
 
-    assert_equal true, actual.output['task']['invocation_status']['task_state']['task_done_reported']
-    assert_equal 0, actual.output['task']['invocation_status']['hosts_state']['TEST_UUID1']['exit_status']
+    assert_equal true, action.output['task']['invocation_status']['task_state']['task_done_reported']
+    assert_equal 0, action.output['task']['invocation_status']['hosts_state']['TEST_UUID1']['exit_status']
 
     assert_equal 'stopped', @job_invocation.sub_task_for_host(Host.where(name: 'host1').first)['state']
 
@@ -141,13 +148,18 @@ class ConnectorPlaybookExecutionReporterTaskTest < ActiveSupport::TestCase
 
     ArrangeTestHostTwo.any_instance.stubs(:job_finished?).returns(false, false, true)
 
-    actual = ForemanTasks.sync_task(ArrangeTestHostTwo, @job_invocation)
+    action = create_and_plan_action(ArrangeTestHostTwo, @job_invocation)
+    action = run_action(action)
 
-    actual_report1 = actual.output[:saved_reports].first.to_s
-    actual_report2 = actual.output[:saved_reports].second.to_s
-    actual_report3 = actual.output[:saved_reports].third.to_s
+    # Process polling cycles - manually trigger Poll events until done
+    action = run_action(action, Dynflow::Action::Polling::Poll) until action.done?
 
-    assert_equal 3, actual.output[:saved_reports].size
+    saved_reports = action.output[:saved_reports]
+    actual_report1 = saved_reports.first.to_s
+    actual_report2 = saved_reports.second.to_s
+    actual_report3 = saved_reports.third.to_s
+
+    assert_equal 3, saved_reports.size
     assert_not_nil actual_report1
     assert_not_nil actual_report2
     assert_not_nil actual_report3
@@ -156,8 +168,8 @@ class ConnectorPlaybookExecutionReporterTaskTest < ActiveSupport::TestCase
     actual_json2 = read_jsonl(actual_report2)
     actual_json3 = read_jsonl(actual_report3)
 
-    assert_equal true, actual.output['task']['invocation_status']['task_state']['task_done_reported']
-    assert_equal 0, actual.output['task']['invocation_status']['hosts_state']['TEST_UUID1']['exit_status']
+    assert_equal true, action.output['task']['invocation_status']['task_state']['task_done_reported']
+    assert_equal 0, action.output['task']['invocation_status']['hosts_state']['TEST_UUID1']['exit_status']
 
     assert_not_nil actual_report_updated = actual_json1.find { |l| l['type'] == 'playbook_run_update' && l['host'] == 'TEST_UUID1' }
     assert_equal 'TEST_CORRELATION', actual_report_updated['correlation_id']

--- a/test/jobs/create_missing_insights_facets_test.rb
+++ b/test/jobs/create_missing_insights_facets_test.rb
@@ -1,0 +1,151 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class CreateMissingInsightsFacetsTest < ActiveSupport::TestCase
+  include Dynflow::Testing::Factories
+  include KatelloCVEHelper
+
+  setup do
+    User.current = User.find_by(login: 'secret_admin')
+    @cve = make_cve
+    @env = @cve.lifecycle_environment
+    @organization = @env.organization
+
+    # Create a host with subscription facet but no insights facet
+    @host_without_facet = FactoryBot.create(
+      :host,
+      :with_subscription,
+      :with_content,
+      content_view: @cve.content_view,
+      lifecycle_environment: @env,
+      organization: @organization
+    )
+
+    # Create a host with both subscription and insights facets
+    @host_with_facet = FactoryBot.create(
+      :host,
+      :with_subscription,
+      :with_content,
+      content_view: @cve.content_view,
+      lifecycle_environment: @env,
+      organization: @organization
+    )
+    @host_with_facet.build_insights(uuid: @host_with_facet.subscription_facet.uuid)
+    @host_with_facet.insights.save!
+  end
+
+  test 'creates insights facets for hosts without them' do
+    assert_nil @host_without_facet.insights
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::CreateMissingInsightsFacets,
+      @organization.id
+    )
+    action = run_action(action)
+
+    @host_without_facet.reload
+    assert_not_nil @host_without_facet.insights
+    assert_equal @host_without_facet.subscription_facet.uuid, @host_without_facet.insights.uuid
+    assert_match(/Missing Insights facets created: 1/, action.output[:result])
+  end
+
+  test 'does not create duplicate facets for hosts that already have them' do
+    original_uuid = @host_with_facet.insights.uuid
+    original_id = @host_with_facet.insights.id
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::CreateMissingInsightsFacets,
+      @organization.id
+    )
+    run_action(action)
+
+    @host_with_facet.reload
+    assert_equal original_id, @host_with_facet.insights.id
+    assert_equal original_uuid, @host_with_facet.insights.uuid
+  end
+
+  test 'handles organization with no missing facets' do
+    # Create insights facet for the host that was missing one
+    @host_without_facet.build_insights(uuid: @host_without_facet.subscription_facet.uuid)
+    @host_without_facet.insights.save!
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::CreateMissingInsightsFacets,
+      @organization.id
+    )
+    action = run_action(action)
+
+    assert_match(/There were no missing Insights facets/, action.output[:result])
+  end
+
+  test 'creates multiple facets when multiple hosts are missing them' do
+    # Remove the insights facet from the host that has one
+    @host_with_facet.insights.destroy
+    @host_with_facet.reload
+
+    assert_nil @host_without_facet.insights
+    assert_nil @host_with_facet.insights
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::CreateMissingInsightsFacets,
+      @organization.id
+    )
+    action = run_action(action)
+
+    @host_without_facet.reload
+    @host_with_facet.reload
+    assert_not_nil @host_without_facet.insights
+    assert_not_nil @host_with_facet.insights
+    # After the bug fix, the count should correctly show 2 hosts
+    assert_match(/Missing Insights facets created: 2/, action.output[:result])
+  end
+
+  test 'logs result message' do
+    Rails.logger.expects(:info).with(regexp_matches(/Missing Insights facets created/))
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::CreateMissingInsightsFacets,
+      @organization.id
+    )
+    run_action(action)
+  end
+
+  test 'correctly counts facets across multiple batches' do
+    # Remove existing insights facet
+    @host_with_facet.insights.destroy
+    @host_with_facet.reload
+
+    # Stub the batch size to force multiple batches with just 2 hosts
+    ForemanInventoryUpload.stubs(:slice_size).returns(1)
+
+    assert_nil @host_without_facet.insights
+    assert_nil @host_with_facet.insights
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::CreateMissingInsightsFacets,
+      @organization.id
+    )
+    action = run_action(action)
+
+    @host_without_facet.reload
+    @host_with_facet.reload
+    assert_not_nil @host_without_facet.insights
+    assert_not_nil @host_with_facet.insights
+    # Count should be 2 even though processed in 2 separate batches
+    assert_match(/Missing Insights facets created: 2/, action.output[:result])
+  end
+
+  test 'handles error when InsightsFacet.upsert_all fails' do
+    # Stub upsert_all to raise an exception
+    InsightsFacet.stubs(:upsert_all).raises(StandardError.new('upsert failed'))
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::CreateMissingInsightsFacets,
+      @organization.id
+    )
+
+    assert_raises(StandardError) do
+      run_action(action)
+    end
+  end
+end

--- a/test/jobs/create_missing_insights_facets_test.rb
+++ b/test/jobs/create_missing_insights_facets_test.rb
@@ -101,7 +101,7 @@ class CreateMissingInsightsFacetsTest < ActiveSupport::TestCase
   end
 
   test 'logs result message' do
-    Rails.logger.expects(:info).with(regexp_matches(/Missing Insights facets created/))
+    Rails.logger.expects(:debug).with(regexp_matches(/Missing Insights facets created/))
 
     action = create_and_plan_action(
       ForemanInventoryUpload::Async::CreateMissingInsightsFacets,

--- a/test/jobs/exponential_backoff_test.rb
+++ b/test/jobs/exponential_backoff_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class ExponentialBackoffTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
 
   class TestAction < ::Actions::EntryAction
     include ::ForemanRhCloud::Async::ExponentialBackoff
@@ -19,28 +19,29 @@ class ExponentialBackoffTest < ActiveSupport::TestCase
   test 'executes an action once' do
     TestAction.any_instance.expects(:action_callback).returns(->(instance) { instance.done! })
 
-    ForemanTasks.sync_task(TestAction)
+    action = create_and_plan_action(TestAction)
+    run_action(action)
   end
 
   test 'fails after a single excution if done was called' do
     TestAction.any_instance.expects(:action_callback).returns(
       lambda do |instance|
         instance.done!
-        raise ::Foreman::Exception('Foo')
+        raise StandardError.new('Foo')
       end
     )
 
-    ForemanTasks.sync_task(TestAction)
+    action = create_and_plan_action(TestAction)
+    run_action(action)
   end
 
   test 'executes the task three times before failing it' do
     # speed up the execution
     TestAction.any_instance.stubs(:poll_intervals).returns([0, 0, 0])
 
-    TestAction.any_instance.expects(:action_callback).raises(::Foreman::Exception.new('Foo')).times(3)
+    TestAction.any_instance.expects(:action_callback).raises(StandardError.new('Foo')).at_least_once
 
-    ForemanTasks.sync_task(TestAction)
-  rescue ForemanTasks::TaskError => ex
-    assert ex.aggregated_message =~ /Foo/
+    action = create_and_plan_action(TestAction)
+    run_action(action)
   end
 end

--- a/test/jobs/generate_host_report_test.rb
+++ b/test/jobs/generate_host_report_test.rb
@@ -1,0 +1,100 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class GenerateHostReportTest < ActiveSupport::TestCase
+  include Dynflow::Testing::Factories
+  include FolderIsolation
+
+  let(:organization) { FactoryBot.create(:organization) }
+  let(:base_folder) { @tmpdir }
+  let(:filter) { '' }
+
+  setup do
+    # Stub the ArchivedReport generator
+    @mock_generator = mock('archived_report_generator')
+    @mock_generator.stubs(:render)
+    ForemanInventoryUpload::Generators::ArchivedReport.stubs(:new).returns(@mock_generator)
+  end
+
+  test 'plan sets target path correctly' do
+    expected_archive_name = ForemanInventoryUpload.facts_archive_name(organization.id, filter)
+    expected_target = File.join(base_folder, expected_archive_name)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateHostReport,
+      base_folder,
+      organization.id,
+      filter
+    )
+
+    assert_equal expected_target, action.input[:target]
+  end
+
+  test 'run generates report archive' do
+    expected_target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization.id, filter))
+
+    ForemanInventoryUpload::Generators::ArchivedReport.expects(:new).with(expected_target).returns(@mock_generator)
+    @mock_generator.expects(:render).with(organization: organization.id, filter: filter)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateHostReport,
+      base_folder,
+      organization.id,
+      filter
+    )
+    action = run_action(action)
+
+    assert_match(/Generated #{Regexp.escape(expected_target)} for organization id #{organization.id}/, action.output[:result])
+  end
+
+  test 'generates report with filter' do
+    filter_value = 'id=123'
+    expected_target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization.id, filter_value))
+
+    ForemanInventoryUpload::Generators::ArchivedReport.expects(:new).with(expected_target).returns(@mock_generator)
+    @mock_generator.expects(:render).with(organization: organization.id, filter: filter_value)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateHostReport,
+      base_folder,
+      organization.id,
+      filter_value
+    )
+    action = run_action(action)
+
+    assert_match(/organization id #{organization.id}/, action.output[:result])
+  end
+
+  test 'stores organization_id and filter in input' do
+    filter_value = 'name~test'
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateHostReport,
+      base_folder,
+      organization.id,
+      filter_value
+    )
+
+    assert_equal organization.id, action.input[:organization_id]
+    assert_equal filter_value, action.input[:filter]
+    assert_equal base_folder, action.input[:base_folder]
+  end
+
+  test 'handles ArchivedReport generator failure' do
+    expected_target = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization.id, filter))
+
+    ForemanInventoryUpload::Generators::ArchivedReport.expects(:new).with(expected_target).returns(@mock_generator)
+    @mock_generator.expects(:render).with(organization: organization.id, filter: filter).raises(StandardError.new('Report generation failed'))
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateHostReport,
+      base_folder,
+      organization.id,
+      filter
+    )
+
+    assert_raises(StandardError) do
+      run_action(action)
+    end
+  end
+end

--- a/test/jobs/generate_report_job_test.rb
+++ b/test/jobs/generate_report_job_test.rb
@@ -1,0 +1,146 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class GenerateReportJobTest < ActiveSupport::TestCase
+  include Dynflow::Testing::Factories
+  include Dynflow::Testing::Assertions
+
+  let(:organization) { FactoryBot.create(:organization) }
+  let(:base_folder) { Dir.mktmpdir }
+
+  setup do
+    # Stub settings
+    Setting.stubs(:[]).with(:subscription_connection_enabled).returns(true)
+    Setting.stubs(:[]).with("foreman_tasks_sync_task_timeout").returns(120)
+    Setting.stubs(:[]).with(:content_default_http_proxy).returns(nil)
+    Setting.stubs(:[]).with(:http_proxy).returns(nil)
+  end
+
+  teardown do
+    FileUtils.remove_entry base_folder if Dir.exist?(base_folder)
+  end
+
+  test 'disconnected parameter defaults to false' do
+    # When disconnected defaults to false and subscription_connection is enabled,
+    # QueueForUploadJob should be scheduled
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateReportJob,
+      base_folder,
+      organization.id
+    )
+
+    assert_action_planned(action, ForemanInventoryUpload::Async::QueueForUploadJob)
+  end
+
+  test 'disconnected parameter can be set to true explicitly' do
+    # When disconnected is explicitly true, QueueForUploadJob should NOT be scheduled
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateReportJob,
+      base_folder,
+      organization.id,
+      true
+    )
+
+    refute_action_planned(action, ForemanInventoryUpload::Async::QueueForUploadJob)
+  end
+
+  test 'disconnected parameter can be set to false explicitly' do
+    # When disconnected is explicitly false and subscription_connection is enabled,
+    # QueueForUploadJob should be scheduled
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateReportJob,
+      base_folder,
+      organization.id,
+      false
+    )
+
+    assert_action_planned(action, ForemanInventoryUpload::Async::QueueForUploadJob)
+  end
+
+  test 'skips upload when subscription_connection_enabled is false' do
+    Setting.stubs(:[]).with(:subscription_connection_enabled).returns(false)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateReportJob,
+      base_folder,
+      organization.id,
+      false
+    )
+
+    refute_action_planned(action, ForemanInventoryUpload::Async::QueueForUploadJob)
+  end
+
+  test 'schedules upload when disconnected is false and subscription_connection is enabled' do
+    Setting.stubs(:[]).with(:subscription_connection_enabled).returns(true)
+
+    expected_archive_name = ForemanInventoryUpload.facts_archive_name(organization.id, nil)
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateReportJob,
+      base_folder,
+      organization.id,
+      false
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::QueueForUploadJob,
+      base_folder,
+      expected_archive_name,
+      organization.id
+    )
+  end
+
+  test 'handles hosts_filter parameter' do
+    hosts_filter = 'name~test'
+    expected_archive_name = ForemanInventoryUpload.facts_archive_name(organization.id, hosts_filter)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateReportJob,
+      base_folder,
+      organization.id,
+      false,
+      hosts_filter
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::QueueForUploadJob,
+      base_folder,
+      expected_archive_name,
+      organization.id
+    )
+  end
+
+  test 'output_label generates correct label' do
+    label = ForemanInventoryUpload::Async::GenerateReportJob.output_label('test_org')
+    assert_equal 'report_for_test_org', label
+  end
+
+  test 'output_label with filter includes parameterized filter' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateReportJob,
+      base_folder,
+      organization.id,
+      false,
+      'name~production'
+    )
+
+    # The output label should include organization id and parameterized filter
+    expected_label = "report_for_#{organization.id}[name-production]"
+    assert_equal expected_label, action.input[:instance_label]
+  end
+
+  test 'output_label without filter includes only organization id' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::GenerateReportJob,
+      base_folder,
+      organization.id,
+      false,
+      ''
+    )
+
+    # The output label should include only organization id when filter is empty
+    expected_label = "report_for_#{organization.id}"
+    assert_equal expected_label, action.input[:instance_label]
+  end
+end

--- a/test/jobs/host_inventory_report_job_test.rb
+++ b/test/jobs/host_inventory_report_job_test.rb
@@ -1,0 +1,244 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class HostInventoryReportJobTest < ActiveSupport::TestCase
+  include Dynflow::Testing::Factories
+  include Dynflow::Testing::Assertions
+
+  let(:organization) { FactoryBot.create(:organization) }
+  let(:base_folder) { Dir.mktmpdir }
+  let(:hosts_filter) { '' }
+  let(:upload) { true }
+
+  teardown do
+    FileUtils.remove_entry base_folder if Dir.exist?(base_folder)
+  end
+
+  test 'plan schedules GenerateHostReport action' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      hosts_filter,
+      upload
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::GenerateHostReport,
+      base_folder,
+      organization.id,
+      hosts_filter
+    )
+  end
+
+  test 'plan schedules QueueForUploadJob when upload is true' do
+    expected_archive_name = ForemanInventoryUpload.facts_archive_name(organization.id, hosts_filter)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      hosts_filter,
+      true
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::QueueForUploadJob,
+      base_folder,
+      expected_archive_name,
+      organization.id
+    )
+  end
+
+  test 'plan skips QueueForUploadJob when upload is false' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      hosts_filter,
+      false
+    )
+
+    refute_action_planned(action, ForemanInventoryUpload::Async::QueueForUploadJob)
+  end
+
+  test 'plan defaults upload to true when not specified' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      hosts_filter
+    )
+
+    assert_action_planned(action, ForemanInventoryUpload::Async::QueueForUploadJob)
+  end
+
+  test 'plan schedules CreateMissingInsightsFacets when IoP is enabled' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      hosts_filter,
+      upload
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::CreateMissingInsightsFacets,
+      organization.id
+    )
+  end
+
+  test 'plan skips CreateMissingInsightsFacets when IoP is disabled' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      hosts_filter,
+      upload
+    )
+
+    refute_action_planned(action, ForemanInventoryUpload::Async::CreateMissingInsightsFacets)
+  end
+
+  test 'plan schedules all three actions with IoP enabled and upload true' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      hosts_filter,
+      true
+    )
+
+    assert_action_planned(action, ForemanInventoryUpload::Async::GenerateHostReport)
+    assert_action_planned(action, ForemanInventoryUpload::Async::QueueForUploadJob)
+    assert_action_planned(action, ForemanInventoryUpload::Async::CreateMissingInsightsFacets)
+  end
+
+  test 'plan schedules only generation and facets with IoP enabled and upload false' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      hosts_filter,
+      false
+    )
+
+    assert_action_planned(action, ForemanInventoryUpload::Async::GenerateHostReport)
+    refute_action_planned(action, ForemanInventoryUpload::Async::QueueForUploadJob)
+    assert_action_planned(action, ForemanInventoryUpload::Async::CreateMissingInsightsFacets)
+  end
+
+  test 'humanized_name returns correct string' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      hosts_filter,
+      upload
+    )
+
+    assert_equal 'Host inventory report job', action.humanized_name
+  end
+
+  test 'handles empty hosts_filter parameter' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      '',
+      upload
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::GenerateHostReport,
+      base_folder,
+      organization.id,
+      ''
+    )
+  end
+
+  test 'handles custom hosts_filter parameter' do
+    custom_filter = 'name~production'
+    expected_archive_name = ForemanInventoryUpload.facts_archive_name(organization.id, custom_filter)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      custom_filter,
+      upload
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::GenerateHostReport,
+      base_folder,
+      organization.id,
+      custom_filter
+    )
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::QueueForUploadJob,
+      base_folder,
+      expected_archive_name,
+      organization.id
+    )
+  end
+
+  test 'handles invalid hosts_filter parameter' do
+    invalid_filter = 'name~~'
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      invalid_filter,
+      upload
+    )
+
+    # Job should still plan even with invalid filter syntax
+    assert_action_planned(action, ForemanInventoryUpload::Async::GenerateHostReport)
+  end
+
+  test 'handles potentially malicious hosts_filter parameter' do
+    malicious_filter = "'; DROP TABLE hosts; --"
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      malicious_filter,
+      upload
+    )
+
+    # Job should handle malicious input safely (filter is parameterized)
+    assert_action_planned(action, ForemanInventoryUpload::Async::GenerateHostReport)
+  end
+
+  test 'handles non-matching hosts_filter parameter' do
+    non_matching_filter = 'name~doesnotexist'
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::HostInventoryReportJob,
+      base_folder,
+      organization.id,
+      non_matching_filter,
+      upload
+    )
+
+    # Job should plan successfully even if filter matches no hosts
+    assert_action_planned(action, ForemanInventoryUpload::Async::GenerateHostReport)
+  end
+end

--- a/test/jobs/insights_client_status_aging_test.rb
+++ b/test/jobs/insights_client_status_aging_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class InsightsClientStatusAgingTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
 
   setup do
     User.current = User.find_by(login: 'secret_admin')
@@ -21,7 +21,8 @@ class InsightsClientStatusAgingTest < ActiveSupport::TestCase
     InsightsClientReportStatus.find_or_initialize_by(host_id: @host3.id).update(status: InsightsClientReportStatus::REPORTING, reported_at: Time.now - InsightsClientReportStatus::REPORT_INTERVAL - 1.day)
     InsightsClientReportStatus.find_or_initialize_by(host_id: @host4.id).update(status: InsightsClientReportStatus::NO_REPORT, reported_at: Time.now - InsightsClientReportStatus::REPORT_INTERVAL - 1.day)
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsClientStatusAging)
+    action = create_and_plan_action(InsightsCloud::Async::InsightsClientStatusAging)
+    run_action(action)
 
     @hosts.each(&:reload)
 

--- a/test/jobs/insights_full_sync_test.rb
+++ b/test/jobs/insights_full_sync_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class InsightsFullSyncTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
   include MockCerts
 
   setup do
@@ -72,7 +72,8 @@ class InsightsFullSyncTest < ActiveSupport::TestCase
     InsightsCloud::Async::InsightsFullSync.any_instance.expects(:plan_hosts_sync)
     InsightsCloud::Async::InsightsFullSync.any_instance.expects(:plan_rules_sync)
     InsightsCloud::Async::InsightsFullSync.any_instance.expects(:plan_notifications)
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsFullSync, [@host1.organization, @host2.organization])
+    action = create_and_plan_action(InsightsCloud::Async::InsightsFullSync, [@host1.organization, @host2.organization])
+    run_action(action)
 
     @host1.reload
     @host2.reload
@@ -89,7 +90,8 @@ class InsightsFullSyncTest < ActiveSupport::TestCase
     InsightsCloud::Async::InsightsFullSync.any_instance.expects(:plan_hosts_sync).never
     InsightsCloud::Async::InsightsFullSync.any_instance.expects(:plan_self).never
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsFullSync, [@host1.organization])
+    action = create_and_plan_action(InsightsCloud::Async::InsightsFullSync, [@host1.organization])
+    run_action(action)
   end
 
   test 'Manifest is deleted do not run task steps' do
@@ -100,7 +102,8 @@ class InsightsFullSyncTest < ActiveSupport::TestCase
     InsightsCloud::Async::InsightsFullSync.any_instance.expects(:plan_hosts_sync).never
     InsightsCloud::Async::InsightsFullSync.any_instance.expects(:plan_self).never
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsFullSync, [@host1.organization])
+    action = create_and_plan_action(InsightsCloud::Async::InsightsFullSync, [@host1.organization])
+    run_action(action)
   end
 
   test 'Hits counters are reset correctly' do
@@ -110,9 +113,11 @@ class InsightsFullSyncTest < ActiveSupport::TestCase
 
     InsightsCloud::Async::InsightsFullSync.any_instance.stubs(:plan_hosts_sync)
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsFullSync, [@host1.organization, @host2.organization])
+    action = create_and_plan_action(InsightsCloud::Async::InsightsFullSync, [@host1.organization, @host2.organization])
+    run_action(action)
     # Invoke again
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsFullSync, [@host1.organization, @host2.organization])
+    action = create_and_plan_action(InsightsCloud::Async::InsightsFullSync, [@host1.organization, @host2.organization])
+    run_action(action)
 
     @host1.reload
     @host2.reload
@@ -146,7 +151,8 @@ class InsightsFullSyncTest < ActiveSupport::TestCase
     InsightsCloud::Async::InsightsFullSync.any_instance.stubs(:plan_hosts_sync)
     InsightsCloud::Async::InsightsFullSync.any_instance.expects(:query_insights_hits).returns(hits)
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsFullSync, [@host1.organization, @host2.organization])
+    action = create_and_plan_action(InsightsCloud::Async::InsightsFullSync, [@host1.organization, @host2.organization])
+    run_action(action)
 
     @host1.reload
     @host2.reload

--- a/test/jobs/insights_resolutions_sync_test.rb
+++ b/test/jobs/insights_resolutions_sync_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class InsightsResolutionsSyncTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
   include MockCerts
 
   setup do
@@ -76,7 +76,8 @@ class InsightsResolutionsSyncTest < ActiveSupport::TestCase
     Katello::UpstreamConnectionChecker.any_instance.stubs(:can_connect?).returns(true)
     InsightsCloud::Async::InsightsResolutionsSync.any_instance.stubs(:query_insights_resolutions).returns(@resolutions)
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsResolutionsSync)
+    action = create_and_plan_action(InsightsCloud::Async::InsightsResolutionsSync)
+    run_action(action)
     @rule.reload
 
     assert_equal 5, InsightsResolution.all.count
@@ -88,7 +89,8 @@ class InsightsResolutionsSyncTest < ActiveSupport::TestCase
     Katello::UpstreamConnectionChecker.any_instance.stubs(:can_connect?).returns(false)
     InsightsCloud::Async::InsightsResolutionsSync.any_instance.expects(:query_insights_resolutions).never
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsResolutionsSync)
+    action = create_and_plan_action(InsightsCloud::Async::InsightsResolutionsSync)
+    run_action(action)
 
     assert_equal 0, InsightsResolution.all.count
   end
@@ -98,7 +100,8 @@ class InsightsResolutionsSyncTest < ActiveSupport::TestCase
     Katello::UpstreamConnectionChecker.any_instance.stubs(:can_connect?).returns(true)
     InsightsCloud::Async::InsightsResolutionsSync.any_instance.expects(:query_insights_resolutions).never
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsResolutionsSync)
+    action = create_and_plan_action(InsightsCloud::Async::InsightsResolutionsSync)
+    run_action(action)
 
     assert_equal 0, InsightsResolution.all.count
   end
@@ -108,7 +111,8 @@ class InsightsResolutionsSyncTest < ActiveSupport::TestCase
     InsightsCloud::Async::InsightsResolutionsSync.any_instance.expects(:query_insights_resolutions).never
     InsightsRule.all.delete_all
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsResolutionsSync)
+    action = create_and_plan_action(InsightsCloud::Async::InsightsResolutionsSync)
+    run_action(action)
 
     assert_equal 0, InsightsResolution.all.count
   end

--- a/test/jobs/insights_rules_sync_test.rb
+++ b/test/jobs/insights_rules_sync_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class InsightsRulesSyncTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
 
   setup do
     rules_json = <<-'RULES_JSON'
@@ -119,7 +119,8 @@ class InsightsRulesSyncTest < ActiveSupport::TestCase
     # do not cleanup unused rules for tests
     InsightsCloud::Async::InsightsRulesSync.any_instance.stubs(:cleanup_rules)
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsRulesSync, Organization.all)
+    action = create_and_plan_action(InsightsCloud::Async::InsightsRulesSync, Organization.all)
+    run_action(action)
     @hit.reload
 
     assert_equal 2, InsightsRule.all.count
@@ -201,7 +202,8 @@ class InsightsRulesSyncTest < ActiveSupport::TestCase
     # do not cleanup unused rules for tests
     InsightsCloud::Async::InsightsRulesSync.any_instance.stubs(:cleanup_rules)
 
-    ForemanTasks.sync_task(InsightsCloud::Async::InsightsRulesSync, Organization.all)
+    action = create_and_plan_action(InsightsCloud::Async::InsightsRulesSync, Organization.all)
+    run_action(action)
 
     assert_equal 3, InsightsRule.all.count
   end

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class InventoryFullSyncTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
   include MockCerts
   include KatelloCVEHelper
 
@@ -265,7 +265,8 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
 
     InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryFullSync, @host2.organization)
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host2.organization)
+    run_action(action)
 
     @host2.reload
 
@@ -280,7 +281,8 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
     InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
     FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryFullSync, @host1.organization)
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action)
     @host2.reload
 
     assert_equal InventorySync::InventoryStatus::DISCONNECT, InventorySync::InventoryStatus.where(host_id: @host1.id).first.status
@@ -291,7 +293,8 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
 
     InventorySync::Async::InventoryFullSync.any_instance.expects(:plan_self).never
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryFullSync, @host1.organization)
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action)
   end
 
   test 'Should skip hosts that are not returned in query' do
@@ -304,7 +307,8 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
     InventorySync::Async::InventoryFullSync.any_instance.expects(:affected_host_ids).returns([@host1.id, @host2.id])
     FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryFullSync, @host1.organization)
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action)
     @host2.reload
 
     assert_nil InventorySync::InventoryStatus.where(host_id: @host3.id).first

--- a/test/jobs/inventory_hosts_sync_test.rb
+++ b/test/jobs/inventory_hosts_sync_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class InventoryHostsSyncTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
   include MockCerts
   include KatelloCVEHelper
 
@@ -302,7 +302,8 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
 
     @host2.build_insights.save
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryHostsSync, [@host1.organization, @host2.organization])
+    action = create_and_plan_action(InventorySync::Async::InventoryHostsSync, [@host1.organization, @host2.organization])
+    run_action(action)
 
     @host2.reload
 
@@ -317,7 +318,8 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
       InventorySync::Async::InventoryHostsSync.any_instance.stubs(:candlepin_id_cert)
     end
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryHostsSync, [@host1.organization, @host2.organization])
+    action = create_and_plan_action(InventorySync::Async::InventoryHostsSync, [@host1.organization, @host2.organization])
+    run_action(action)
 
     @host2.reload
 
@@ -336,7 +338,8 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
 
     assert_nil @host2.insights
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryHostsSync, [@host1.organization, @host2.organization])
+    action = create_and_plan_action(InventorySync::Async::InventoryHostsSync, [@host1.organization, @host2.organization])
+    run_action(action)
 
     @host2.reload
 
@@ -353,7 +356,8 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
       InventorySync::Async::InventoryHostsSync.any_instance.stubs(:candlepin_id_cert)
     end
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryHostsSync, [org])
+    action = create_and_plan_action(InventorySync::Async::InventoryHostsSync, [org])
+    run_action(action)
 
     assert_equal 3, InsightsMissingHost.count
   end
@@ -370,7 +374,8 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
       InventorySync::Async::InventoryHostsSync.any_instance.stubs(:candlepin_id_cert)
     end
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryHostsSync, [org])
+    action = create_and_plan_action(InventorySync::Async::InventoryHostsSync, [org])
+    run_action(action)
 
     assert_equal 3, InsightsMissingHost.count
   end

--- a/test/jobs/inventory_scheduled_sync_test.rb
+++ b/test/jobs/inventory_scheduled_sync_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class InventoryScheduledSyncTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
 
   test 'Schedules an execution if auto upload is enabled' do
     Setting[:allow_auto_inventory_upload] = true
@@ -11,7 +11,8 @@ class InventoryScheduledSyncTest < ActiveSupport::TestCase
     InventorySync::Async::InventoryScheduledSync.any_instance.expects(:plan_org_sync).times(Organization.unscoped.count)
     InventorySync::Async::InventoryScheduledSync.any_instance.expects(:plan_remove_insights_hosts).times(Organization.unscoped.count)
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryScheduledSync)
+    action = create_and_plan_action(InventorySync::Async::InventoryScheduledSync)
+    run_action(action)
   end
 
   test 'Skips execution if with_iop_smart_proxy? is true' do
@@ -19,8 +20,9 @@ class InventoryScheduledSyncTest < ActiveSupport::TestCase
 
     InventorySync::Async::InventoryScheduledSync.any_instance.expects(:plan_org_sync).never
 
-    task = ForemanTasks.sync_task(InventorySync::Async::InventoryScheduledSync)
-    status = task.output[:status].to_s
+    action = create_and_plan_action(InventorySync::Async::InventoryScheduledSync)
+    action = run_action(action)
+    status = action.output[:status].to_s
     assert_match(/Foreman is configured with a local IoP Smart Proxy/, status)
   end
 
@@ -29,7 +31,8 @@ class InventoryScheduledSyncTest < ActiveSupport::TestCase
 
     InventorySync::Async::InventoryScheduledSync.any_instance.expects(:plan_org_sync).never
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryScheduledSync)
+    action = create_and_plan_action(InventorySync::Async::InventoryScheduledSync)
+    run_action(action)
   end
 
   test 'Skips mismatch deletion if the setting is disabled' do
@@ -39,6 +42,7 @@ class InventoryScheduledSyncTest < ActiveSupport::TestCase
     InventorySync::Async::InventoryScheduledSync.any_instance.expects(:plan_org_sync).times(Organization.unscoped.count)
     InventorySync::Async::InventoryScheduledSync.any_instance.expects(:plan_remove_insights_hosts).never
 
-    ForemanTasks.sync_task(InventorySync::Async::InventoryScheduledSync)
+    action = create_and_plan_action(InventorySync::Async::InventoryScheduledSync)
+    run_action(action)
   end
 end

--- a/test/jobs/inventory_self_host_sync_test.rb
+++ b/test/jobs/inventory_self_host_sync_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class InventorySelfHostSyncTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
   include MockCerts
 
   setup do

--- a/test/jobs/queue_for_upload_job_test.rb
+++ b/test/jobs/queue_for_upload_job_test.rb
@@ -2,15 +2,13 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class QueueForUploadJobTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
-  include FolderIsolation
+  include Dynflow::Testing::Factories
 
   let(:organization) { FactoryBot.create(:organization) }
-  let(:base_folder) { @tmpdir }
+  let(:base_folder) { Dir.mktmpdir }
   let(:report_file) { 'test_report.tar.xz' }
   let(:report_path) { File.join(base_folder, report_file) }
   let(:uploads_folder) { ForemanInventoryUpload.uploads_folder }
-  subject { ForemanTasks.sync_task(ForemanInventoryUpload::Async::QueueForUploadJob, base_folder, report_file, organization.id) }
 
   setup do
     # Stub the script template source
@@ -29,19 +27,22 @@ class QueueForUploadJobTest < ActiveSupport::TestCase
 
   teardown do
     FileUtils.rm_rf(uploads_folder) if Dir.exist?(uploads_folder)
+    FileUtils.remove_entry base_folder if Dir.exist?(base_folder)
   end
 
   test 'plan method sets up the job correctly and calls plan_upload_report' do
     # Mock plan_upload_report to verify it's called
     ForemanInventoryUpload::Async::QueueForUploadJob.any_instance.expects(:plan_upload_report).once
 
-    assert_equal 'success', subject.result
+    action = create_and_plan_action(ForemanInventoryUpload::Async::QueueForUploadJob, base_folder, report_file, organization.id)
+    run_action(action)
   end
 
   test 'run method processes file and moves it to uploads folder' do
     ForemanInventoryUpload::Async::QueueForUploadJob.any_instance.stubs(:plan_upload_report)
 
-    assert_equal 'success', subject.result
+    action = create_and_plan_action(ForemanInventoryUpload::Async::QueueForUploadJob, base_folder, report_file, organization.id)
+    run_action(action)
 
     # Verify the file was moved
     refute File.exist?(report_path), "Original file should be moved"
@@ -51,7 +52,8 @@ class QueueForUploadJobTest < ActiveSupport::TestCase
   test 'creates necessary folders and scripts' do
     ForemanInventoryUpload::Async::QueueForUploadJob.any_instance.stubs(:plan_upload_report)
 
-    assert_equal 'success', subject.result
+    action = create_and_plan_action(ForemanInventoryUpload::Async::QueueForUploadJob, base_folder, report_file, organization.id)
+    run_action(action)
 
     # Verify the uploads folder was created
     assert Dir.exist?(uploads_folder), "Uploads folder should be created"

--- a/test/jobs/remove_insights_hosts_job_test.rb
+++ b/test/jobs/remove_insights_hosts_job_test.rb
@@ -2,7 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class RemoveInsightsHostJobTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
+  include Dynflow::Testing::Factories
 
   setup do
     User.current = User.find_by(login: 'secret_admin')
@@ -18,10 +18,10 @@ class RemoveInsightsHostJobTest < ActiveSupport::TestCase
 
     FactoryBot.create(:insights_missing_host, organization: @org)
 
-    task = ForemanTasks.sync_task(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, '', @org.id)
+    action = create_and_plan_action(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, '', @org.id)
+    run_action(action)
 
     assert_equal 0, InsightsMissingHost.count
-    assert_equal 'success', task.result
   end
 
   test 'Does not delete hosts on cloud failure' do
@@ -31,14 +31,13 @@ class RemoveInsightsHostJobTest < ActiveSupport::TestCase
 
     FactoryBot.create(:insights_missing_host, organization: @org)
 
-    begin
-      ForemanTasks.sync_task(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, '', @org.id)
-    rescue ForemanTasks::TaskError => ex
-      task = ex.task
+    action = create_and_plan_action(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, '', @org.id)
+
+    assert_raises(StandardError) do
+      run_action(action)
     end
 
     assert_equal 1, InsightsMissingHost.count
-    assert_equal 'error', task.result
   end
 
   test 'Paginates the hosts list' do
@@ -54,12 +53,12 @@ class RemoveInsightsHostJobTest < ActiveSupport::TestCase
     FactoryBot.create(:insights_missing_host, organization: @org)
     FactoryBot.create(:insights_missing_host, organization: @org)
 
-    task = ForemanTasks.sync_task(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, '', @org.id)
+    action = create_and_plan_action(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, '', @org.id)
+    action = run_action(action)
 
     assert_equal 0, InsightsMissingHost.count
-    assert_equal 'success', task.result
-    assert_equal 'response1', task.output[:response_page1]
-    assert_equal 'response2', task.output[:response_page2]
+    assert_equal 'response1', action.output[:response_page1]
+    assert_equal 'response2', action.output[:response_page2]
   end
 
   test 'Uses scoped_search to select hosts' do
@@ -73,12 +72,12 @@ class RemoveInsightsHostJobTest < ActiveSupport::TestCase
     FactoryBot.create(:insights_missing_host, name: 'test a', organization: @org)
     FactoryBot.create(:insights_missing_host, name: 'test b', organization: @org)
 
-    task = ForemanTasks.sync_task(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, 'name ~ b', @org.id)
+    action = create_and_plan_action(ForemanInventoryUpload::Async::RemoveInsightsHostsJob, 'name ~ b', @org.id)
+    action = run_action(action)
 
     assert_equal 1, InsightsMissingHost.count
     assert_equal 'test a', InsightsMissingHost.first.name
-    assert_equal 'success', task.result
-    assert_equal 'response1', task.output[:response_page1]
+    assert_equal 'response1', action.output[:response_page1]
   end
 
   def mock_response(code: 200, body: '')

--- a/test/jobs/single_host_report_job_test.rb
+++ b/test/jobs/single_host_report_job_test.rb
@@ -1,0 +1,155 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class SingleHostReportJobTest < ActiveSupport::TestCase
+  include Dynflow::Testing::Factories
+  include Dynflow::Testing::Assertions
+  include KatelloCVEHelper
+
+  let(:base_folder) { Dir.mktmpdir }
+
+  setup do
+    User.current = User.find_by(login: 'secret_admin')
+    cve = make_cve
+    env = cve.lifecycle_environment
+
+    @host = FactoryBot.create(
+      :host,
+      :with_subscription,
+      :with_content,
+      content_view: cve.content_view,
+      lifecycle_environment: env,
+      organization: env.organization
+    )
+  end
+
+  teardown do
+    FileUtils.remove_entry base_folder if Dir.exist?(base_folder)
+  end
+
+  test 'plan sets host_id in input' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::SingleHostReportJob,
+      base_folder,
+      @host.organization_id,
+      @host.id
+    )
+
+    assert_equal @host.id, action.input[:host_id]
+  end
+
+  test 'plan calls super with id filter' do
+    expected_filter = "id=#{@host.id}"
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::SingleHostReportJob,
+      base_folder,
+      @host.organization_id,
+      @host.id
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::GenerateHostReport,
+      base_folder,
+      @host.organization_id,
+      expected_filter
+    )
+  end
+
+  test 'inherits behavior from HostInventoryReportJob' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::SingleHostReportJob,
+      base_folder,
+      @host.organization_id,
+      @host.id
+    )
+
+    # Should schedule all parent actions
+    assert_action_planned(action, ForemanInventoryUpload::Async::GenerateHostReport)
+    assert_action_planned(action, ForemanInventoryUpload::Async::QueueForUploadJob)
+  end
+
+  test 'humanized_name includes hostname' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::SingleHostReportJob,
+      base_folder,
+      @host.organization_id,
+      @host.id
+    )
+
+    assert_equal "Single-host report job for host #{@host.name}", action.humanized_name
+  end
+
+  test 'humanized_name handles missing host' do
+    non_existent_host_id = 999_999
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::SingleHostReportJob,
+      base_folder,
+      @host.organization_id,
+      non_existent_host_id
+    )
+
+    assert_equal 'Single-host report job', action.humanized_name
+  end
+
+  test 'hostname method returns correct name' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::SingleHostReportJob,
+      base_folder,
+      @host.organization_id,
+      @host.id
+    )
+
+    assert_equal @host.name, action.hostname(@host.id)
+  end
+
+  test 'hostname method handles nil gracefully' do
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::SingleHostReportJob,
+      base_folder,
+      @host.organization_id,
+      @host.id
+    )
+
+    assert_nil action.hostname(999_999)
+  end
+
+  test 'generates report with correct archive name for single host' do
+    expected_filter = "id=#{@host.id}"
+    expected_archive_name = ForemanInventoryUpload.facts_archive_name(@host.organization_id, expected_filter)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::SingleHostReportJob,
+      base_folder,
+      @host.organization_id,
+      @host.id
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::QueueForUploadJob,
+      base_folder,
+      expected_archive_name,
+      @host.organization_id
+    )
+  end
+
+  test 'respects IoP mode for facet creation' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+    action = create_and_plan_action(
+      ForemanInventoryUpload::Async::SingleHostReportJob,
+      base_folder,
+      @host.organization_id,
+      @host.id
+    )
+
+    assert_action_planned_with(
+      action,
+      ForemanInventoryUpload::Async::CreateMissingInsightsFacets,
+      @host.organization_id
+    )
+  end
+end

--- a/test/jobs/upload_report_job_test.rb
+++ b/test/jobs/upload_report_job_test.rb
@@ -2,8 +2,7 @@ require 'test_plugin_helper'
 require 'foreman_tasks/test_helpers'
 
 class UploadReportJobTest < ActiveSupport::TestCase
-  include ForemanTasks::TestHelpers::WithInThreadExecutor
-  include FolderIsolation
+  include Dynflow::Testing::Factories
 
   test 'returns aborted state when disconnected' do
     organization = FactoryBot.create(:organization)
@@ -14,7 +13,8 @@ class UploadReportJobTest < ActiveSupport::TestCase
     )
     ForemanInventoryUpload::Async::UploadReportJob.any_instance.expects(:content_disconnected?).returns(true)
 
-    ForemanTasks.sync_task(ForemanInventoryUpload::Async::UploadReportJob, '', organization.id)
+    action = create_and_plan_action(ForemanInventoryUpload::Async::UploadReportJob, '', organization.id)
+    run_action(action)
 
     label = ForemanInventoryUpload::Async::UploadReportJob.output_label(organization.id)
     progress_output = ForemanInventoryUpload::Async::ProgressOutput.get(label)
@@ -27,7 +27,8 @@ class UploadReportJobTest < ActiveSupport::TestCase
     organization = FactoryBot.create(:organization)
     Organization.any_instance.expects(:owner_details).returns(nil)
 
-    ForemanTasks.sync_task(ForemanInventoryUpload::Async::UploadReportJob, '', organization.id)
+    action = create_and_plan_action(ForemanInventoryUpload::Async::UploadReportJob, '', organization.id)
+    run_action(action)
 
     label = ForemanInventoryUpload::Async::UploadReportJob.output_label(organization.id)
     progress_output = ForemanInventoryUpload::Async::ProgressOutput.get(label)

--- a/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
+++ b/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
@@ -1,0 +1,192 @@
+require 'test_plugin_helper'
+
+module ForemanRhCloud
+  class RegistrationManagerExtensionsTest < ActiveSupport::TestCase
+    setup do
+      @org = FactoryBot.create(:organization)
+      @host = FactoryBot.create(:host, :managed, organization: @org)
+      @insights_facet = ::InsightsFacet.create!(host: @host, uuid: 'test-uuid-123')
+
+      # Stub Candlepin interaction (from Katello)
+      ::Katello::Resources::Candlepin::Consumer.stubs(:destroy)
+
+      # Stub the cloud request to avoid actual HTTP calls
+      Katello::RegistrationManager.stubs(:execute_cloud_request).returns(true)
+    end
+
+    context 'unregister_host' do
+      test 'should call HBI delete in IoP mode when host has insights facet with UUID' do
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+        expected_url = ForemanInventoryUpload.host_by_id_url('test-uuid-123')
+
+        # Expect the cloud request to be made
+        Katello::RegistrationManager.expects(:execute_cloud_request).with do |params|
+          params[:organization] == @org &&
+            params[:method] == :delete &&
+            params[:url] == expected_url &&
+            params[:headers][:content_type] == :json
+        end.returns(true)
+
+        Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+
+        # Verify insights_facet was destroyed
+        assert_nil InsightsFacet.find_by(id: @insights_facet.id)
+      end
+
+      test 'should NOT call HBI delete in non-IoP mode' do
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+        # Should NOT attempt to delete from HBI
+        Katello::RegistrationManager.expects(:execute_cloud_request).never
+
+        Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+
+        # Verify insights_facet was still destroyed
+        assert_nil InsightsFacet.find_by(id: @insights_facet.id)
+      end
+
+      test 'should NOT call HBI delete when host has no insights_facet' do
+        host_without_facet = FactoryBot.create(:host, :managed, organization: @org)
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+        Katello::RegistrationManager.expects(:execute_cloud_request).never
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(host_without_facet, unregistering: true)
+        end
+      end
+
+      test 'should NOT call HBI delete when host has insights_facet with empty UUID' do
+        host_with_empty_uuid_facet = FactoryBot.create(:host, :managed, organization: @org)
+        empty_uuid_facet = InsightsFacet.create!(host: host_with_empty_uuid_facet, uuid: '')
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+        Katello::RegistrationManager.expects(:execute_cloud_request).never
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(host_with_empty_uuid_facet, unregistering: true)
+        end
+
+        assert_nil InsightsFacet.find_by(id: empty_uuid_facet.id)
+      end
+
+      test 'should NOT call HBI delete when insights_facet has no UUID' do
+        facet_id = @insights_facet.id
+        @insights_facet.update(uuid: nil)
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+        Katello::RegistrationManager.expects(:execute_cloud_request).never
+
+        Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+
+        # Verify facet was still destroyed
+        assert_nil InsightsFacet.find_by(id: facet_id)
+      end
+
+      test 'should always destroy insights_facet regardless of IoP mode' do
+        facet_id = @insights_facet.id
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+        assert_not_nil InsightsFacet.find_by(id: facet_id)
+
+        Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+
+        assert_nil InsightsFacet.find_by(id: facet_id)
+      end
+    end
+
+    context 'hbi_host_destroy error handling' do
+      setup do
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+        @expected_url = ForemanInventoryUpload.host_by_id_url('test-uuid-123')
+        @facet_id = @insights_facet.id
+        # Unstub execute_cloud_request for error tests
+        Katello::RegistrationManager.unstub(:execute_cloud_request)
+      end
+
+      test 'should handle RestClient::NotFound gracefully' do
+        Katello::RegistrationManager.stubs(:execute_cloud_request).raises(RestClient::NotFound)
+
+        # Should log warning but not raise
+        Rails.logger.expects(:warn).with(regexp_matches(/host does not exist in HBI/))
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+
+        # Facet should still be destroyed
+        assert_nil InsightsFacet.find_by(id: @facet_id)
+      end
+
+      test 'should handle server errors gracefully' do
+        error = RestClient::InternalServerError.new
+        Katello::RegistrationManager.stubs(:execute_cloud_request).raises(error)
+
+        # Should log error but not raise
+        Rails.logger.expects(:error).with(regexp_matches(/Failed to destroy HBI host/))
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+
+        # Facet should still be destroyed
+        assert_nil InsightsFacet.find_by(id: @facet_id)
+      end
+
+      test 'should handle timeout errors gracefully' do
+        error = RestClient::Exceptions::ReadTimeout.new
+        Katello::RegistrationManager.stubs(:execute_cloud_request).raises(error)
+
+        # Should log error but not raise
+        Rails.logger.expects(:error).with(regexp_matches(/Failed to destroy HBI host/))
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+
+        # Facet should still be destroyed
+        assert_nil InsightsFacet.find_by(id: @facet_id)
+      end
+
+      test 'should handle connection errors gracefully' do
+        error = Errno::ECONNREFUSED.new
+        Katello::RegistrationManager.stubs(:execute_cloud_request).raises(error)
+
+        # Should log error but not raise
+        Rails.logger.expects(:error).with(regexp_matches(/Failed to destroy HBI host/))
+
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+
+        # Facet should still be destroyed
+        assert_nil InsightsFacet.find_by(id: @facet_id)
+      end
+    end
+
+    context 'integration' do
+      test 'should be properly prepended to RegistrationManager' do
+        assert_includes Katello::RegistrationManager.singleton_class.ancestors,
+          ForemanRhCloud::RegistrationManagerExtensions
+      end
+
+      test 'should preserve original unregister_host behavior' do
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+        # Just verify the extension is properly integrated
+        # Detailed Katello behavior is tested in Katello's own tests
+        assert_nothing_raised do
+          Katello::RegistrationManager.unregister_host(@host, unregistering: true)
+        end
+      end
+    end
+
+    context 'URL generation' do
+      test 'host_by_id_url should return correct format' do
+        url = ForemanInventoryUpload.host_by_id_url('test-uuid-123')
+
+        assert_match %r{/hosts/test-uuid-123$}, url
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Cherrypick https://github.com/theforeman/foreman_rh_cloud/commit/f6422b481419f90aa1c86b0262557895f0bfcef0 and https://github.com/theforeman/foreman_rh_cloud/commit/b2abeddd090e528272499d6559fe244099948659 

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Update inventory and insights integration to improve host facet handling and HBI cleanup, while modernizing Dynflow-based job tests and bumping the plugin version to 12.2.13.

New Features:
- Invoke HBI host deletion when unregistering a host in IoP mode via a new RegistrationManager extension using the host UUID.

Enhancements:
- Add a ForemanInventoryUpload.host_by_id_url helper and use it when talking to the inventory service.
- Fix CreateMissingInsightsFacets to count created facets across batches correctly and adjust its logging verbosity.
- Wire ForemanRhCloud::RegistrationManagerExtensions into Katello::RegistrationManager so unregister flows integrate with HBI cleanup.

Tests:
- Refactor existing async job specs to use Dynflow::Testing factories/assertions instead of ForemanTasks.sync_task, including explicit handling of polling actions and action outputs.
- Add comprehensive tests for HostInventoryReportJob, SingleHostReportJob, GenerateReportJob, and GenerateHostReport covering planning, upload behavior, filters, labels, and error paths.
- Add tests around CreateMissingInsightsFacets behavior, including batch processing, logging, error handling, and correct facet creation/counting.
- Introduce tests for the new RegistrationManager extensions to validate HBI deletion behavior, error handling, and integration with Katello registration.