### PR TITLE
Fix broken cloud connector docs link

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.2.13'.freeze
+  VERSION = '12.2.14'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.2.13",
+  "version": "12.2.14",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/__tests__/__snapshots__/PageTitle.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/__tests__/__snapshots__/PageTitle.test.js.snap
@@ -32,7 +32,7 @@ exports[`PageTitle rendering render without Props 1`] = `
             Actions history
           </DropdownItem>,
           <DropdownItem
-            href="/links/manual/?root_url=https%3A%2F%2Faccess.redhat.com%2Fdocumentation%2Fen-us%2Fred_hat_insights%2F2023%2Fhtml%2Fred_hat_insights_remediations_guide%2Fhost-communication-with-insights_red-hat-insights-remediation-guide%23uploading-satellite-host-inventory-to-insights_configuring-satellite-cloud-connector"
+            href="/links/manual/?root_url=https%3A%2F%2Fdocs.redhat.com%2Fen%2Fdocumentation%2Fred_hat_lightspeed%2F1-latest%2Fhtml-single%2Fred_hat_lightspeed_remediations_guide%2Findex"
             ouiaId="inventory-documentation-button"
             rel="noopener noreferrer"
             target="_blank"

--- a/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
+++ b/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
@@ -7,7 +7,7 @@ export const inventoryUrl = path =>
 export const getInventoryDocsUrl = () =>
   foremanUrl(
     `/links/manual/?root_url=${URI.encode(
-      'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/red_hat_insights_remediations_guide/host-communication-with-insights_red-hat-insights-remediation-guide#uploading-satellite-host-inventory-to-insights_configuring-satellite-cloud-connector'
+      'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html-single/red_hat_lightspeed_remediations_guide/index'
     )}`
   );
 

--- a/webpack/ForemanInventoryUpload/__tests__/__snapshots__/ForemanInventoryHelpers.test.js.snap
+++ b/webpack/ForemanInventoryUpload/__tests__/__snapshots__/ForemanInventoryHelpers.test.js.snap
@@ -2,4 +2,4 @@
 
 exports[`ForemanInventoryUpload helpers should return inventory Url 1`] = `"/foreman_inventory_upload/test_path"`;
 
-exports[`ForemanInventoryUpload helpers should return inventory docs url 1`] = `"/links/manual/?root_url=https%3A%2F%2Faccess.redhat.com%2Fdocumentation%2Fen-us%2Fred_hat_insights%2F2023%2Fhtml%2Fred_hat_insights_remediations_guide%2Fhost-communication-with-insights_red-hat-insights-remediation-guide%23uploading-satellite-host-inventory-to-insights_configuring-satellite-cloud-connector"`;
+exports[`ForemanInventoryUpload helpers should return inventory docs url 1`] = `"/links/manual/?root_url=https%3A%2F%2Fdocs.redhat.com%2Fen%2Fdocumentation%2Fred_hat_lightspeed%2F1-latest%2Fhtml-single%2Fred_hat_lightspeed_remediations_guide%2Findex"`;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Cherrypicks https://github.com/theforeman/foreman_rh_cloud/pull/1133

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Update RH Cloud plugin and UI to use a Foreman context-based IoP configuration flag, adjust behavior of affected components accordingly, and bump the plugin version.

Enhancements:
- Replace API-based advisor engine configuration hook with a Foreman context-driven IoP flag and wire it through inventory, insights, and vulnerability components.
- Adjust toolbar buttons, page header, insights views, and remediation modal to hide or alter controls when running in IoP mode.
- Register IoP state in the plugin app metadata registry and mark the insights column as relevant only in IoP contexts.
- Allow inventory host sync to always run regardless of IoP smart proxy presence and update the inventory documentation link URL.

Build:
- Bump Ruby gem and npm package versions from 12.2.13 to 12.2.14.

Documentation:
- Update the inventory upload documentation link to point to the latest Red Hat Lightspeed remediations guide.

Tests:
- Rewrite and expand Jest/RTL tests for page header, toolbar buttons, CVE count cell, and insights table to cover IoP mode behavior via Foreman context and store-backed config.

## Summary by Sourcery

Bump the RH Cloud plugin to version 12.2.14 and update the inventory documentation link to the latest Red Hat Lightspeed remediations guide.

Enhancements:
- Update the inventory upload documentation URL to point to the current Red Hat Lightspeed remediations guide.

Build:
- Increase Ruby gem and npm package versions from 12.2.13 to 12.2.14.

Documentation:
- Refresh the inventory upload help link to reference the latest Lightspeed remediations documentation.

Tests:
- Update Jest snapshot files to reflect the new documentation URL.