### PR TITLE
Display 'Analysis disabled' in CVE column

### DIFF
--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -74,7 +74,7 @@ const hostsIndexColumnExtensions = [
     columnName: 'cves_count',
     title: __('Total CVEs'),
     wrapper: hostDetails => <CVECountCell hostDetails={hostDetails} />,
-    weight: 2600,
+    weight: 1600,
     tableName: 'hosts',
     categoryName: insightsCategoryName,
     categoryKey: 'insights',

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { UnknownIcon } from '@patternfly/react-icons';
+import { translate as __ } from 'foremanReact/common/I18n';
 import { Link } from 'react-router-dom';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
 import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
 import { useIopConfig } from '../common/Hooks/ConfigHooks';
 
@@ -24,24 +25,23 @@ export const CVECountCell = ({ hostDetails }) => {
     }
   );
 
-  if (!isIopEnabled) {
-    return <UnknownIcon />;
+  if (!isIopEnabled || uuid === undefined) {
+    return '—';
   }
 
-  if (uuid === undefined) {
-    return <UnknownIcon />;
-  }
-
-  // eslint-disable-next-line camelcase
-  const { cve_count } = (response.response?.data || [])[0]?.attributes || {};
-
-  const cveLink = (
-    // eslint-disable-next-line camelcase
-    <Link to={`hosts/${hostDetails.name}#/Vulnerabilities`}>{cve_count}</Link>
+  const { cveCount, optOut } = propsToCamelCase(
+    (response.response?.data || [])[0]?.attributes || {}
   );
 
-  // eslint-disable-next-line camelcase
-  return cve_count === undefined ? <UnknownIcon /> : cveLink;
+  if (optOut === true) {
+    return __('Analysis disabled');
+  }
+
+  const cveLink = (
+    <Link to={`hosts/${hostDetails.name}#/Vulnerabilities`}>{cveCount}</Link>
+  );
+
+  return cveCount === undefined ? '—' : cveLink;
 };
 
 CVECountCell.propTypes = {

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { rtlHelpers } from 'foremanReact/common/rtlTestHelpers';
 import { API } from 'foremanReact/redux/API';
 import { CVECountCell } from '../CVECountCell';
@@ -54,10 +55,10 @@ describe('CVECountCell', () => {
         },
       },
     });
-    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
-  it('renders UnknownIcon when IoP is not enabled', () => {
+  it('renders — when IoP is not enabled', () => {
     renderWithStore(<CVECountCell hostDetails={hostDetailsMock} />, {
       router: {
         location: {
@@ -74,10 +75,10 @@ describe('CVECountCell', () => {
         },
       },
     });
-    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
-  it('renders UnknownIcon when IoP is enabled but CVE API call fails', () => {
+  it('renders — when IoP is enabled but CVE API call fails', () => {
     // Mock CVE API failure - override the global mock for this test
     API.get.mockImplementationOnce(async () => {
       throw new Error('CVE API call failed');
@@ -104,11 +105,11 @@ describe('CVECountCell', () => {
         },
       },
     });
-    // Should render UnknownIcon when CVE API fails
-    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    // Should render em-dash when CVE API fails
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
-  it('renders UnknownIcon when IoP is undefined (API call pending)', () => {
+  it('renders — when IoP is undefined (API call pending)', () => {
     renderWithStore(<CVECountCell hostDetails={hostDetailsMock} />, {
       router: {
         location: {
@@ -124,6 +125,6 @@ describe('CVECountCell', () => {
         },
       },
     });
-    expect(screen.getByRole('img', { hidden: true })).toBeTruthy();
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 });

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
@@ -1,24 +1,31 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { rtlHelpers } from 'foremanReact/common/rtlTestHelpers';
-import { API } from 'foremanReact/redux/API';
+import { Provider } from 'react-redux';
+import { ConnectedRouter } from 'connected-react-router';
+import { createMemoryHistory } from 'history';
+import configureMockStore from 'redux-mock-store';
+import { STATUS } from 'foremanReact/constants';
+import * as APIHooks from 'foremanReact/common/hooks/API/APIHooks';
+import * as ConfigHooks from '../../common/Hooks/ConfigHooks';
 import { CVECountCell } from '../CVECountCell';
 
-jest.mock('foremanReact/redux/API');
+jest.mock('foremanReact/common/hooks/API/APIHooks');
 jest.mock('../../common/Hooks/ConfigHooks');
 
-const { renderWithStore } = rtlHelpers;
-
-API.get.mockImplementation(async () => ({
-  data: [
-    {
-      attributes: {
-        cve_count: 1,
-      },
+const mockStore = configureMockStore();
+const history = createMemoryHistory();
+const store = mockStore({
+  router: {
+    location: {
+      pathname: '/',
+      search: '',
+      hash: '',
+      state: null,
     },
-  ],
-}));
+    action: 'POP',
+  },
+});
 
 const hostDetailsMock = {
   name: 'test-host.example.com',
@@ -27,104 +34,121 @@ const hostDetailsMock = {
   },
 };
 
+const renderComponent = (props = {}) => {
+  const allProps = {
+    hostDetails: hostDetailsMock,
+    ...props,
+  };
+
+  return render(
+    <Provider store={store}>
+      <ConnectedRouter history={history}>
+        <CVECountCell {...allProps} />
+      </ConnectedRouter>
+    </Provider>
+  );
+};
+
 describe('CVECountCell', () => {
-  afterEach(() => {
+  beforeEach(() => {
+    store.clearActions();
     jest.clearAllMocks();
   });
 
   it('renders an empty cves count column when no subscription UUID', () => {
-    const hostDetailsMockIoP = {
+    ConfigHooks.useIopConfig.mockReturnValue(true);
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.RESOLVED,
+      response: null,
+    });
+
+    const hostDetailsMockNoUuid = {
       name: 'test-host.example.com',
       subscription_facet_attributes: {
         uuid: null, // no subscription
       },
     };
-    renderWithStore(<CVECountCell hostDetails={hostDetailsMockIoP} />, {
-      router: {
-        location: {
-          pathname: '/',
-          search: '',
-          hash: '',
-          query: {},
-        },
-      },
-      API: {
-        ADVISOR_ENGINE_CONFIG: {
-          response: { use_iop_mode: true },
-          status: 'RESOLVED',
-        },
-      },
-    });
+
+    renderComponent({ hostDetails: hostDetailsMockNoUuid });
     expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('renders — when IoP is not enabled', () => {
-    renderWithStore(<CVECountCell hostDetails={hostDetailsMock} />, {
-      router: {
-        location: {
-          pathname: '/',
-          search: '',
-          hash: '',
-          query: {},
-        },
-      },
-      API: {
-        ADVISOR_ENGINE_CONFIG: {
-          response: { use_iop_mode: false },
-          status: 'RESOLVED',
-        },
-      },
+    ConfigHooks.useIopConfig.mockReturnValue(false);
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.RESOLVED,
+      response: null,
     });
+
+    renderComponent();
     expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('renders — when IoP is enabled but CVE API call fails', () => {
-    // Mock CVE API failure - override the global mock for this test
-    API.get.mockImplementationOnce(async () => {
-      throw new Error('CVE API call failed');
+    ConfigHooks.useIopConfig.mockReturnValue(true);
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.ERROR,
+      response: null,
     });
 
-    renderWithStore(<CVECountCell hostDetails={hostDetailsMock} />, {
-      router: {
-        location: {
-          pathname: '/',
-          search: '',
-          hash: '',
-          query: {},
-        },
-      },
-      API: {
-        ADVISOR_ENGINE_CONFIG: {
-          response: { use_iop_mode: true },
-          status: 'RESOLVED',
-        },
-        // Mock the API failure state for the CVE endpoint
-        [`HOST_CVE_COUNT_${hostDetailsMock.subscription_facet_attributes.uuid}`]: {
-          status: 'ERROR',
-          error: 'CVE API call failed',
-        },
-      },
-    });
-    // Should render em-dash when CVE API fails
+    renderComponent();
     expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   it('renders — when IoP is undefined (API call pending)', () => {
-    renderWithStore(<CVECountCell hostDetails={hostDetailsMock} />, {
-      router: {
-        location: {
-          pathname: '/',
-          search: '',
-          hash: '',
-          query: {},
-        },
-      },
-      API: {
-        ADVISOR_ENGINE_CONFIG: {
-          status: 'PENDING',
-        },
+    ConfigHooks.useIopConfig.mockReturnValue(undefined);
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.PENDING,
+      response: null,
+    });
+
+    renderComponent();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('renders "Analysis disabled" when opt_out is true', () => {
+    ConfigHooks.useIopConfig.mockReturnValue(true);
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.RESOLVED,
+      response: {
+        data: [
+          {
+            attributes: {
+              opt_out: true,
+            },
+          },
+        ],
       },
     });
-    expect(screen.getByText('—')).toBeInTheDocument();
+
+    renderComponent();
+    expect(screen.getByText('Analysis disabled')).toBeInTheDocument();
+  });
+
+  it('renders CVE count link when valid count is returned', () => {
+    ConfigHooks.useIopConfig.mockReturnValue(true);
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.RESOLVED,
+      response: {
+        data: [
+          {
+            attributes: {
+              cve_count: 1,
+            },
+          },
+        ],
+      },
+    });
+
+    renderComponent();
+
+    // Should render a link with the CVE count
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent('1');
+    expect(link).toHaveAttribute(
+      'href',
+      `/hosts/${hostDetailsMock.name}#/Vulnerabilities`
+    );
   });
 });

--- a/webpack/__mocks__/foremanReact/common/helpers.js
+++ b/webpack/__mocks__/foremanReact/common/helpers.js
@@ -1,3 +1,14 @@
+import camelCase from 'lodash/camelCase';
+
 export const getURIQuery = jest.fn(() => ({}));
 
 export const noop = Function.prototype;
+
+export const propsToCamelCase = ob => {
+  if (typeof ob !== 'object' || ob === null) return ob;
+
+  return Object.keys(ob).reduce((memo, key) => {
+    memo[camelCase(key)] = ob[key];
+    return memo;
+  }, {});
+};


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Hey, we've got some upgrades to the __Total CVEs__ column for IoP-enabled systems!

<img width="3058" height="1854" alt="image" src="https://github.com/user-attachments/assets/7309a1d3-d229-494b-94cb-2f96b96a86da" />



1. Display "Analysis disabled" for hosts that have vulnerability analysis disabled
2. Instead of a QuestionIcon, display '—' like we do for other columns. This will show for unregistered hosts, or when data is missing.
3. Change the weight of the Total CVEs column so that 'Content view environments' doesn't show up between Recommendations and Total CVEs
4. use propsToCamelCase so we can stop disabling that silly eslint rule

#### Considerations taken when implementing this change?

everything is well considered!!

This code is :sparkles: artisan :sparkles: and no AI was used in its creation

#### What are the testing steps for this pull request?

Hosts > All Hosts > Manage Columns > add the Total CVEs column

```js
// CVECountCell.js line 36
// Change this 
if (optOut === true) {
// to this
if (true) {
```

Alternatively, you could figure out the proper curl command to send IoP a `[PATCH /api/vulnerability/v1/systems/opt_out](https://console.redhat.com/docs/api/vulnerability/v1#operations-default-manager\.system_handler\.PatchBulkSystemsOptOut\.patch)`

You should now see "Analysis disabled" for your host.
Additionally, you should see '—' and NOT a QuestionIcon for unregistered hosts.
You should continue to see a number of vulnerabilities (with link) for hosts with vulnerabilities.
