### PR TITLE
Expose Insights permissions to Scalprum apps via ForemanContext

### DIFF
--- a/app/controllers/insights_cloud/ui_requests_controller.rb
+++ b/app/controllers/insights_cloud/ui_requests_controller.rb
@@ -18,6 +18,10 @@ module InsightsCloud
           @organization,
           @location
         )
+      rescue ::Foreman::PermissionMissingException => e
+        logger.warn("Permission denied for forwarding request: #{e}")
+        message = e.message
+        return render json: { message: message, error: message }, status: :forbidden
       rescue RestClient::Exceptions::Timeout => e
         response_obj = e.response.presence || e.exception
         return render json: { message: response_obj.to_s, error: response_obj.to_s }, status: :gateway_timeout

--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
-import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
+import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
+import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 import './CVEsHostDetailsTab.scss';
 
 const CVEsHostDetailsTab = ({ systemId }) => {
@@ -18,14 +19,17 @@ CVEsHostDetailsTab.propTypes = {
   systemId: PropTypes.string.isRequired,
 };
 
-const CVEsHostDetailsTabWrapper = ({ response }) => (
-  <ScalprumProvider {...providerOptions}>
-    <CVEsHostDetailsTab
-      // eslint-disable-next-line camelcase
-      systemId={response?.subscription_facet_attributes?.uuid}
-    />
-  </ScalprumProvider>
-);
+const CVEsHostDetailsTabWrapper = ({ response }) => {
+  const permissions = useInsightsPermissions();
+  return (
+    <ScalprumProvider {...createProviderOptions(permissions)}>
+      <CVEsHostDetailsTab
+        // eslint-disable-next-line camelcase
+        systemId={response?.subscription_facet_attributes?.uuid}
+      />
+    </ScalprumProvider>
+  );
+};
 
 CVEsHostDetailsTabWrapper.propTypes = {
   response: PropTypes.shape({

--- a/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
+++ b/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
@@ -2,6 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import CVEsHostDetailsTabWrapper from '../CVEsHostDetailsTab';
 
+jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
+  useForemanContext: () => ({
+    metadata: {
+      permissions: new Set(['view_vulnerability']),
+    },
+  }),
+}));
+
 jest.mock('@scalprum/react-core', () => ({
   ScalprumComponent: jest.fn(props => (
     <div data-testid="mock-scalprum-component">{JSON.stringify(props)}</div>

--- a/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
+++ b/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
@@ -8,6 +8,7 @@ jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
       permissions: new Set(['view_vulnerability']),
     },
   }),
+  useForemanPermissions: () => new Set(['view_vulnerability']),
 }));
 
 jest.mock('@scalprum/react-core', () => ({

--- a/webpack/CveDetailsPage/CveDetailsPage.js
+++ b/webpack/CveDetailsPage/CveDetailsPage.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
-import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
+import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
+import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 
 const CveDetailsPage = () => {
   const { cveId } = useParams();
+  const permissions = useInsightsPermissions();
   const scope = 'vulnerability';
   const module = './CveDetailPage';
 
   return (
-    <ScalprumProvider {...providerOptions}>
+    <ScalprumProvider {...createProviderOptions(permissions)}>
       <div className="rh-cloud-cve-details-page vulnerability">
         <ScalprumComponent scope={scope} module={module} cveId={cveId} />
       </div>

--- a/webpack/CveDetailsPage/CveDetailsPage.test.js
+++ b/webpack/CveDetailsPage/CveDetailsPage.test.js
@@ -14,6 +14,7 @@ jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
       permissions: new Set(['view_vulnerability']),
     },
   }),
+  useForemanPermissions: () => new Set(['view_vulnerability']),
 }));
 
 jest.mock('@scalprum/react-core', () => ({

--- a/webpack/CveDetailsPage/CveDetailsPage.test.js
+++ b/webpack/CveDetailsPage/CveDetailsPage.test.js
@@ -8,6 +8,14 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn(() => ({ cveId: 'CVE-2021-1234' })),
 }));
 
+jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
+  useForemanContext: () => ({
+    metadata: {
+      permissions: new Set(['view_vulnerability']),
+    },
+  }),
+}));
+
 jest.mock('@scalprum/react-core', () => ({
   ScalprumComponent: jest.fn(props => (
     <div data-testid="mock-scalprum-component">{JSON.stringify(props)}</div>

--- a/webpack/InsightsCloudSync/InsightsCloudSync.js
+++ b/webpack/InsightsCloudSync/InsightsCloudSync.js
@@ -14,7 +14,8 @@ import './InsightsCloudSync.scss';
 import Pagination from './Components/InsightsTable/Pagination';
 import ToolbarDropdown from './Components/ToolbarDropdown';
 import InsightsSettings from './Components/InsightsSettings';
-import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
+import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
+import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 
 // Hosted Insights advisor
 const InsightsCloudSync = ({ syncInsights, query, fetchInsights }) => {
@@ -78,11 +79,14 @@ const IopRecommendationsPage = props => (
   </div>
 );
 
-const IopRecommendationsPageWrapped = props => (
-  <ScalprumProvider {...providerOptions}>
-    <IopRecommendationsPage {...props} />
-  </ScalprumProvider>
-);
+const IopRecommendationsPageWrapped = props => {
+  const permissions = useInsightsPermissions();
+  return (
+    <ScalprumProvider {...createProviderOptions(permissions)}>
+      <IopRecommendationsPage {...props} />
+    </ScalprumProvider>
+  );
+};
 
 const RecommendationsPage = props => {
   const isIop = useIopConfig();

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -23,7 +23,8 @@ import {
 import { redHatAdvisorSystems } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
 import { useIopConfig } from '../common/Hooks/ConfigHooks';
 import { generateRuleUrl } from '../InsightsCloudSync/InsightsCloudSync';
-import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
+import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
+import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 
 // Hosted Insights advisor
 const NewHostDetailsTab = ({ hostName, router }) => {
@@ -124,11 +125,14 @@ const IopInsightsTab = props => (
   </div>
 );
 
-const IopInsightsTabWrapped = props => (
-  <ScalprumProvider {...providerOptions}>
-    <IopInsightsTab {...props} />
-  </ScalprumProvider>
-);
+const IopInsightsTabWrapped = props => {
+  const permissions = useInsightsPermissions();
+  return (
+    <ScalprumProvider {...createProviderOptions(permissions)}>
+      <IopInsightsTab {...props} />
+    </ScalprumProvider>
+  );
+};
 
 const InsightsTab = props => {
   const isIop = useIopConfig();

--- a/webpack/InsightsVulnerability/InsightsVulnerabilityListPage.js
+++ b/webpack/InsightsVulnerability/InsightsVulnerabilityListPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
-import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
+import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
+import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 
 const InsightsVulnerabilityListPage = () => {
   const scope = 'vulnerability';
@@ -12,10 +13,13 @@ const InsightsVulnerabilityListPage = () => {
   );
 };
 
-const InsightsVulnerabilityListPageWrap = () => (
-  <ScalprumProvider {...providerOptions}>
-    <InsightsVulnerabilityListPage />
-  </ScalprumProvider>
-);
+const InsightsVulnerabilityListPageWrap = () => {
+  const permissions = useInsightsPermissions();
+  return (
+    <ScalprumProvider {...createProviderOptions(permissions)}>
+      <InsightsVulnerabilityListPage />
+    </ScalprumProvider>
+  );
+};
 
 export default InsightsVulnerabilityListPageWrap;

--- a/webpack/InsightsVulnerability/InsightsVulnerabilityListPage.test.js
+++ b/webpack/InsightsVulnerability/InsightsVulnerabilityListPage.test.js
@@ -9,6 +9,7 @@ jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
       permissions: new Set(['view_vulnerability']),
     },
   }),
+  useForemanPermissions: () => new Set(['view_vulnerability']),
 }));
 
 jest.mock('@scalprum/react-core', () => ({

--- a/webpack/InsightsVulnerability/InsightsVulnerabilityListPage.test.js
+++ b/webpack/InsightsVulnerability/InsightsVulnerabilityListPage.test.js
@@ -3,6 +3,14 @@ import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import InsightsVulnerabilityListPage from './InsightsVulnerabilityListPage';
 
+jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
+  useForemanContext: () => ({
+    metadata: {
+      permissions: new Set(['view_vulnerability']),
+    },
+  }),
+}));
+
 jest.mock('@scalprum/react-core', () => ({
   ScalprumComponent: jest.fn(props => (
     <div data-testid="mock-scalprum-component">{JSON.stringify(props)}</div>

--- a/webpack/IopRecommendationDetails/IopRecommendationDetails.js
+++ b/webpack/IopRecommendationDetails/IopRecommendationDetails.js
@@ -3,7 +3,8 @@ import { useRouteMatch } from 'react-router-dom';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
 
 import RemediationModal from '../InsightsCloudSync/Components/RemediationModal';
-import { providerOptions } from '../common/ScalprumModule/ScalprumContext';
+import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
+import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 
 const scope = 'advisor';
 const module = './RecommendationDetailsWrapped';
@@ -25,10 +26,13 @@ const IopRecommendationDetails = props => {
   );
 };
 
-const IopRecommendationDetailsWrapped = props => (
-  <ScalprumProvider {...providerOptions}>
-    <IopRecommendationDetails {...props} />
-  </ScalprumProvider>
-);
+const IopRecommendationDetailsWrapped = props => {
+  const permissions = useInsightsPermissions();
+  return (
+    <ScalprumProvider {...createProviderOptions(permissions)}>
+      <IopRecommendationDetails {...props} />
+    </ScalprumProvider>
+  );
+};
 
 export default IopRecommendationDetailsWrapped;

--- a/webpack/common/Hooks/PermissionsHooks.js
+++ b/webpack/common/Hooks/PermissionsHooks.js
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import { useForemanContext } from 'foremanReact/Root/Context/ForemanContext';
+
+/**
+ * Mapping from Foreman permissions to Insights Chrome API permissions.
+ * Used to convert Foreman's permission names to the format expected by
+ * Scalprum-loaded Insights apps (vulnerability-ui, advisor).
+ *
+ * When adding new permissions, update both:
+ * - This mapping (for front-end RBAC in Scalprum apps)
+ * - The SCOPED_REQUESTS in app/services/foreman_rh_cloud/insights_api_forwarder.rb (for backend API enforcement)
+ */
+const PERMISSION_MAPPING = {
+  view_vulnerability: [
+    'inventory:hosts:read',
+    'vulnerability:vulnerability_results:read',
+    'vulnerability:system.opt_out:read',
+    'vulnerability:report_and_export:read',
+    'vulnerability:advanced_report:read',
+  ],
+  edit_vulnerability: [
+    'vulnerability:system.cve.status:write',
+    'vulnerability:cve.business_risk_and_status:write',
+    'vulnerability:system.opt_out:write',
+  ],
+  view_advisor: ['advisor:recommendation-results:read', 'advisor:exports:read'],
+  edit_advisor: ['advisor:disable-recommendations:write'],
+};
+
+/**
+ * Hook to access Insights permissions in Chrome API format.
+ * Reads Foreman permissions from context and converts them to the format
+ * expected by Scalprum-loaded Insights apps.
+ *
+ * Uses ForemanContext.metadata.permissions (added in Foreman PR #10338).
+ * Falls back to empty permissions if not available (older Foreman versions).
+ *
+ * @see https://github.com/theforeman/foreman/blob/develop/developer_docs/handling_user_permissions.asciidoc
+ * @returns {Array<{permission: string, resourceDefinitions: Array}>} User's Insights permissions
+ */
+export const useInsightsPermissions = () => {
+  const context = useForemanContext();
+  const userPermissions = context?.metadata?.permissions || new Set();
+
+  return useMemo(
+    () =>
+      Object.entries(PERMISSION_MAPPING).flatMap(
+        ([foremanPerm, insightsPerms]) =>
+          userPermissions.has(foremanPerm)
+            ? insightsPerms.map(perm => ({
+                permission: perm,
+                resourceDefinitions: [],
+              }))
+            : []
+      ),
+    [userPermissions]
+  );
+};

--- a/webpack/common/Hooks/PermissionsHooks.js
+++ b/webpack/common/Hooks/PermissionsHooks.js
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useForemanContext } from 'foremanReact/Root/Context/ForemanContext';
+import { useForemanPermissions } from 'foremanReact/Root/Context/ForemanContext';
 
 /**
  * Mapping from Foreman permissions to Insights Chrome API permissions.
@@ -39,8 +39,7 @@ const PERMISSION_MAPPING = {
  * @returns {Array<{permission: string, resourceDefinitions: Array}>} User's Insights permissions
  */
 export const useInsightsPermissions = () => {
-  const context = useForemanContext();
-  const userPermissions = context?.metadata?.permissions || new Set();
+  const userPermissions = useForemanPermissions() || new Set();
 
   return useMemo(
     () =>

--- a/webpack/common/ScalprumModule/ScalprumContext.js
+++ b/webpack/common/ScalprumModule/ScalprumContext.js
@@ -39,7 +39,25 @@ export const mockUser = {
   },
 };
 
-export const providerOptions = {
+/**
+ * Creates getUserPermissions function for Chrome API.
+ * @param {Array} permissions - Permissions array from ForemanContext
+ * @returns {Function} getUserPermissions function
+ */
+const createGetUserPermissions = permissions => async (app, _bypassCache) =>
+  app
+    ? permissions.filter(p => p.permission?.startsWith(`${app}:`))
+    : permissions;
+
+/**
+ * Creates provider options with the given permissions.
+ * Call this from wrapper components with permissions from useInsightsPermissions().
+ *
+ * @see https://github.com/theforeman/foreman/blob/develop/developer_docs/foreman-context.asciidoc
+ * @param {Array} permissions - Permissions from useInsightsPermissions()
+ * @returns {Object} Provider options for ScalprumProvider
+ */
+export const createProviderOptions = (permissions = []) => ({
   pluginSDKOptions: {
     pluginLoaderOptions: {
       transformPluginManifest: manifest => {
@@ -66,8 +84,9 @@ export const providerOptions = {
       on: () => {},
       auth: {
         getUser: () => Promise.resolve(mockUser),
+        getUserPermissions: createGetUserPermissions(permissions),
       },
     },
   },
   config: modulesConfig,
-};
+});

--- a/webpack/common/ScalprumModule/__tests__/ScalprumContext.test.js
+++ b/webpack/common/ScalprumModule/__tests__/ScalprumContext.test.js
@@ -1,0 +1,120 @@
+import {
+  modulesConfig,
+  mockUser,
+  createProviderOptions,
+} from '../ScalprumContext';
+
+describe('ScalprumContext', () => {
+  describe('modulesConfig', () => {
+    it('should have vulnerability module config', () => {
+      expect(modulesConfig.vulnerability).toBeDefined();
+      expect(modulesConfig.vulnerability.name).toBe('vulnerability');
+    });
+
+    it('should have advisor module config', () => {
+      expect(modulesConfig.advisor).toBeDefined();
+      expect(modulesConfig.advisor.name).toBe('advisor');
+    });
+
+    it('should have inventory module config', () => {
+      expect(modulesConfig.inventory).toBeDefined();
+      expect(modulesConfig.inventory.name).toBe('inventory');
+    });
+  });
+
+  describe('mockUser', () => {
+    it('should have identity with org_id FOREMAN', () => {
+      expect(mockUser.identity.org_id).toBe('FOREMAN');
+    });
+  });
+
+  describe('createProviderOptions', () => {
+    it('should have isBeta function', () => {
+      const options = createProviderOptions([]);
+      expect(options.api.chrome.isBeta).toBeInstanceOf(Function);
+      expect(options.api.chrome.isBeta()).toBe(false);
+    });
+
+    it('should have auth.getUser that resolves to mockUser', async () => {
+      const options = createProviderOptions([]);
+      expect(options.api.chrome.auth.getUser).toBeInstanceOf(Function);
+      const user = await options.api.chrome.auth.getUser();
+      expect(user).toEqual(mockUser);
+    });
+
+    it('should return empty array when no permissions provided', async () => {
+      const options = createProviderOptions([]);
+      const permissions = await options.api.chrome.auth.getUserPermissions();
+      expect(permissions).toEqual([]);
+    });
+
+    describe('getUserPermissions', () => {
+      const testPermissions = [
+        { permission: 'inventory:hosts:read', resourceDefinitions: [] },
+        {
+          permission: 'vulnerability:vulnerability_results:read',
+          resourceDefinitions: [],
+        },
+        {
+          permission: 'vulnerability:system.opt_out:read',
+          resourceDefinitions: [],
+        },
+      ];
+
+      it('should filter vulnerability permissions by app prefix', async () => {
+        const options = createProviderOptions(testPermissions);
+        const permissions = await options.api.chrome.auth.getUserPermissions(
+          'vulnerability'
+        );
+
+        expect(permissions).toHaveLength(2);
+        expect(permissions[0].permission).toBe(
+          'vulnerability:vulnerability_results:read'
+        );
+      });
+
+      it('should filter inventory permissions by app prefix', async () => {
+        const options = createProviderOptions(testPermissions);
+        const permissions = await options.api.chrome.auth.getUserPermissions(
+          'inventory'
+        );
+
+        expect(permissions).toHaveLength(1);
+        expect(permissions[0].permission).toBe('inventory:hosts:read');
+      });
+
+      it('should return all permissions when no app filter is provided', async () => {
+        const options = createProviderOptions(testPermissions);
+        const permissions = await options.api.chrome.auth.getUserPermissions();
+
+        expect(permissions).toHaveLength(3);
+      });
+
+      it('should return permissions in Chrome API format', async () => {
+        const options = createProviderOptions(testPermissions);
+        const permissions = await options.api.chrome.auth.getUserPermissions(
+          'vulnerability'
+        );
+
+        expect(permissions[0]).toHaveProperty('permission');
+        expect(permissions[0]).toHaveProperty('resourceDefinitions');
+        expect(Array.isArray(permissions[0].resourceDefinitions)).toBe(true);
+      });
+
+      it('should handle permissions with missing permission field', async () => {
+        const malformedPermissions = [
+          { permission: 'inventory:hosts:read', resourceDefinitions: [] },
+          { resourceDefinitions: [] }, // missing permission field
+          { permission: null, resourceDefinitions: [] },
+        ];
+        const options = createProviderOptions(malformedPermissions);
+
+        const permissions = await options.api.chrome.auth.getUserPermissions(
+          'inventory'
+        );
+        expect(permissions).toHaveLength(1);
+        expect(permissions[0].permission).toBe('inventory:hosts:read');
+      });
+    });
+  });
+});


### PR DESCRIPTION
**ToDo:** Improve the displayed error message on the Insights page if the user does not have the necessary permissions.

**Requires** https://github.com/theforeman/foreman_rh_cloud/pull/1136.

#### What are the changes introduced in this pull request?

Add Chrome API getUserPermissions() implementation for vulnerability-ui
and advisor apps to query user permissions and control UI accordingly.

Implements frontend RBAC for Scalprum-loaded Insights applications
(vulnerability-ui, advisor) by exposing user permissions through
the Chrome API getUserPermissions() interface.

Changes:
- Add useInsightsPermissions() hook that reads Foreman permissions
  from ForemanContext (PR #10338) and converts them to Chrome API format
- Add createProviderOptions() factory to pass permissions to ScalprumProvider
- Update all Scalprum wrapper components to use the new permission flow
- Add permission denied handling in UI requests controller (403 response)

Permission mapping (Foreman → Chrome API):
  view_vulnerability → inventory:hosts:read, vulnerability:*:read
  edit_vulnerability → vulnerability:*:write
  view_advisor → advisor:*:read
  edit_advisor → advisor:*:write

This enables Insights frontend apps to check user permissions and
show/hide UI elements based on RBAC, complementing the existing
backend permission enforcement in the API forwarder.

#### Considerations taken when implementing this change?

1. Chrome API Compatibility: Implemented getUserPermissions() to match the Insights Chrome API specification, returning permissions in the expected format ({ permission: string, resourceDefinitions: [] }). This allows Scalprum-loaded Insights apps (vulnerability-ui, advisor) to use their existing RBAC logic without modification.
2. Synchronous Availability: Permissions are read from ForemanContext, which is initialized when the React app mounts. This ensures permissions are available before Scalprum components render, avoiding race conditions or loading states in the permission checks.
3. Using Foreman's Native Permission System: Rather than creating a custom permission mechanism, we leverage Foreman's context-based permission system introduced in PR #10338. This ensures consistency with Foreman's RBAC architecture and avoids duplicating permission logic.
4. Chrome API Compatibility: Scalprum-loaded Insights apps (vulnerability-ui, advisor) expect permissions in Chrome API format (app:resource:action). The implementation includes a mapping layer that converts Foreman permission names (e.g., view_vulnerability) to the Chrome API format (e.g., vulnerability:vulnerability_results:read).
5. Frontend vs Backend Enforcement: This change implements frontend RBAC only - it controls UI visibility and user experience. The authoritative permission enforcement remains on the backend via SCOPED_REQUESTS in the API forwarder. Frontend permissions are supplementary and should never be the sole security mechanism.
6. Performance - Memoization: The useInsightsPermissions hook uses useMemo to prevent rebuilding the permissions array on every React render, reducing unnecessary computation.

#### What are the testing steps for this pull request?

1. **Verify that all tests pass successfully.** (tesing is still in progress)

***Prerequisites***
Newer Advisor frontend that respects RBAC - The advisor-ui must be a version that queries chrome.auth.getUserPermissions() and respects the returned permissions for UI access control

3. **Test user with view-only permissions**:
   - Create a role with only view permissions (no edit)
   - Assign role to a test user and log in
   - Navigate to Insights → Recommendations/Vulnerability
   - Verify page loads and displays recommendations
   - Verify edit actions are hidden

4. **Test user with edit permissions**:
   - Create a role with both view and edit permissions
   - Assign role to a test user and log in
   - Navigate to Insights → Recommendations/Vulnerability
   - Verify all actions are enabled

## Summary by Sourcery

Expose Insights RBAC permissions from Foreman to Scalprum-based frontends and enforce them on forwarded Insights and Vulnerability API requests.

New Features:
- Expose Insights-style user permissions to Scalprum frontends via chrome.auth.getUserPermissions backed by backend-injected permission data.
- Introduce a permissions helper that maps Foreman RBAC permissions to Insights permission strings for Vulnerability and Advisor applications.
- Add hidden HTML injection of serialized user permissions that are initialized into a global window object for frontend consumption.

Enhancements:
- Enforce Foreman RBAC on forwarded Vulnerability, Inventory, and Advisor API requests by mapping HTTP paths and methods to required permissions before proxying.
- Extend the RH Cloud plugin with dedicated Vulnerability and Advisor view/edit permissions and include them in the default plugin role.
- Return explicit 403 responses from the UI forwarding controller when permission checks fail to inform frontend clients.

Tests:
- Add comprehensive unit tests covering permission mapping, Insights permission formatting, and combinations of user capabilities.
- Add unit tests verifying permission enforcement for Insights and Vulnerability API forwarding, including allowed and denied cases and helper behavior.

## Summary by Sourcery

Enforce Foreman RBAC for Insights, Vulnerability, and Advisor traffic and expose mapped permissions to Scalprum-based frontend apps.

New Features:
- Expose Insights-style permissions to Scalprum providers via a configurable createProviderOptions helper and a useInsightsPermissions hook backed by ForemanContext.

Enhancements:
- Add fine-grained permission mapping in InsightsApiForwarder to require specific Foreman permissions per Insights, Vulnerability, and Inventory API endpoint before proxying requests.
- Return explicit 403 responses with an error payload from the UI requests controller when permission checks fail.
- Extend the RH Cloud plugin with dedicated view/edit permissions for Vulnerability and Advisor and include them in the default plugin role.
- Preserve backwards compatibility for existing Scalprum usage by providing default provider options with no permissions.

Tests:
- Add extensive unit tests covering permission resolution in InsightsApiForwarder for Vulnerability, Inventory, and Advisor endpoints, including helper behavior and allowed/denied scenarios.