### PR TITLE
Fix IoP host UUID data consistency issues

### DIFF
--- a/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
+++ b/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
@@ -19,7 +19,7 @@ module ForemanRhCloud
     end
 
     def hbi_host_destroy(host)
-      uuid = host.insights_facet.uuid
+      uuid = host.insights_uuid
       logger.debug "Unregistering host #{uuid} from HBI"
       execute_cloud_request(
         organization: host.organization,

--- a/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
+++ b/app/controllers/concerns/foreman_rh_cloud/registration_manager_extensions.rb
@@ -13,7 +13,7 @@ module ForemanRhCloud
       host.reload
 
       # Only delete from HBI in IoP mode (hosted mode uses async job for cleanup)
-      hbi_host_destroy(host) if ForemanRhCloud.with_iop_smart_proxy? && !organization_destroy && host.insights_facet&.uuid&.presence
+      hbi_host_destroy(host) if ForemanRhCloud.with_iop_smart_proxy? && !organization_destroy && host.insights_uuid.presence
       host.insights&.destroy!
       super(host, options)
     end

--- a/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
@@ -21,6 +21,8 @@ module InsightsCloud
         @host.id
       )
 
+      @host.ensure_iop_insights_uuid
+
       # in IoP case, the hosts are identified by the sub-man ID, and we can assume they already
       # exist in the local inventory. This will also handle facet creation for new hosts.
       return if @host.insights

--- a/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
@@ -21,6 +21,7 @@ module InsightsCloud
         @host.id
       )
 
+      # Ensure insights UUID matches subscription UUID (only runs in IoP mode per method guard above)
       @host.ensure_iop_insights_uuid
 
       # in IoP case, the hosts are identified by the sub-man ID, and we can assume they already

--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -26,5 +26,19 @@ module RhCloudHost
     def insights_facet
       insights
     end
+
+    # In IoP, read directly from the subscription facet to avoid stale data (see comment on ensure_iop_insights_uuid)
+    def insights_uuid
+      ForemanRhCloud.with_iop_smart_proxy? ? subscription_facet&.uuid : insights_facet&.uuid
+    end
+
+    # In non-IoP, insights_facet uuids are assigned by Hosted.
+    # In IoP, insights_facet uuids must match Katello subscription_facet uuids.
+    # If the host was previously registered to hosted Insights,
+    # we need to correct its uuid.
+    def ensure_iop_insights_uuid
+      return unless insights_facet.present? && subscription_facet.present? && insights_facet.uuid != subscription_facet.uuid
+      insights_facet.update!(uuid: subscription_facet.uuid)
+    end
   end
 end

--- a/app/views/api/v2/advisor_engine/host_details.json.rabl
+++ b/app/views/api/v2/advisor_engine/host_details.json.rabl
@@ -1,9 +1,7 @@
 collection @hosts
 
 attributes :name
-node :insights_uuid do |host|
-  host.insights_facet&.uuid
-end
+node :insights_uuid, &:insights_uuid
 node :insights_hit_details do |host|
   host&.facts('insights::hit_details')&.values&.first
 end

--- a/app/views/api/v2/hosts/insights/base.rabl
+++ b/app/views/api/v2/hosts/insights/base.rabl
@@ -1,5 +1,6 @@
-attributes :uuid
-
+node :uuid do |facet|
+  facet&.host&.insights_uuid
+end
 node :insights_hit_details do |facet|
   facet&.host&.facts('insights::hit_details')&.values&.first
 end

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -118,6 +118,11 @@ module ForemanRhCloud
           end
         end
 
+        # Preload insights facet to avoid N+1 queries when rendering host list with facets
+        add_controller_action_scope('Api::V2::HostsController', :index) do |base_scope|
+          base_scope.preload(:insights)
+        end
+
         register_global_js_file 'global'
 
         register_custom_status InventorySync::InventoryStatus

--- a/lib/insights_cloud/async/connector_playbook_execution_reporter_task.rb
+++ b/lib/insights_cloud/async/connector_playbook_execution_reporter_task.rb
@@ -128,8 +128,8 @@ module InsightsCloud
         hosts_state = Hash[job_invocation.targeting.hosts.map do |host|
           next unless host.insights&.uuid
           [
-            host.insights.uuid,
-            task_status(job_invocation.sub_task_for_host(host), host.insights.uuid),
+            host.insights_uuid,
+            task_status(job_invocation.sub_task_for_host(host), host.insights_uuid),
           ]
         end.compact]
 

--- a/lib/insights_cloud/async/connector_playbook_execution_reporter_task.rb
+++ b/lib/insights_cloud/async/connector_playbook_execution_reporter_task.rb
@@ -126,7 +126,7 @@ module InsightsCloud
 
       def invocation_status
         hosts_state = Hash[job_invocation.targeting.hosts.map do |host|
-          next unless host.insights&.uuid
+          next unless host.insights_uuid
           [
             host.insights_uuid,
             task_status(job_invocation.sub_task_for_host(host), host.insights_uuid),

--- a/test/controllers/insights_cloud/api/advisor_engine_controller_test.rb
+++ b/test/controllers/insights_cloud/api/advisor_engine_controller_test.rb
@@ -13,7 +13,7 @@ module InsightsCloud
       end
 
       test 'shows hosts with uuids' do
-        uuids = [@host1.insights.uuid, @host2.insights.uuid]
+        uuids = [@host1.insights_uuid, @host2.insights_uuid]
         get :host_details, params: { organization_id: @test_org.id, host_uuids: uuids }
         assert_response :success
         assert_template 'api/v2/advisor_engine/host_details'

--- a/test/controllers/insights_cloud/api/advisor_engine_controller_test.rb
+++ b/test/controllers/insights_cloud/api/advisor_engine_controller_test.rb
@@ -36,7 +36,7 @@ module InsightsCloud
         # Query using the stale insights UUID
         get :host_details, params: {
           organization_id: @test_org.id,
-          host_uuids: [stale_insights_uuid]
+          host_uuids: [stale_insights_uuid],
         }
 
         assert_response :success

--- a/test/controllers/insights_cloud/api/advisor_engine_controller_test.rb
+++ b/test/controllers/insights_cloud/api/advisor_engine_controller_test.rb
@@ -21,6 +21,33 @@ module InsightsCloud
         refute_equal @test_org.hosts.count, assigns(:hosts).count
       end
 
+      test 'in IoP mode host_details uses subscription uuid when insights uuid is stale' do
+        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+        stale_insights_uuid = 'stale-insights-uuid-123'
+        subscription_uuid   = 'subscription-uuid-456'
+
+        # Create host with diverging facet UUIDs
+        host = FactoryBot.create(:host, :with_subscription, organization: @test_org)
+        host.subscription_facet.update!(uuid: subscription_uuid)
+        host.insights = FactoryBot.create(:insights_facet, host_id: host.id, uuid: stale_insights_uuid)
+        host.save!
+
+        # Query using the stale insights UUID
+        get :host_details, params: {
+          organization_id: @test_org.id,
+          host_uuids: [stale_insights_uuid]
+        }
+
+        assert_response :success
+        body = JSON.parse(response.body)
+
+        # Should return the subscription UUID, not the stale insights UUID
+        insights_uuids = body.map { |h| h['insights_uuid'] }
+        assert_includes insights_uuids, subscription_uuid, "Should use subscription UUID in IoP mode"
+        refute_includes insights_uuids, stale_insights_uuid, "Should not use stale insights UUID"
+      end
+
       test 'shows error when no hosts found' do
         get :host_details, params: { organization_id: @test_org.id, host_uuids: ['nonexistentuuid'] }
         assert_response :not_found

--- a/test/factories/insights_factories.rb
+++ b/test/factories/insights_factories.rb
@@ -58,5 +58,30 @@ FactoryBot.modify do
         host.insights = FactoryBot.create(:insights_facet, :with_hits, host_id: host.id)
       end
     end
+
+    trait :with_mismatched_insights_uuid do
+      # Simulates host previously registered to cloud with stale UUID
+      # Requires :with_subscription trait to be used together
+      after(:create) do |host, _evaluator|
+        host.insights = FactoryBot.create(
+          :insights_facet,
+          host_id: host.id,
+          uuid: 'stale-cloud-uuid' # Different from subscription_facet
+        )
+      end
+    end
+
+    trait :with_synced_insights_uuid do
+      # Ideal state: insights_facet UUID matches subscription_facet UUID
+      # Requires :with_subscription trait to be used together
+      after(:create) do |host, _evaluator|
+        subscription_uuid = host.subscription_facet&.uuid
+        host.insights = FactoryBot.create(
+          :insights_facet,
+          host_id: host.id,
+          uuid: subscription_uuid  # Same as subscription_facet
+        )
+      end
+    end
   end
 end

--- a/test/factories/insights_factories.rb
+++ b/test/factories/insights_factories.rb
@@ -63,6 +63,8 @@ FactoryBot.modify do
       # Simulates host previously registered to cloud with stale UUID
       # Requires :with_subscription trait to be used together
       after(:create) do |host, _evaluator|
+        raise "subscription_facet required for :with_mismatched_insights_uuid trait" unless host.subscription_facet&.uuid
+
         host.insights = FactoryBot.create(
           :insights_facet,
           host_id: host.id,
@@ -75,7 +77,9 @@ FactoryBot.modify do
       # Ideal state: insights_facet UUID matches subscription_facet UUID
       # Requires :with_subscription trait to be used together
       after(:create) do |host, _evaluator|
-        subscription_uuid = host.subscription_facet&.uuid
+        raise "subscription_facet required for :with_synced_insights_uuid trait" unless host.subscription_facet&.uuid
+
+        subscription_uuid = host.subscription_facet.uuid
         host.insights = FactoryBot.create(
           :insights_facet,
           host_id: host.id,

--- a/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
+++ b/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
@@ -15,7 +15,7 @@ module ForemanRhCloud
     end
 
     context 'unregister_host' do
-      test 'should call HBI delete in IoP mode when host has insights facet with UUID' do
+      test 'should call HBI delete in IoP mode when host has insights UUID' do
         ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
         expected_url = ForemanInventoryUpload.host_by_id_url(@host.subscription_facet.uuid)
 
@@ -43,44 +43,6 @@ module ForemanRhCloud
 
         # Verify insights_facet was still destroyed
         assert_nil InsightsFacet.find_by(id: @insights_facet.id)
-      end
-
-      test 'should NOT call HBI delete when host has no insights_facet' do
-        host_without_facet = FactoryBot.create(:host, :managed, organization: @org)
-        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
-
-        Katello::RegistrationManager.expects(:execute_cloud_request).never
-
-        assert_nothing_raised do
-          Katello::RegistrationManager.unregister_host(host_without_facet, unregistering: true)
-        end
-      end
-
-      test 'should NOT call HBI delete when host has insights_facet with empty UUID' do
-        host_with_empty_uuid_facet = FactoryBot.create(:host, :managed, organization: @org)
-        empty_uuid_facet = InsightsFacet.create!(host: host_with_empty_uuid_facet, uuid: '')
-        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
-
-        Katello::RegistrationManager.expects(:execute_cloud_request).never
-
-        assert_nothing_raised do
-          Katello::RegistrationManager.unregister_host(host_with_empty_uuid_facet, unregistering: true)
-        end
-
-        assert_nil InsightsFacet.find_by(id: empty_uuid_facet.id)
-      end
-
-      test 'should NOT call HBI delete when insights_facet has no UUID' do
-        facet_id = @insights_facet.id
-        @insights_facet.update(uuid: nil)
-        ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
-
-        Katello::RegistrationManager.expects(:execute_cloud_request).never
-
-        Katello::RegistrationManager.unregister_host(@host, unregistering: true)
-
-        # Verify facet was still destroyed
-        assert_nil InsightsFacet.find_by(id: facet_id)
       end
 
       test 'should always destroy insights_facet regardless of IoP mode' do

--- a/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
+++ b/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
@@ -4,8 +4,8 @@ module ForemanRhCloud
   class RegistrationManagerExtensionsTest < ActiveSupport::TestCase
     setup do
       @org = FactoryBot.create(:organization)
-      @host = FactoryBot.create(:host, :managed, organization: @org)
-      @insights_facet = ::InsightsFacet.create!(host: @host, uuid: 'test-uuid-123')
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      @insights_facet = ::InsightsFacet.create!(host: @host, uuid: @host.subscription_facet.uuid)
 
       # Stub Candlepin interaction (from Katello)
       ::Katello::Resources::Candlepin::Consumer.stubs(:destroy)
@@ -17,7 +17,7 @@ module ForemanRhCloud
     context 'unregister_host' do
       test 'should call HBI delete in IoP mode when host has insights facet with UUID' do
         ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
-        expected_url = ForemanInventoryUpload.host_by_id_url('test-uuid-123')
+        expected_url = ForemanInventoryUpload.host_by_id_url(@host.subscription_facet.uuid)
 
         # Expect the cloud request to be made
         Katello::RegistrationManager.expects(:execute_cloud_request).with do |params|

--- a/test/unit/rh_cloud_host_test.rb
+++ b/test/unit/rh_cloud_host_test.rb
@@ -1,0 +1,191 @@
+require 'test_plugin_helper'
+
+class RhCloudHostTest < ActiveSupport::TestCase
+  setup do
+    @org = FactoryBot.create(:organization)
+  end
+
+  teardown do
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+  end
+
+  context 'insights_uuid method' do
+    test 'returns insights_facet uuid in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: 'insights-123')
+
+      assert_equal 'insights-123', @host.insights_uuid
+      assert_not_equal @host.subscription_facet.uuid, @host.insights_uuid
+    end
+
+    test 'returns subscription_facet uuid in IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: 'insights-456')
+
+      assert_equal @host.subscription_facet.uuid, @host.insights_uuid
+      assert_not_equal 'insights-456', @host.insights_uuid
+    end
+
+    test 'returns nil when insights_facet missing in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      assert_nil @host.insights_uuid
+    end
+
+    test 'returns nil when subscription_facet missing in IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      @host = FactoryBot.create(:host, :managed, organization: @org)
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: 'insights-789')
+
+      assert_nil @host.insights_uuid
+    end
+
+    test 'returns nil when both facets missing' do
+      @host = FactoryBot.create(:host, :managed, organization: @org)
+
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      assert_nil @host.insights_uuid
+
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      assert_nil @host.insights_uuid
+    end
+
+    test 'never returns stale insights_facet uuid in IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      current_uuid = @host.subscription_facet.uuid
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: 'stale-456')
+
+      # Should return subscription_facet UUID, never the stale insights_facet UUID
+      assert_equal current_uuid, @host.insights_uuid
+      assert_not_equal 'stale-456', @host.insights_uuid
+
+      # Verify multiple calls always return subscription_facet UUID
+      3.times do
+        assert_equal current_uuid, @host.insights_uuid
+      end
+    end
+
+    test 'dynamically responds to IoP mode changes' do
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: 'insights-123')
+      subscription_uuid = @host.subscription_facet.uuid
+
+      # Non-IoP mode: should return insights_facet UUID
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      assert_equal 'insights-123', @host.insights_uuid
+
+      # IoP mode: should return subscription_facet UUID
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      assert_equal subscription_uuid, @host.insights_uuid
+
+      # Toggle back to non-IoP mode
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      assert_equal 'insights-123', @host.insights_uuid
+    end
+  end
+
+  context 'ensure_iop_insights_uuid method' do
+    test 'updates insights_facet uuid when different from subscription_facet' do
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      correct_uuid = @host.subscription_facet.uuid
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: 'wrong-456')
+
+      assert_equal 'wrong-456', @host.insights_facet.uuid
+
+      @host.ensure_iop_insights_uuid
+
+      assert_equal correct_uuid, @host.insights_facet.reload.uuid
+    end
+
+    test 'does nothing when uuids already match' do
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      matching_uuid = @host.subscription_facet.uuid
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: matching_uuid)
+
+      # Expect no update call since UUIDs already match
+      @host.insights_facet.expects(:update!).never
+
+      @host.ensure_iop_insights_uuid
+
+      assert_equal matching_uuid, @host.insights_facet.uuid
+    end
+
+    test 'does nothing when insights_facet missing' do
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      assert_nothing_raised do
+        @host.ensure_iop_insights_uuid
+      end
+    end
+
+    test 'does nothing when subscription_facet missing' do
+      @host = FactoryBot.create(:host, :managed, organization: @org)
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: 'insights-999')
+      original_uuid = @host.insights_facet.uuid
+
+      assert_nothing_raised do
+        @host.ensure_iop_insights_uuid
+      end
+
+      assert_equal original_uuid, @host.insights_facet.uuid
+    end
+
+    test 'does nothing when both facets missing' do
+      @host = FactoryBot.create(:host, :managed, organization: @org)
+
+      assert_nothing_raised do
+        @host.ensure_iop_insights_uuid
+      end
+    end
+
+    test 'handles nil uuids gracefully' do
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      # Scenario 1: subscription_facet uuid is nil (shouldn't happen but test gracefully)
+      @host.subscription_facet.update(uuid: nil)
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: 'some-uuid')
+
+      assert_nothing_raised do
+        @host.ensure_iop_insights_uuid
+      end
+
+      # Scenario 2: insights_facet uuid is nil
+      @host.subscription_facet.update(uuid: 'valid-uuid')
+      @host.insights_facet.update(uuid: nil)
+
+      assert_nothing_raised do
+        @host.ensure_iop_insights_uuid
+      end
+
+      # Should update to match subscription_facet
+      assert_equal 'valid-uuid', @host.insights_facet.reload.uuid
+    end
+
+    test 'corrects stale uuid after cloud registration' do
+      # Simulate a host that was previously registered to cloud with cloud-assigned UUID
+      @host = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      local_uuid = @host.subscription_facet.uuid
+      @host.insights = FactoryBot.create(:insights_facet, host_id: @host.id, uuid: 'cloud-456')
+
+      # Before sync: insights_facet has stale cloud UUID
+      assert_equal 'cloud-456', @host.insights_facet.uuid
+
+      # In IoP mode, insights_uuid should return subscription_facet UUID (not stale)
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      assert_equal local_uuid, @host.insights_uuid
+
+      # Call sync to correct the stale UUID
+      @host.ensure_iop_insights_uuid
+
+      # After sync: insights_facet UUID should match subscription_facet UUID
+      assert_equal local_uuid, @host.insights_facet.reload.uuid
+
+      # Verify insights_uuid still returns correct value
+      assert_equal local_uuid, @host.insights_uuid
+    end
+  end
+end


### PR DESCRIPTION
 # Fix IoP host UUID data consistency issues

  ## User Impact

  In IoP (Insights on Premise) mode, hosts that were previously registered to Red Hat Hybrid Cloud Console could display incorrect/stale UUIDs throughout the application. This caused:

  - **Data inconsistencies** when viewing host details and recommendations
  - **Incorrect identification** during host unregistration
  - **Mismatched records** between Foreman and the local Insights inventory

  This fix ensures IoP hosts always use their subscription manager UUID (the correct identifier for IoP environments) instead of stale cloud-assigned UUIDs. Hosts are automatically
  synchronized when they upload package profiles.

Note: This does _not_ remove the UUID field from insights facets, or allow nils there. The insights UUID is still kept in sync just as before, as a "just in case" kind of thing. But I've tried to move the actual _decision points_ to look at subscription facet. This gets us closer to a single source of truth.

  ## Technical Changes

  - Added `insights_uuid` method that returns the appropriate UUID based on operating mode:
    - **IoP mode**: Always uses subscription facet UUID (current/correct)
    - **Cloud mode**: Uses insights facet UUID (cloud-assigned)
  - Added `ensure_iop_insights_uuid` method to automatically sync mismatched UUIDs
  - Updated all call sites to use the new `insights_uuid` method
  - Comprehensive test coverage with 14 new test cases

  ## Testing steps

  1. Get an IoP host with recommendations
  2. Note that recommendations display BOTH on the Insights > Recommendations page, and on the host details > Recommendations tab
  3. In rails console, run
```
myhost.subscription_facet.uuid
myhost.insights_facet.uuid
```
Note that they are the same.
  5. In rails console, run
```
myhost.insights_facet.update(uuid: "foo")
```
Now, the uuids are different. This simulates a stale uuid from a host previously registered to Hosted insights.

6. Refresh

#### Before checking out the PR:
Note that recommendations still display in Insights > Recommendations, and show the affected host. BUT they do NOT show up on the host details > Recommendations tab.
You may notice a failed API request to "foo" on the browser Network tab

#### After checking out the PR:
Recommendations will display on BOTH pages
No failed API requests
