### PR TITLE
Evaluate IoP status at runtime, not application start, and register Ping extension always

### DIFF
--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -7,7 +7,7 @@ module ForemanRhCloud
       include ForemanRhCloud::CertAuth
 
       def iop_smart_proxy_url
-        @iop_smart_proxy_url ||= ForemanRhCloud.iop_smart_proxy&.url
+        ForemanRhCloud.iop_smart_proxy&.url
       end
 
       def service_urls

--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -7,7 +7,7 @@ module ForemanRhCloud
       include ForemanRhCloud::CertAuth
 
       def iop_smart_proxy_url
-        @iop_smart_proxy_url ||= ForemanRhCloud.iop_smart_proxy.url
+        @iop_smart_proxy_url ||= ForemanRhCloud.iop_smart_proxy&.url
       end
 
       def service_urls
@@ -33,6 +33,7 @@ module ForemanRhCloud
       end
 
       def ping
+        return {} unless ForemanRhCloud.with_iop_smart_proxy?
         ping_services
       end
 

--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -14,15 +14,15 @@ module ForemanRhCloud
 
   def self.base_url
     # for testing set ENV to 'https://ci.cloud.redhat.com'
-    @base_url ||= env_or_on_premise_url('SATELLITE_RH_CLOUD_URL') || 'https://cloud.redhat.com'
+    env_or_on_premise_url('SATELLITE_RH_CLOUD_URL') || 'https://cloud.redhat.com'
   end
 
   def self.cert_base_url
-    @cert_base_url ||= env_or_on_premise_url('SATELLITE_CERT_RH_CLOUD_URL') || 'https://cert.cloud.redhat.com'
+    env_or_on_premise_url('SATELLITE_CERT_RH_CLOUD_URL') || 'https://cert.cloud.redhat.com'
   end
 
   def self.legacy_insights_url
-    @legacy_insights_url ||= env_or_on_premise_url('SATELLITE_LEGACY_INSIGHTS_URL') || 'https://cert-api.access.redhat.com'
+    env_or_on_premise_url('SATELLITE_LEGACY_INSIGHTS_URL') || 'https://cert-api.access.redhat.com'
   end
 
   def self.verify_ssl_method

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -127,10 +127,8 @@ module ForemanRhCloud
 
         register_custom_status InventorySync::InventoryStatus
         register_custom_status InsightsClientReportStatus
-        if ForemanRhCloud.with_iop_smart_proxy?
-          register_ping_extension { ForemanRhCloud::Ping.ping }
-          register_status_extension { ForemanRhCloud::Ping.status }
-        end
+        register_ping_extension { ForemanRhCloud::Ping.ping }
+        register_status_extension { ForemanRhCloud::Ping.status }
 
         describe_host do
           overview_buttons_provider :insights_host_overview_buttons
@@ -153,7 +151,7 @@ module ForemanRhCloud
         end
 
         ::Foreman::Plugin.app_metadata_registry.register(:foreman_rh_cloud, {
-          iop: ForemanRhCloud.with_iop_smart_proxy?,
+          iop: -> { ForemanRhCloud.with_iop_smart_proxy? },
         })
 
         extend_template_helpers ForemanRhCloud::TemplateRendererHelper

--- a/test/unit/foreman_rh_cloud_iop_metadata_test.rb
+++ b/test/unit/foreman_rh_cloud_iop_metadata_test.rb
@@ -115,6 +115,22 @@ class ForemanRhCloudIopMetadataTest < ActiveSupport::TestCase
       ENV.delete('SATELLITE_RH_CLOUD_URL')
     end
 
+    test 'cert_base_url returns ENV var when set' do
+      ENV['SATELLITE_CERT_RH_CLOUD_URL'] = 'https://env-cert.cloud.test'
+
+      assert_equal 'https://env-cert.cloud.test', ForemanRhCloud.cert_base_url
+    ensure
+      ENV.delete('SATELLITE_CERT_RH_CLOUD_URL')
+    end
+
+    test 'legacy_insights_url returns ENV var when set' do
+      ENV['SATELLITE_LEGACY_INSIGHTS_URL'] = 'https://env-legacy.insights.test'
+
+      assert_equal 'https://env-legacy.insights.test', ForemanRhCloud.legacy_insights_url
+    ensure
+      ENV.delete('SATELLITE_LEGACY_INSIGHTS_URL')
+    end
+
     test 'base_url prefers IoP URL over ENV var' do
       ENV['SATELLITE_RH_CLOUD_URL'] = 'https://custom.example.com'
 
@@ -126,28 +142,59 @@ class ForemanRhCloudIopMetadataTest < ActiveSupport::TestCase
       ENV.delete('SATELLITE_RH_CLOUD_URL')
     end
 
+    test 'cert_base_url prefers IoP URL over ENV var' do
+      ENV['SATELLITE_CERT_RH_CLOUD_URL'] = 'https://env-cert.cloud.test'
+
+      create_iop_proxy
+
+      # IoP URL should take precedence
+      assert_equal 'https://iop.example.com', ForemanRhCloud.cert_base_url
+    ensure
+      ENV.delete('SATELLITE_CERT_RH_CLOUD_URL')
+    end
+
+    test 'legacy_insights_url prefers IoP URL over ENV var' do
+      ENV['SATELLITE_LEGACY_INSIGHTS_URL'] = 'https://env-legacy.insights.test'
+
+      create_iop_proxy
+
+      # IoP URL should take precedence
+      assert_equal 'https://iop.example.com', ForemanRhCloud.legacy_insights_url
+    ensure
+      ENV.delete('SATELLITE_LEGACY_INSIGHTS_URL')
+    end
+
     test 'URL methods update when IoP smart proxy is created' do
-      # Initially returns cloud URL
+      # Initially returns cloud URLs
       assert_equal 'https://cloud.redhat.com', ForemanRhCloud.base_url
+      assert_equal 'https://cert.cloud.redhat.com', ForemanRhCloud.cert_base_url
+      assert_equal 'https://cert-api.access.redhat.com', ForemanRhCloud.legacy_insights_url
 
       # Create an IoP smart proxy
       create_iop_proxy
 
-      # Should now return IoP URL
+      # Should now return IoP URL for all helpers
       assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+      assert_equal 'https://iop.example.com', ForemanRhCloud.cert_base_url
+      assert_equal 'https://iop.example.com', ForemanRhCloud.legacy_insights_url
     end
 
     test 'URL methods update when IoP smart proxy is destroyed' do
       # Create an IoP smart proxy
       proxy = create_iop_proxy
 
+      # Initially returns IoP URL for all helpers
       assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+      assert_equal 'https://iop.example.com', ForemanRhCloud.cert_base_url
+      assert_equal 'https://iop.example.com', ForemanRhCloud.legacy_insights_url
 
       # Destroy the proxy
       proxy.destroy
 
-      # Should now return cloud URL
+      # Should now return cloud URLs again
       assert_equal 'https://cloud.redhat.com', ForemanRhCloud.base_url
+      assert_equal 'https://cert.cloud.redhat.com', ForemanRhCloud.cert_base_url
+      assert_equal 'https://cert-api.access.redhat.com', ForemanRhCloud.legacy_insights_url
     end
   end
 end

--- a/test/unit/foreman_rh_cloud_iop_metadata_test.rb
+++ b/test/unit/foreman_rh_cloud_iop_metadata_test.rb
@@ -1,0 +1,153 @@
+require 'test_plugin_helper'
+
+class ForemanRhCloudIopMetadataTest < ActiveSupport::TestCase
+  setup do
+    # Clean up any existing IoP smart proxies
+    SmartProxy.unscoped.with_features('iop').destroy_all
+  end
+
+  teardown do
+    # Clean up
+    SmartProxy.unscoped.with_features('iop').destroy_all
+  end
+
+  def create_iop_proxy(url: 'https://iop.example.com')
+    feature = Feature.find_or_create_by(name: 'iop')
+    proxy = FactoryBot.create(:smart_proxy, :url => url)
+    # Clear any existing associations for this feature
+    feature.reload
+    feature.smart_proxies.clear
+    proxy.features << feature
+    proxy
+  end
+
+  describe 'plugin metadata' do
+    test 'iop metadata is false when no IoP smart proxy exists' do
+      # Ensure no IoP proxy exists
+      refute ForemanRhCloud.with_iop_smart_proxy?
+
+      # Plugin metadata should reflect this
+      metadata = ::Foreman::Plugin.app_metadata_registry.all_plugin_metadata[:foreman_rh_cloud]
+
+      # The value is a lambda, so we need to call it
+      assert_kind_of Proc, metadata[:iop]
+      refute metadata[:iop].call
+    end
+
+    test 'iop metadata is true when IoP smart proxy exists' do
+      # Create an IoP smart proxy
+      create_iop_proxy
+
+      # Verify proxy exists
+      assert ForemanRhCloud.with_iop_smart_proxy?
+
+      # Plugin metadata should reflect this
+      metadata = ::Foreman::Plugin.app_metadata_registry.all_plugin_metadata[:foreman_rh_cloud]
+
+      # The value is a lambda, so we need to call it
+      assert_kind_of Proc, metadata[:iop]
+      assert metadata[:iop].call
+    end
+
+    test 'iop metadata updates when IoP smart proxy is created' do
+      # Initially no IoP proxy
+      metadata = ::Foreman::Plugin.app_metadata_registry.all_plugin_metadata[:foreman_rh_cloud]
+      refute metadata[:iop].call
+
+      # Create an IoP smart proxy
+      create_iop_proxy
+
+      # Metadata should now return true
+      assert metadata[:iop].call
+    end
+
+    test 'iop metadata updates when IoP smart proxy is destroyed' do
+      # Create an IoP smart proxy
+      proxy = create_iop_proxy
+
+      metadata = ::Foreman::Plugin.app_metadata_registry.all_plugin_metadata[:foreman_rh_cloud]
+      assert metadata[:iop].call
+
+      # Destroy the proxy
+      proxy.destroy
+
+      # Metadata should now return false
+      refute metadata[:iop].call
+    end
+  end
+
+  describe 'URL methods' do
+    test 'base_url returns cloud URL when no IoP smart proxy exists' do
+      assert_equal 'https://cloud.redhat.com', ForemanRhCloud.base_url
+    end
+
+    test 'cert_base_url returns cloud URL when no IoP smart proxy exists' do
+      assert_equal 'https://cert.cloud.redhat.com', ForemanRhCloud.cert_base_url
+    end
+
+    test 'legacy_insights_url returns cloud URL when no IoP smart proxy exists' do
+      assert_equal 'https://cert-api.access.redhat.com', ForemanRhCloud.legacy_insights_url
+    end
+
+    test 'base_url returns IoP URL when IoP smart proxy exists' do
+      create_iop_proxy
+
+      assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+    end
+
+    test 'cert_base_url returns IoP URL when IoP smart proxy exists' do
+      create_iop_proxy
+
+      assert_equal 'https://iop.example.com', ForemanRhCloud.cert_base_url
+    end
+
+    test 'legacy_insights_url returns IoP URL when IoP smart proxy exists' do
+      create_iop_proxy
+
+      assert_equal 'https://iop.example.com', ForemanRhCloud.legacy_insights_url
+    end
+
+    test 'base_url returns ENV var when set' do
+      ENV['SATELLITE_RH_CLOUD_URL'] = 'https://custom.example.com'
+
+      assert_equal 'https://custom.example.com', ForemanRhCloud.base_url
+    ensure
+      ENV.delete('SATELLITE_RH_CLOUD_URL')
+    end
+
+    test 'base_url prefers IoP URL over ENV var' do
+      ENV['SATELLITE_RH_CLOUD_URL'] = 'https://custom.example.com'
+
+      create_iop_proxy
+
+      # IoP URL should take precedence
+      assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+    ensure
+      ENV.delete('SATELLITE_RH_CLOUD_URL')
+    end
+
+    test 'URL methods update when IoP smart proxy is created' do
+      # Initially returns cloud URL
+      assert_equal 'https://cloud.redhat.com', ForemanRhCloud.base_url
+
+      # Create an IoP smart proxy
+      create_iop_proxy
+
+      # Should now return IoP URL
+      assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+    end
+
+    test 'URL methods update when IoP smart proxy is destroyed' do
+      # Create an IoP smart proxy
+      proxy = create_iop_proxy
+
+      assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+
+      # Destroy the proxy
+      proxy.destroy
+
+      # Should now return cloud URL
+      assert_equal 'https://cloud.redhat.com', ForemanRhCloud.base_url
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

1. Evaluate `ForemanRhCloud.with_iop_smart_proxy?` in a lambda for ForemanContext app metadata registration. This ensures the UI responds immediately when switching between IoP and non-IoP.
2. Register the foreman_rh_cloud Ping extension regardless of IoP. This ensures that the advisor and vulnerability nodes will immediately appear when IoP is turned on, and disappear when turned off.

AI slop below, but I'm gonna hand-write the manual testing steps.

**IoP Metadata Runtime Evaluation:**
- Wrapped `with_iop_smart_proxy?` check in lambda for plugin metadata registration
- Fixes stale metadata when IoP smart proxy is created/destroyed without server restart
- Depends on Foreman core PR: https://github.com/theforeman/foreman/pull/10814

**Simplified URL Caching:**
- Removed complex IoP state tracking from `base_url`, `cert_base_url`, and `legacy_insights_url`
- These methods now rely on `env_or_on_premise_url` which is already IoP-aware
- Cleaner, more maintainable code that's easier to understand

**Ping Extension Improvements:**
- Removed conditional ping extension registration (always register, return `{}` when no IoP)
- Added nil safety to `iop_smart_proxy_url` with safe navigation operator
- Early return in `ping` method when no IoP proxy exists

#### Considerations taken when implementing this change?

- **Performance**: The lambda evaluation relies on ActiveRecord query cache, so performance is unchanged despite dynamic evaluation
- **Backward compatibility**: Always registering ping/status extensions ensures consistent behavior
- **Foreman core dependency**: This PR depends on the runtime Proc evaluation feature in Foreman core (PR #10814)
- **User impact**: When an IoP smart proxy is created or destroyed, the plugin metadata and URLs will now correctly reflect the current state without requiring a server restart

#### What are the testing steps for this pull request?

**Unit Tests:**
- 4 tests for plugin metadata lambda evaluation
- 10 tests for URL method dynamic behavior with IoP mode changes
- All 336 foreman_rh_cloud tests passing

**Manual Testing:**
Check out this PR and the Foreman PR --> https://github.com/theforeman/foreman/pull/10814

1. Start Foreman with IoP smart proxy
2. Infrastructure > About: Backend system status should show "advisor" and "vulnerability"
3. Main nav: Insights should have 'Recommendations' and 'Vulnerability' sub-items.
4. Both pages should load Scalprum components (you can tell because you see the "loading..." text)
5. Host details page should have Recommendations and Vulnerability tabs
6. Recommendations tab should load the Scalprum component

8. Now, go to Infrastructure > Smart Proxies and DELETE the IoP smart proxy
9. The following changes should be IMMEDIATE:
10. Infrastructure > About: Backend system status will NOT have "advisor" and "vulnerability"
11. Main nav: Insights should have 'Recommendations' and 'Inventory Upload'
12. Host details page should have only 'Recommendations', NOT 'Vulnerabilities'
13. Should NOT load Scalprum components anywhere

Now, Infrastructure > Smart Proxies > Create a new smart proxy with url `https://localhost:24443 `
Everything should immediately go back to how it was in steps 1-6.
