### PR TITLE
Fix broken cloud connector docs link

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/__tests__/__snapshots__/PageTitle.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/__tests__/__snapshots__/PageTitle.test.js.snap
@@ -32,7 +32,7 @@ exports[`PageTitle rendering render without Props 1`] = `
             Actions history
           </DropdownItem>,
           <DropdownItem
-            href="/links/manual/?root_url=https%3A%2F%2Faccess.redhat.com%2Fdocumentation%2Fen-us%2Fred_hat_insights%2F2023%2Fhtml%2Fred_hat_insights_remediations_guide%2Fhost-communication-with-insights_red-hat-insights-remediation-guide%23uploading-satellite-host-inventory-to-insights_configuring-satellite-cloud-connector"
+            href="/links/manual/?root_url=https%3A%2F%2Fdocs.redhat.com%2Fen%2Fdocumentation%2Fred_hat_lightspeed%2F1-latest%2Fhtml-single%2Fred_hat_lightspeed_remediations_guide%2Findex"
             ouiaId="inventory-documentation-button"
             rel="noopener noreferrer"
             target="_blank"

--- a/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
+++ b/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
@@ -7,7 +7,7 @@ export const inventoryUrl = path =>
 export const getInventoryDocsUrl = () =>
   foremanUrl(
     `/links/manual/?root_url=${URI.encode(
-      'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/red_hat_insights_remediations_guide/host-communication-with-insights_red-hat-insights-remediation-guide#uploading-satellite-host-inventory-to-insights_configuring-satellite-cloud-connector'
+      'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html-single/red_hat_lightspeed_remediations_guide/index'
     )}`
   );
 

--- a/webpack/ForemanInventoryUpload/__tests__/__snapshots__/ForemanInventoryHelpers.test.js.snap
+++ b/webpack/ForemanInventoryUpload/__tests__/__snapshots__/ForemanInventoryHelpers.test.js.snap
@@ -2,4 +2,4 @@
 
 exports[`ForemanInventoryUpload helpers should return inventory Url 1`] = `"/foreman_inventory_upload/test_path"`;
 
-exports[`ForemanInventoryUpload helpers should return inventory docs url 1`] = `"/links/manual/?root_url=https%3A%2F%2Faccess.redhat.com%2Fdocumentation%2Fen-us%2Fred_hat_insights%2F2023%2Fhtml%2Fred_hat_insights_remediations_guide%2Fhost-communication-with-insights_red-hat-insights-remediation-guide%23uploading-satellite-host-inventory-to-insights_configuring-satellite-cloud-connector"`;
+exports[`ForemanInventoryUpload helpers should return inventory docs url 1`] = `"/links/manual/?root_url=https%3A%2F%2Fdocs.redhat.com%2Fen%2Fdocumentation%2Fred_hat_lightspeed%2F1-latest%2Fhtml-single%2Fred_hat_lightspeed_remediations_guide%2Findex"`;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Changing the link from https://docs.redhat.com/en/documentation/red_hat_insights/2023/html/red_hat_insights_remediations_guide/host-communication-with-insights_red-hat-insights-remediation-guide#uploading-satellite-host-inventory-to-insights_configuring-satellite-cloud-connector 
  * to https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html-single/red_hat_lightspeed_remediations_guide/index
* Updated the JS snapshots for the page as well

#### What are the testing steps for this pull request?
* Head to Insights -> Inventory Upload
* Click the Kebab at the top right and select documentation and see that it takes you to a 404
* Check out PR
* Try it again and see if it works

## Summary by Sourcery

Update the inventory upload documentation link to point to the current Red Hat Lightspeed remediation guide and refresh related UI test snapshots.

Documentation:
- Update the Inventory Upload documentation link to the new Red Hat Lightspeed remediation guide URL.

Tests:
- Regenerate Jest snapshots for the inventory upload page header and helper utilities to reflect the new documentation link.