### PR TITLE
SAT-38427 - Implement CSV exports on the hosts overview

### DIFF
--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -142,7 +142,7 @@ module ForemanRhCloud
         extend_page 'hosts/_list' do |context|
           context.with_profile :cloud, _('RH Cloud'), default: true do
             add_pagelet :hosts_table_column_header, key: :insights_recommendations_count, label: _('Recommendations'), sortable: true, width: '12%', class: 'hidden-xs ellipsis', priority: 100,
-                        export_data: CsvExporter::ExportDefinition.new(:insights_recommendations_count, callback: ->(host) { host&.insights_hits&.count })
+                        export_data: CsvExporter::ExportDefinition.new(:insights_recommendations_count, label: _('Recommendations'), callback: ->(host) { ForemanRhCloud.with_iop_smart_proxy? ? 'N/A' : host&.insights_hits&.count })
             add_pagelet :hosts_table_column_content, key: :insights_recommendations_count, callback: ->(host) { hits_counts_cell(host) }, class: 'hidden-xs ellipsis text-center', priority: 100
           end
         end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add missing Manage columns to pagelet for CSV export.

Requires https://github.com/theforeman/foreman/pull/10793

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Add CSV export support for RH Cloud host overview columns related to insights recommendations and CVE counts.

New Features:
- Enable CSV export for the insights recommendations count column on the RH Cloud hosts overview.
- Expose total CVEs as a new column on the RH Cloud hosts overview with CSV export support.