### PR TITLE
Release 13.0.11

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '13.0.10'.freeze
+  VERSION = '13.0.11'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "13.0.10",
+  "version": "13.0.11",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Bump the ForemanRhCloud plugin and npm package versions for the 13.0.11 release.

Build:
- Update Ruby gem version constant to 13.0.11.
- Update npm package.json version to 13.0.11.