### PR TITLE
Release 13.0.9

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '13.0.8'.freeze
+  VERSION = '13.0.9'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "13.0.8",
+  "version": "13.0.9",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Bump the plugin and package versions to 13.0.9 for the new release.

Build:
- Update Ruby gem version constant to 13.0.9.
- Update npm package.json version to 13.0.9.