### PR TITLE
Implement permission-scoped forwarding for Insights API requests

### DIFF
--- a/app/services/foreman_rh_cloud/insights_api_forwarder.rb
+++ b/app/services/foreman_rh_cloud/insights_api_forwarder.rb
@@ -32,47 +32,62 @@ module ForemanRhCloud
           'GET' => :view_vulnerability,
         },
       },
-      # Vulnerability CVEs list - POST requires view_vulnerability (for filtering)
+      # Vulnerability CVEs list - POST requires view_vulnerability (no tags support per OpenAPI spec)
       {
         test: %r{api/vulnerability/v1/vulnerabilities/cves},
-        tag_name: :tags,
         permissions: {
           'POST' => :view_vulnerability,
         },
       },
       # Vulnerability status - PATCH requires edit_vulnerability
+      # Note: GET /status does not support tags parameter per OpenAPI spec
       {
         test: %r{api/vulnerability/v1/status},
-        tag_name: :tags,
         permissions: {
           'PATCH' => :edit_vulnerability,
         },
       },
-      # CVE status - PATCH requires edit_vulnerability
+      # CVE status - PATCH requires edit_vulnerability (no GET endpoint)
       {
         test: %r{api/vulnerability/v1/cves/status},
-        tag_name: :tags,
         permissions: {
           'PATCH' => :edit_vulnerability,
         },
       },
-      # CVE business risk - PATCH requires edit_vulnerability
+      # CVE business risk - PATCH requires edit_vulnerability (no GET endpoint)
       {
         test: %r{api/vulnerability/v1/cves/business_risk},
-        tag_name: :tags,
         permissions: {
           'PATCH' => :edit_vulnerability,
         },
       },
-      # Systems opt out - PATCH requires edit_vulnerability
+      # Systems opt out - PATCH requires edit_vulnerability (no GET endpoint)
       {
         test: %r{api/vulnerability/v1/systems/opt_out},
-        tag_name: :tags,
         permissions: {
           'PATCH' => :edit_vulnerability,
         },
       },
-      # Other vulnerability endpoints - GET requires view_vulnerability
+      # Endpoints without tags support (per OpenAPI spec) - still require view_vulnerability for GET
+      {
+        test: %r{api/vulnerability/v1/(apistatus|version|business_risk|announcement)$},
+        permissions: {
+          'GET' => :view_vulnerability,
+        },
+      },
+      {
+        test: %r{api/vulnerability/v1/cves/[^/]+$},
+        permissions: {
+          'GET' => :view_vulnerability,
+        },
+      },
+      {
+        test: %r{api/vulnerability/v1/(playbooks|report)/},
+        permissions: {
+          'GET' => :view_vulnerability,
+        },
+      },
+      # Other vulnerability endpoints - GET requires view_vulnerability (with tags support)
       {
         test: %r{api/vulnerability/v1/.*},
         tag_name: :tags,
@@ -229,38 +244,26 @@ module ForemanRhCloud
       Foreman::Logging.logger('app')
     end
 
-    # Returns the required permission for the given path and HTTP method.
-    #
-    # == Pattern Resolution
-    #
-    # When multiple patterns in SCOPED_REQUESTS match the path, this method selects
-    # the most specific pattern using regex source length as a proxy for specificity.
-    # Longer regex sources generally indicate more specific patterns (e.g.,
-    # `api/vulnerability/v1/cves/status` is more specific than `api/vulnerability/v1/.*`).
-    #
-    # Only patterns that define `:permissions` participate in resolution. Patterns
-    # without `:permissions` (tagging-only entries like `api/inventory/.*`) are excluded
-    # to prevent them from overriding permission-enforcing patterns for the same path.
-    #
-    # If you add new patterns with similar specificity, consider using more explicit
-    # path segments or a priority field to ensure deterministic resolution.
-    #
+    # Returns the required permission for the given path and HTTP method
+    # Resolves overlapping patterns by choosing the most specific matcher,
+    # defined as the one with the longest regex source that matches the path.
+    # This avoids permission changes caused by reordering SCOPED_REQUESTS.
     # @param path [String] The request path
     # @param http_method [String] The HTTP method (GET, POST, etc.)
     # @return [Symbol, nil] The required permission symbol or nil if no permission required
     def required_permission_for(path, http_method)
-      # Only consider patterns that define permissions - this ensures tagging-only
-      # patterns cannot override permission-enforcing patterns for the same path
-      matching_patterns = SCOPED_REQUESTS.select do |pattern|
-        pattern[:permissions] && pattern[:test].match?(path)
-      end
+      # Collect all matching patterns
+      matching_patterns = SCOPED_REQUESTS.select { |pattern| pattern[:test].match?(path) }
       return nil if matching_patterns.empty?
 
       # Choose the most specific pattern: longest regex source wins.
       # This makes overlapping patterns deterministic and independent of array order.
       request_pattern = matching_patterns.max_by { |pattern| pattern[:test].source.length }
 
-      request_pattern[:permissions][http_method]
+      permissions = request_pattern[:permissions]
+      return nil unless permissions
+
+      permissions[http_method]
     end
   end
 end

--- a/app/services/foreman_rh_cloud/insights_api_forwarder.rb
+++ b/app/services/foreman_rh_cloud/insights_api_forwarder.rb
@@ -4,17 +4,129 @@ module ForemanRhCloud
   class InsightsApiForwarder
     include ForemanRhCloud::CertAuth
 
+    # Permission mapping for API paths:
+    #
+    # Foreman Permission   | Paths
+    # ---------------------|--------------------------------------------------
+    # view_vulnerability   | GET /api/inventory/v1/hosts(/*)
+    # view_vulnerability   | GET /api/vulnerability/v1/*
+    #                      | POST /api/vulnerability/v1/vulnerabilities/cves
+    # edit_vulnerability   | PATCH /api/vulnerability/v1/status
+    # edit_vulnerability   | PATCH /api/vulnerability/v1/cves/status
+    #                      | PATCH /api/vulnerability/v1/cves/business_risk
+    # edit_vulnerability   | PATCH /api/vulnerability/v1/systems/opt_out
+    #
+    # view_advisor         | GET /api/insights/v1/*
+    # edit_advisor         | POST /api/insights/v1/ack/
+    #                      | DELETE /api/insights/v1/ack/{rule_id}/
+    #                      | POST /api/insights/v1/hostack/
+    #                      | DELETE /api/insights/v1/hostack/{id}/
+    #                      | POST /api/insights/v1/rule/{rule_id}/unack_hosts/
+    #
     SCOPED_REQUESTS = [
-      { test: %r{api/vulnerability/v1/vulnerabilities/cves}, tag_name: :tags },
-      { test: %r{api/vulnerability/v1/dashbar}, tag_name: :tags },
-      { test: %r{api/vulnerability/v1/cves/[^/]+/affected_systems}, tag_name: :tags },
-      { test: %r{api/vulnerability/v1/systems/[^/]+/cves}, tag_name: :tags },
-      { test: %r{api/insights/.*}, tag_name: :tags },
+      # Inventory hosts - requires view_vulnerability for GET
+      {
+        test: %r{api/inventory/v1/hosts(/.*)?$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_vulnerability,
+        },
+      },
+      # Vulnerability CVEs list - POST requires view_vulnerability (for filtering)
+      {
+        test: %r{api/vulnerability/v1/vulnerabilities/cves},
+        tag_name: :tags,
+        permissions: {
+          'POST' => :view_vulnerability,
+        },
+      },
+      # Vulnerability status - PATCH requires edit_vulnerability
+      {
+        test: %r{api/vulnerability/v1/status},
+        tag_name: :tags,
+        permissions: {
+          'PATCH' => :edit_vulnerability,
+        },
+      },
+      # CVE status - PATCH requires edit_vulnerability
+      {
+        test: %r{api/vulnerability/v1/cves/status},
+        tag_name: :tags,
+        permissions: {
+          'PATCH' => :edit_vulnerability,
+        },
+      },
+      # CVE business risk - PATCH requires edit_vulnerability
+      {
+        test: %r{api/vulnerability/v1/cves/business_risk},
+        tag_name: :tags,
+        permissions: {
+          'PATCH' => :edit_vulnerability,
+        },
+      },
+      # Systems opt out - PATCH requires edit_vulnerability
+      {
+        test: %r{api/vulnerability/v1/systems/opt_out},
+        tag_name: :tags,
+        permissions: {
+          'PATCH' => :edit_vulnerability,
+        },
+      },
+      # Other vulnerability endpoints - GET requires view_vulnerability
+      {
+        test: %r{api/vulnerability/v1/.*},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_vulnerability,
+        },
+      },
+      # Advisor ack endpoints - POST/DELETE require edit_advisor
+      {
+        test: %r{api/insights/v1/ack(/[^/]*)?$},
+        tag_name: :tags,
+        permissions: {
+          'POST' => :edit_advisor,
+          'DELETE' => :edit_advisor,
+        },
+      },
+      # Advisor hostack endpoints - POST/DELETE require edit_advisor
+      {
+        test: %r{api/insights/v1/hostack(/[^/]*)?$},
+        tag_name: :tags,
+        permissions: {
+          'POST' => :edit_advisor,
+          'DELETE' => :edit_advisor,
+        },
+      },
+      # Advisor rule unack_hosts - POST requires edit_advisor
+      {
+        test: %r{api/insights/v1/rule/[^/]+/unack_hosts},
+        tag_name: :tags,
+        permissions: {
+          'POST' => :edit_advisor,
+        },
+      },
+      # Other Advisor/Insights endpoints - GET requires view_advisor
+      {
+        test: %r{api/insights/v1/.*},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_advisor,
+        },
+      },
+      # Other API endpoints (tagging only, no permission enforcement)
       { test: %r{api/inventory/.*}, tag_name: :tags },
       { test: %r{api/tasks/.*}, tag_name: :tags },
     ].freeze
 
     def forward_request(original_request, path, controller_name, user, organization, location)
+      # Check permissions before forwarding
+      permission = required_permission_for(path, original_request.request_method)
+      if permission && !user&.can?(permission)
+        logger.warn("User #{user&.login || 'anonymous'} lacks permission #{permission} for #{original_request.request_method} #{path}")
+        raise ::Foreman::PermissionMissingException.new(N_("You do not have permission to perform this action"))
+      end
+
       TagsAuth.new(user, organization, location, logger).update_tag if scope_request?(original_request, path)
 
       forward_params = prepare_forward_params(original_request, path, user: user, organization: organization, location: location).to_a
@@ -115,6 +227,40 @@ module ForemanRhCloud
 
     def logger
       Foreman::Logging.logger('app')
+    end
+
+    # Returns the required permission for the given path and HTTP method.
+    #
+    # == Pattern Resolution
+    #
+    # When multiple patterns in SCOPED_REQUESTS match the path, this method selects
+    # the most specific pattern using regex source length as a proxy for specificity.
+    # Longer regex sources generally indicate more specific patterns (e.g.,
+    # `api/vulnerability/v1/cves/status` is more specific than `api/vulnerability/v1/.*`).
+    #
+    # Only patterns that define `:permissions` participate in resolution. Patterns
+    # without `:permissions` (tagging-only entries like `api/inventory/.*`) are excluded
+    # to prevent them from overriding permission-enforcing patterns for the same path.
+    #
+    # If you add new patterns with similar specificity, consider using more explicit
+    # path segments or a priority field to ensure deterministic resolution.
+    #
+    # @param path [String] The request path
+    # @param http_method [String] The HTTP method (GET, POST, etc.)
+    # @return [Symbol, nil] The required permission symbol or nil if no permission required
+    def required_permission_for(path, http_method)
+      # Only consider patterns that define permissions - this ensures tagging-only
+      # patterns cannot override permission-enforcing patterns for the same path
+      matching_patterns = SCOPED_REQUESTS.select do |pattern|
+        pattern[:permissions] && pattern[:test].match?(path)
+      end
+      return nil if matching_patterns.empty?
+
+      # Choose the most specific pattern: longest regex source wins.
+      # This makes overlapping patterns deterministic and independent of array order.
+      request_pattern = matching_patterns.max_by { |pattern| pattern[:test].source.length }
+
+      request_pattern[:permissions][http_method]
     end
   end
 end

--- a/app/services/foreman_rh_cloud/insights_api_forwarder.rb
+++ b/app/services/foreman_rh_cloud/insights_api_forwarder.rb
@@ -224,8 +224,15 @@ module ForemanRhCloud
     def scope_request?(original_request, path)
       return nil unless original_request.get?
 
-      request_pattern = SCOPED_REQUESTS.find { |pattern| pattern[:test].match?(path) }
-      request_pattern[:tag_name] if request_pattern
+      # Only consider patterns that define tag_name - this ensures patterns without
+      # tag_name (permission-only entries) cannot override tag-supporting patterns
+      matching_patterns = SCOPED_REQUESTS.select { |pattern| pattern[:tag_name] && pattern[:test].match?(path) }
+      return nil if matching_patterns.empty?
+
+      # Choose the most specific pattern by regex source length for consistency
+      # with required_permission_for behavior
+      request_pattern = matching_patterns.max_by { |pattern| pattern[:test].source.length }
+      request_pattern[:tag_name]
     end
 
     def core_app_name

--- a/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
@@ -18,17 +18,9 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'should scope GET requests with proper tags' do
-    user_agent = { :foo => :bar }
-    params = {}
+    req = build_request(method: 'GET', uri: '/api/vulnerability/v1/cves/abc-123/affected_systems')
 
-    req = ActionDispatch::Request.new(
-      'REQUEST_URI' => '/api/vulnerability/v1/cves/abc-123/affected_systems',
-      'REQUEST_METHOD' => 'GET',
-      'HTTP_USER_AGENT' => user_agent,
-      'rack.input' => ::Puma::NullIO.new,
-      'action_dispatch.request.query_parameters' => params
-    )
-
+    @user.stubs(:can?).with(:view_vulnerability).returns(true)
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
       actual = actual_params[:headers][:params]
@@ -37,22 +29,10 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     end
 
     @forwarder.forward_request(req, '/api/vulnerability/v1/cves/abc-123/affected_systems', 'test_controller', @user, @organization, @location)
-
-    # This test asserts the parameters that are sent to the execute_cloud_request method.
-    # This is done by setting the expectation before the actual call.
   end
 
   test 'should not scope GET requests for unknown uris' do
-    user_agent = { :foo => :bar }
-    params = {}
-
-    req = ActionDispatch::Request.new(
-      'REQUEST_URI' => '/api/vulnerability/foo/bar',
-      'REQUEST_METHOD' => 'GET',
-      'HTTP_USER_AGENT' => user_agent,
-      'rack.input' => ::Puma::NullIO.new,
-      'action_dispatch.request.query_parameters' => params
-    )
+    req = build_request(method: 'GET', uri: '/api/vulnerability/foo/bar')
 
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
@@ -62,23 +42,12 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     end
 
     @forwarder.forward_request(req, '/api/vulnerability/foo/bar', 'test_controller', @user, @organization, @location)
-
-    # This test asserts the parameters that are sent to the execute_cloud_request method.
-    # This is done by setting the expectation before the actual call.
   end
 
   test 'should merge URI params in GET requests' do
-    user_agent = { :foo => :bar }
-    params = { :page => 5, :per_page => 42 }
+    req = build_request(method: 'GET', uri: '/api/vulnerability/v1/cves/abc-123/affected_systems', params: { page: 5, per_page: 42 })
 
-    req = ActionDispatch::Request.new(
-      'REQUEST_URI' => '/api/vulnerability/v1/cves/abc-123/affected_systems',
-      'REQUEST_METHOD' => 'GET',
-      'HTTP_USER_AGENT' => user_agent,
-      'rack.input' => ::Puma::NullIO.new,
-      'action_dispatch.request.query_parameters' => params
-    )
-
+    @user.stubs(:can?).with(:view_vulnerability).returns(true)
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
       actual = actual_params[:headers][:params]
@@ -89,18 +58,10 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     end
 
     @forwarder.forward_request(req, '/api/vulnerability/v1/cves/abc-123/affected_systems', 'test_controller', @user, @organization, @location)
-    # This test asserts the parameters that are sent to the execute_cloud_request method.
-    # This is done by setting the expectation before the actual call.
   end
 
   test 'should not scope POST requests' do
-    post_data = 'Random POST data'
-    req = ActionDispatch::Request.new(
-      'REQUEST_URI' => '/foo/bar',
-      'REQUEST_METHOD' => 'POST',
-      'rack.input' => ::Puma::NullIO.new,
-      'RAW_POST_DATA' => post_data
-    )
+    req = build_request(method: 'POST', uri: '/foo/bar', data: 'Random POST data')
 
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
@@ -110,19 +71,10 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     end
 
     @forwarder.forward_request(req, '/api/vulnerability/v1/cves', 'test_controller', @user, @organization, @location)
-
-    # This test asserts the parameters that are sent to the execute_cloud_request method.
-    # This is done by setting the expectation before the actual call.
   end
 
   test 'should not scope PUT requests' do
-    put_data = 'Random PUT data'
-    req = ActionDispatch::Request.new(
-      'REQUEST_URI' => '/foo/bar',
-      'REQUEST_METHOD' => 'PUT',
-      'rack.input' => ::Puma::NullIO.new,
-      'RAW_POST_DATA' => put_data
-    )
+    req = build_request(method: 'PUT', uri: '/foo/bar', data: 'Random PUT data')
 
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
@@ -132,20 +84,10 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     end
 
     @forwarder.forward_request(req, '/api/vulnerability/v1/cves', 'test_controller', @user, @organization, @location)
-
-    # This test asserts the parameters that are sent to the execute_cloud_request method.
-    # This is done by setting the expectation before the actual call.
   end
 
   test 'should not scope PATCH requests' do
-    post_data = 'Random PATCH data'
-    req = ActionDispatch::Request.new(
-      'REQUEST_URI' => '/foo/bar',
-      'REQUEST_METHOD' => 'PATCH',
-      'rack.input' => ::Puma::NullIO.new,
-      'RAW_POST_DATA' => post_data,
-      "action_dispatch.request.path_parameters" => { :format => "json" }
-    )
+    req = build_request(method: 'PATCH', uri: '/foo/bar', data: 'Random PATCH data')
 
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
@@ -155,41 +97,26 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     end
 
     @forwarder.forward_request(req, '/api/vulnerability/v1/cves', 'test_controller', @user, @organization, @location)
-
-    # This test asserts the parameters that are sent to the execute_cloud_request method.
-    # This is done by setting the expectation before the actual call.
   end
 
   test 'scope_request? should return tag_name for scoped requests' do
-    get_req = ActionDispatch::Request.new(
-      'REQUEST_URI' => '/api/vulnerability/v1/vulnerabilities/cves',
-      'REQUEST_METHOD' => 'GET',
-      'rack.input' => ::Puma::NullIO.new
-    )
+    req = build_request(method: 'GET', uri: '/api/vulnerability/v1/vulnerabilities/cves')
 
-    result = @forwarder.send(:scope_request?, get_req, 'api/vulnerability/v1/vulnerabilities/cves')
+    result = @forwarder.send(:scope_request?, req, 'api/vulnerability/v1/vulnerabilities/cves')
     assert_equal :tags, result
   end
 
   test 'scope_request? should return nil for non-GET requests' do
-    post_req = ActionDispatch::Request.new(
-      'REQUEST_URI' => '/api/vulnerability/v1/cves',
-      'REQUEST_METHOD' => 'POST',
-      'rack.input' => ::Puma::NullIO.new
-    )
+    req = build_request(method: 'POST', uri: '/api/vulnerability/v1/cves')
 
-    result = @forwarder.send(:scope_request?, post_req, '/api/vulnerability/v1/cves')
+    result = @forwarder.send(:scope_request?, req, '/api/vulnerability/v1/cves')
     assert_nil result
   end
 
   test 'scope_request? should return nil for unmatched paths' do
-    get_req = ActionDispatch::Request.new(
-      'REQUEST_URI' => '/api/unmatched/path',
-      'REQUEST_METHOD' => 'GET',
-      'rack.input' => ::Puma::NullIO.new
-    )
+    req = build_request(method: 'GET', uri: '/api/unmatched/path')
 
-    result = @forwarder.send(:scope_request?, get_req, '/api/unmatched/path')
+    result = @forwarder.send(:scope_request?, req, '/api/unmatched/path')
     assert_nil result
   end
 
@@ -213,5 +140,242 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
 
     tag_string = CGI.unescape(param_value)
     tag_string.split('=')[0]
+  end
+
+  # Helper to build test requests with minimal boilerplate
+  def build_request(method:, uri:, params: {}, data: nil)
+    env = {
+      'REQUEST_URI' => uri,
+      'REQUEST_METHOD' => method,
+      'rack.input' => ::Puma::NullIO.new,
+      'action_dispatch.request.query_parameters' => params,
+    }
+    env['RAW_POST_DATA'] = data if data
+    env['action_dispatch.request.path_parameters'] = { format: 'json' } if method == 'PATCH'
+    ActionDispatch::Request.new(env)
+  end
+
+  # Permission enforcement tests
+
+  # GET /api/inventory/v1/hosts requires view_vulnerability
+  test 'should allow GET request to inventory hosts when user has view_vulnerability permission' do
+    req = build_request(method: 'GET', uri: '/api/inventory/v1/hosts')
+
+    @user.stubs(:can?).with(:view_vulnerability).returns(true)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/inventory/v1/hosts', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny GET request to inventory hosts when user lacks view_vulnerability permission' do
+    req = build_request(method: 'GET', uri: '/api/inventory/v1/hosts')
+
+    @user.stubs(:can?).with(:view_vulnerability).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/inventory/v1/hosts', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  # POST /api/vulnerability/v1/vulnerabilities/cves requires view_vulnerability
+  test 'should deny POST request to vulnerabilities cves when user lacks view_vulnerability permission' do
+    req = build_request(method: 'POST', uri: '/api/vulnerability/v1/vulnerabilities/cves', data: '{"test": "data"}')
+
+    @user.stubs(:can?).with(:view_vulnerability).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/vulnerability/v1/vulnerabilities/cves', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  # PATCH /api/vulnerability/v1/status requires edit_vulnerability
+  test 'should allow PATCH request to vulnerability status when user has edit_vulnerability permission' do
+    req = build_request(method: 'PATCH', uri: '/api/vulnerability/v1/status', data: '{"status": "resolved"}')
+
+    @user.stubs(:can?).with(:edit_vulnerability).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/vulnerability/v1/status', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny PATCH request to vulnerability status when user lacks edit_vulnerability permission' do
+    req = build_request(method: 'PATCH', uri: '/api/vulnerability/v1/status', data: '{"status": "resolved"}')
+
+    @user.stubs(:can?).with(:edit_vulnerability).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/vulnerability/v1/status', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  # Data-driven tests for required_permission_for
+  PERMISSION_MAPPINGS = [
+    # Vulnerability endpoints
+    { path: 'api/inventory/v1/hosts', method: 'GET', expected: :view_vulnerability },
+    { path: 'api/inventory/v1/hosts/abc-123', method: 'GET', expected: :view_vulnerability },
+    { path: 'api/vulnerability/v1/vulnerabilities/cves', method: 'POST', expected: :view_vulnerability },
+    { path: 'api/vulnerability/v1/status', method: 'PATCH', expected: :edit_vulnerability },
+    { path: 'api/vulnerability/v1/cves/status', method: 'PATCH', expected: :edit_vulnerability },
+    { path: 'api/vulnerability/v1/cves/business_risk', method: 'PATCH', expected: :edit_vulnerability },
+    { path: 'api/vulnerability/v1/systems/opt_out', method: 'PATCH', expected: :edit_vulnerability },
+    { path: 'api/vulnerability/v1/dashbar', method: 'GET', expected: :view_vulnerability },
+    { path: 'api/vulnerability/v1/cves/CVE-2024-1234/affected_systems', method: 'GET', expected: :view_vulnerability },
+    # Advisor endpoints
+    { path: 'api/insights/v1/stats/systems', method: 'GET', expected: :view_advisor },
+    { path: 'api/insights/v1/ack/', method: 'POST', expected: :edit_advisor },
+    { path: 'api/insights/v1/ack/rule_id', method: 'DELETE', expected: :edit_advisor },
+    { path: 'api/insights/v1/hostack/', method: 'POST', expected: :edit_advisor },
+    { path: 'api/insights/v1/hostack/123', method: 'DELETE', expected: :edit_advisor },
+    { path: 'api/insights/v1/rule/test_rule/unack_hosts', method: 'POST', expected: :edit_advisor },
+    # Unknown endpoints
+    { path: 'api/unknown/endpoint', method: 'GET', expected: nil },
+  ].freeze
+
+  PERMISSION_MAPPINGS.each do |mapping|
+    test "required_permission_for returns #{mapping[:expected].inspect} for #{mapping[:method]} #{mapping[:path]}" do
+      permission = @forwarder.send(:required_permission_for, mapping[:path], mapping[:method])
+      assert_equal mapping[:expected], permission
+    end
+  end
+
+  # Advisor permission integration tests
+  test 'should allow GET request to insights endpoint when user has view_advisor permission' do
+    req = build_request(method: 'GET', uri: '/api/insights/v1/stats/systems')
+
+    @user.stubs(:can?).with(:view_advisor).returns(true)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/insights/v1/stats/systems', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny GET request to insights endpoint when user lacks view_advisor permission' do
+    req = build_request(method: 'GET', uri: '/api/insights/v1/stats/systems')
+
+    @user.stubs(:can?).with(:view_advisor).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/insights/v1/stats/systems', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  test 'should allow POST request to insights ack when user has edit_advisor permission' do
+    req = build_request(method: 'POST', uri: '/api/insights/v1/ack/', data: '{"rule_id": "test|RULE"}')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/insights/v1/ack/', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny POST request to insights ack when user lacks edit_advisor permission' do
+    req = build_request(method: 'POST', uri: '/api/insights/v1/ack/', data: '{"rule_id": "test|RULE"}')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/insights/v1/ack/', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  # DELETE /api/insights/v1/ack/{rule_id} requires edit_advisor
+  test 'should allow DELETE request to insights ack when user has edit_advisor permission' do
+    req = build_request(method: 'DELETE', uri: '/api/insights/v1/ack/test-rule-id')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/insights/v1/ack/test-rule-id', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny DELETE request to insights ack when user lacks edit_advisor permission' do
+    req = build_request(method: 'DELETE', uri: '/api/insights/v1/ack/test-rule-id')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/insights/v1/ack/test-rule-id', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  # POST /api/insights/v1/hostack/ requires edit_advisor
+  test 'should allow POST request to insights hostack when user has edit_advisor permission' do
+    req = build_request(method: 'POST', uri: '/api/insights/v1/hostack/', data: '{"host_id": "123"}')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/insights/v1/hostack/', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny POST request to insights hostack when user lacks edit_advisor permission' do
+    req = build_request(method: 'POST', uri: '/api/insights/v1/hostack/', data: '{"host_id": "123"}')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/insights/v1/hostack/', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  # DELETE /api/insights/v1/hostack/{id} requires edit_advisor
+  test 'should allow DELETE request to insights hostack when user has edit_advisor permission' do
+    req = build_request(method: 'DELETE', uri: '/api/insights/v1/hostack/123')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/insights/v1/hostack/123', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny DELETE request to insights hostack when user lacks edit_advisor permission' do
+    req = build_request(method: 'DELETE', uri: '/api/insights/v1/hostack/123')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/insights/v1/hostack/123', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  # POST /api/insights/v1/rule/{rule_id}/unack_hosts requires edit_advisor
+  test 'should allow POST request to insights unack_hosts when user has edit_advisor permission' do
+    req = build_request(method: 'POST', uri: '/api/insights/v1/rule/test-rule-id/unack_hosts', data: '{"host_ids": ["123"]}')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/insights/v1/rule/test-rule-id/unack_hosts', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny POST request to insights unack_hosts when user lacks edit_advisor permission' do
+    req = build_request(method: 'POST', uri: '/api/insights/v1/rule/test-rule-id/unack_hosts', data: '{"host_ids": ["123"]}')
+
+    @user.stubs(:can?).with(:edit_advisor).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/insights/v1/rule/test-rule-id/unack_hosts', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  # Edge case: anonymous user
+  test 'should deny request when user is nil' do
+    req = build_request(method: 'GET', uri: '/api/insights/v1/stats/systems')
+
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/insights/v1/stats/systems', 'test_controller', nil, @organization, @location)
+    end
   end
 end

--- a/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
@@ -18,7 +18,16 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'should scope GET requests with proper tags' do
-    req = build_request(method: 'GET', uri: '/api/vulnerability/v1/cves/abc-123/affected_systems')
+    user_agent = { :foo => :bar }
+    params = {}
+
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/v1/cves/abc-123/affected_systems',
+      'REQUEST_METHOD' => 'GET',
+      'HTTP_USER_AGENT' => user_agent,
+      'rack.input' => ::Puma::NullIO.new,
+      'action_dispatch.request.query_parameters' => params
+    )
 
     @user.stubs(:can?).with(:view_vulnerability).returns(true)
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
@@ -32,7 +41,16 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'should not scope GET requests for unknown uris' do
-    req = build_request(method: 'GET', uri: '/api/vulnerability/foo/bar')
+    user_agent = { :foo => :bar }
+    params = {}
+
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/foo/bar',
+      'REQUEST_METHOD' => 'GET',
+      'HTTP_USER_AGENT' => user_agent,
+      'rack.input' => ::Puma::NullIO.new,
+      'action_dispatch.request.query_parameters' => params
+    )
 
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
@@ -45,7 +63,16 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'should merge URI params in GET requests' do
-    req = build_request(method: 'GET', uri: '/api/vulnerability/v1/cves/abc-123/affected_systems', params: { page: 5, per_page: 42 })
+    user_agent = { :foo => :bar }
+    params = { :page => 5, :per_page => 42 }
+
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/v1/cves/abc-123/affected_systems',
+      'REQUEST_METHOD' => 'GET',
+      'HTTP_USER_AGENT' => user_agent,
+      'rack.input' => ::Puma::NullIO.new,
+      'action_dispatch.request.query_parameters' => params
+    )
 
     @user.stubs(:can?).with(:view_vulnerability).returns(true)
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
@@ -61,7 +88,13 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'should not scope POST requests' do
-    req = build_request(method: 'POST', uri: '/foo/bar', data: 'Random POST data')
+    post_data = 'Random POST data'
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/foo/bar',
+      'REQUEST_METHOD' => 'POST',
+      'rack.input' => ::Puma::NullIO.new,
+      'RAW_POST_DATA' => post_data
+    )
 
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
@@ -74,7 +107,13 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'should not scope PUT requests' do
-    req = build_request(method: 'PUT', uri: '/foo/bar', data: 'Random PUT data')
+    put_data = 'Random PUT data'
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/foo/bar',
+      'REQUEST_METHOD' => 'PUT',
+      'rack.input' => ::Puma::NullIO.new,
+      'RAW_POST_DATA' => put_data
+    )
 
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
@@ -87,7 +126,14 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'should not scope PATCH requests' do
-    req = build_request(method: 'PATCH', uri: '/foo/bar', data: 'Random PATCH data')
+    post_data = 'Random PATCH data'
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/foo/bar',
+      'REQUEST_METHOD' => 'PATCH',
+      'rack.input' => ::Puma::NullIO.new,
+      'RAW_POST_DATA' => post_data,
+      "action_dispatch.request.path_parameters" => { :format => "json" }
+    )
 
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
     @forwarder.expects(:execute_cloud_request).with do |actual_params|
@@ -100,23 +146,35 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'scope_request? should return tag_name for scoped requests' do
-    req = build_request(method: 'GET', uri: '/api/vulnerability/v1/vulnerabilities/cves')
+    get_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/v1/vulnerabilities/cves',
+      'REQUEST_METHOD' => 'GET',
+      'rack.input' => ::Puma::NullIO.new
+    )
 
-    result = @forwarder.send(:scope_request?, req, 'api/vulnerability/v1/vulnerabilities/cves')
+    result = @forwarder.send(:scope_request?, get_req, 'api/vulnerability/v1/vulnerabilities/cves')
     assert_equal :tags, result
   end
 
   test 'scope_request? should return nil for non-GET requests' do
-    req = build_request(method: 'POST', uri: '/api/vulnerability/v1/cves')
+    post_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/v1/cves',
+      'REQUEST_METHOD' => 'POST',
+      'rack.input' => ::Puma::NullIO.new
+    )
 
-    result = @forwarder.send(:scope_request?, req, '/api/vulnerability/v1/cves')
+    result = @forwarder.send(:scope_request?, post_req, '/api/vulnerability/v1/cves')
     assert_nil result
   end
 
   test 'scope_request? should return nil for unmatched paths' do
-    req = build_request(method: 'GET', uri: '/api/unmatched/path')
+    get_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/unmatched/path',
+      'REQUEST_METHOD' => 'GET',
+      'rack.input' => ::Puma::NullIO.new
+    )
 
-    result = @forwarder.send(:scope_request?, req, '/api/unmatched/path')
+    result = @forwarder.send(:scope_request?, get_req, '/api/unmatched/path')
     assert_nil result
   end
 
@@ -159,7 +217,16 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
 
   # GET /api/inventory/v1/hosts requires view_vulnerability
   test 'should allow GET request to inventory hosts when user has view_vulnerability permission' do
-    req = build_request(method: 'GET', uri: '/api/inventory/v1/hosts')
+    user_agent = { :foo => :bar }
+    params = {}
+
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/inventory/v1/hosts',
+      'REQUEST_METHOD' => 'GET',
+      'HTTP_USER_AGENT' => user_agent,
+      'rack.input' => ::Puma::NullIO.new,
+      'action_dispatch.request.query_parameters' => params
+    )
 
     @user.stubs(:can?).with(:view_vulnerability).returns(true)
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
@@ -169,10 +236,18 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'should deny GET request to inventory hosts when user lacks view_vulnerability permission' do
-    req = build_request(method: 'GET', uri: '/api/inventory/v1/hosts')
+    user_agent = { :foo => :bar }
+    params = {}
+
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/inventory/v1/hosts',
+      'REQUEST_METHOD' => 'GET',
+      'HTTP_USER_AGENT' => user_agent,
+      'rack.input' => ::Puma::NullIO.new,
+      'action_dispatch.request.query_parameters' => params
+    )
 
     @user.stubs(:can?).with(:view_vulnerability).returns(false)
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
 
     assert_raises(::Foreman::PermissionMissingException) do
       @forwarder.forward_request(req, 'api/inventory/v1/hosts', 'test_controller', @user, @organization, @location)
@@ -181,10 +256,15 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
 
   # POST /api/vulnerability/v1/vulnerabilities/cves requires view_vulnerability
   test 'should deny POST request to vulnerabilities cves when user lacks view_vulnerability permission' do
-    req = build_request(method: 'POST', uri: '/api/vulnerability/v1/vulnerabilities/cves', data: '{"test": "data"}')
+    post_data = '{"test": "data"}'
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/v1/vulnerabilities/cves',
+      'REQUEST_METHOD' => 'POST',
+      'rack.input' => ::Puma::NullIO.new,
+      'RAW_POST_DATA' => post_data
+    )
 
     @user.stubs(:can?).with(:view_vulnerability).returns(false)
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
 
     assert_raises(::Foreman::PermissionMissingException) do
       @forwarder.forward_request(req, 'api/vulnerability/v1/vulnerabilities/cves', 'test_controller', @user, @organization, @location)
@@ -193,7 +273,14 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
 
   # PATCH /api/vulnerability/v1/status requires edit_vulnerability
   test 'should allow PATCH request to vulnerability status when user has edit_vulnerability permission' do
-    req = build_request(method: 'PATCH', uri: '/api/vulnerability/v1/status', data: '{"status": "resolved"}')
+    patch_data = '{"status": "resolved"}'
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/v1/status',
+      'REQUEST_METHOD' => 'PATCH',
+      'rack.input' => ::Puma::NullIO.new,
+      'RAW_POST_DATA' => patch_data,
+      "action_dispatch.request.path_parameters" => { :format => "json" }
+    )
 
     @user.stubs(:can?).with(:edit_vulnerability).returns(true)
     @forwarder.expects(:execute_cloud_request).returns(true)
@@ -202,10 +289,16 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
   end
 
   test 'should deny PATCH request to vulnerability status when user lacks edit_vulnerability permission' do
-    req = build_request(method: 'PATCH', uri: '/api/vulnerability/v1/status', data: '{"status": "resolved"}')
+    patch_data = '{"status": "resolved"}'
+    req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/vulnerability/v1/status',
+      'REQUEST_METHOD' => 'PATCH',
+      'rack.input' => ::Puma::NullIO.new,
+      'RAW_POST_DATA' => patch_data,
+      "action_dispatch.request.path_parameters" => { :format => "json" }
+    )
 
     @user.stubs(:can?).with(:edit_vulnerability).returns(false)
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
 
     assert_raises(::Foreman::PermissionMissingException) do
       @forwarder.forward_request(req, 'api/vulnerability/v1/status', 'test_controller', @user, @organization, @location)
@@ -224,6 +317,14 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     { path: 'api/vulnerability/v1/systems/opt_out', method: 'PATCH', expected: :edit_vulnerability },
     { path: 'api/vulnerability/v1/dashbar', method: 'GET', expected: :view_vulnerability },
     { path: 'api/vulnerability/v1/cves/CVE-2024-1234/affected_systems', method: 'GET', expected: :view_vulnerability },
+    # Endpoints without tags support (still require view_vulnerability)
+    { path: 'api/vulnerability/v1/apistatus', method: 'GET', expected: :view_vulnerability },
+    { path: 'api/vulnerability/v1/version', method: 'GET', expected: :view_vulnerability },
+    { path: 'api/vulnerability/v1/business_risk', method: 'GET', expected: :view_vulnerability },
+    { path: 'api/vulnerability/v1/announcement', method: 'GET', expected: :view_vulnerability },
+    { path: 'api/vulnerability/v1/cves/CVE-2024-1234', method: 'GET', expected: :view_vulnerability },
+    { path: 'api/vulnerability/v1/playbooks/abc-123', method: 'GET', expected: :view_vulnerability },
+    { path: 'api/vulnerability/v1/report/abc-123', method: 'GET', expected: :view_vulnerability },
     # Advisor endpoints
     { path: 'api/insights/v1/stats/systems', method: 'GET', expected: :view_advisor },
     { path: 'api/insights/v1/ack/', method: 'POST', expected: :edit_advisor },
@@ -257,7 +358,6 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     req = build_request(method: 'GET', uri: '/api/insights/v1/stats/systems')
 
     @user.stubs(:can?).with(:view_advisor).returns(false)
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
 
     assert_raises(::Foreman::PermissionMissingException) do
       @forwarder.forward_request(req, 'api/insights/v1/stats/systems', 'test_controller', @user, @organization, @location)
@@ -277,102 +377,15 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     req = build_request(method: 'POST', uri: '/api/insights/v1/ack/', data: '{"rule_id": "test|RULE"}')
 
     @user.stubs(:can?).with(:edit_advisor).returns(false)
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
 
     assert_raises(::Foreman::PermissionMissingException) do
       @forwarder.forward_request(req, 'api/insights/v1/ack/', 'test_controller', @user, @organization, @location)
     end
   end
 
-  # DELETE /api/insights/v1/ack/{rule_id} requires edit_advisor
-  test 'should allow DELETE request to insights ack when user has edit_advisor permission' do
-    req = build_request(method: 'DELETE', uri: '/api/insights/v1/ack/test-rule-id')
-
-    @user.stubs(:can?).with(:edit_advisor).returns(true)
-    @forwarder.expects(:execute_cloud_request).returns(true)
-
-    @forwarder.forward_request(req, 'api/insights/v1/ack/test-rule-id', 'test_controller', @user, @organization, @location)
-  end
-
-  test 'should deny DELETE request to insights ack when user lacks edit_advisor permission' do
-    req = build_request(method: 'DELETE', uri: '/api/insights/v1/ack/test-rule-id')
-
-    @user.stubs(:can?).with(:edit_advisor).returns(false)
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
-
-    assert_raises(::Foreman::PermissionMissingException) do
-      @forwarder.forward_request(req, 'api/insights/v1/ack/test-rule-id', 'test_controller', @user, @organization, @location)
-    end
-  end
-
-  # POST /api/insights/v1/hostack/ requires edit_advisor
-  test 'should allow POST request to insights hostack when user has edit_advisor permission' do
-    req = build_request(method: 'POST', uri: '/api/insights/v1/hostack/', data: '{"host_id": "123"}')
-
-    @user.stubs(:can?).with(:edit_advisor).returns(true)
-    @forwarder.expects(:execute_cloud_request).returns(true)
-
-    @forwarder.forward_request(req, 'api/insights/v1/hostack/', 'test_controller', @user, @organization, @location)
-  end
-
-  test 'should deny POST request to insights hostack when user lacks edit_advisor permission' do
-    req = build_request(method: 'POST', uri: '/api/insights/v1/hostack/', data: '{"host_id": "123"}')
-
-    @user.stubs(:can?).with(:edit_advisor).returns(false)
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
-
-    assert_raises(::Foreman::PermissionMissingException) do
-      @forwarder.forward_request(req, 'api/insights/v1/hostack/', 'test_controller', @user, @organization, @location)
-    end
-  end
-
-  # DELETE /api/insights/v1/hostack/{id} requires edit_advisor
-  test 'should allow DELETE request to insights hostack when user has edit_advisor permission' do
-    req = build_request(method: 'DELETE', uri: '/api/insights/v1/hostack/123')
-
-    @user.stubs(:can?).with(:edit_advisor).returns(true)
-    @forwarder.expects(:execute_cloud_request).returns(true)
-
-    @forwarder.forward_request(req, 'api/insights/v1/hostack/123', 'test_controller', @user, @organization, @location)
-  end
-
-  test 'should deny DELETE request to insights hostack when user lacks edit_advisor permission' do
-    req = build_request(method: 'DELETE', uri: '/api/insights/v1/hostack/123')
-
-    @user.stubs(:can?).with(:edit_advisor).returns(false)
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
-
-    assert_raises(::Foreman::PermissionMissingException) do
-      @forwarder.forward_request(req, 'api/insights/v1/hostack/123', 'test_controller', @user, @organization, @location)
-    end
-  end
-
-  # POST /api/insights/v1/rule/{rule_id}/unack_hosts requires edit_advisor
-  test 'should allow POST request to insights unack_hosts when user has edit_advisor permission' do
-    req = build_request(method: 'POST', uri: '/api/insights/v1/rule/test-rule-id/unack_hosts', data: '{"host_ids": ["123"]}')
-
-    @user.stubs(:can?).with(:edit_advisor).returns(true)
-    @forwarder.expects(:execute_cloud_request).returns(true)
-
-    @forwarder.forward_request(req, 'api/insights/v1/rule/test-rule-id/unack_hosts', 'test_controller', @user, @organization, @location)
-  end
-
-  test 'should deny POST request to insights unack_hosts when user lacks edit_advisor permission' do
-    req = build_request(method: 'POST', uri: '/api/insights/v1/rule/test-rule-id/unack_hosts', data: '{"host_ids": ["123"]}')
-
-    @user.stubs(:can?).with(:edit_advisor).returns(false)
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
-
-    assert_raises(::Foreman::PermissionMissingException) do
-      @forwarder.forward_request(req, 'api/insights/v1/rule/test-rule-id/unack_hosts', 'test_controller', @user, @organization, @location)
-    end
-  end
-
   # Edge case: anonymous user
   test 'should deny request when user is nil' do
     req = build_request(method: 'GET', uri: '/api/insights/v1/stats/systems')
-
-    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag).never
 
     assert_raises(::Foreman::PermissionMissingException) do
       @forwarder.forward_request(req, 'api/insights/v1/stats/systems', 'test_controller', nil, @organization, @location)


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman_rh_cloud/pull/1135.

#### What are the changes introduced in this pull request?
Add permission enforcement for Insights API forwarding.

Implement permission checks in InsightsApiForwarder before proxying
requests to Insights cloud. Users without appropriate view/edit
permissions for Vulnerability or Advisor apps receive 403 Forbidden.

Add ForemanRhCloudPermissionsHelper to map Foreman permissions to
Insights Chrome API format for frontend UI access control.

Includes comprehensive tests for all protected endpoints.

#### Considerations taken when implementing this change?
This is Part 2 of a 3-part PR series. 

#### What are the testing steps for this pull request?
This PR should be tested together with the related PRs. For now, please ensure that all Ruby tests pass.

## Summary by Sourcery

Enforce permission-scoped forwarding for Insights-related API requests and extend plugin permissions accordingly.

New Features:
- Introduce fine-grained Foreman permissions for Insights Vulnerability and Advisor applications.
- Gate forwarding of specific Insights, Vulnerability, and Inventory API endpoints on corresponding view/edit permissions.

Enhancements:
- Refine scoped request configuration to associate API path patterns with required permissions in a deterministic way.

Tests:
- Add integration and unit tests covering permission checks for Insights, Vulnerability, and Inventory endpoints, including anonymous and unauthorized access cases.