### PR TITLE
Add vulnerability analysis actions to host table row kebab menu

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,7 +54,8 @@
           "theforeman",
           "tooltip",
           "unmount",
-          "vnd"
+          "vnd",
+          "vuln"
         ],
         "minLength": 3
       }

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -79,9 +79,10 @@ const hostsIndexColumnExtensions = [
     categoryName: insightsCategoryName,
     categoryKey: 'insights',
     isSorted: false,
-    // eslint-disable-next-line camelcase
     // Show column unless IoP is explicitly disabled (handles undefined during loading)
-    isRelevant: contextData => contextData?.metadata?.foreman_rh_cloud?.iop !== false,
+    isRelevant: contextData =>
+      // eslint-disable-next-line camelcase
+      contextData?.metadata?.foreman_rh_cloud?.iop !== false,
   },
 ];
 

--- a/webpack/ForemanColumnExtensions/index.js
+++ b/webpack/ForemanColumnExtensions/index.js
@@ -80,7 +80,8 @@ const hostsIndexColumnExtensions = [
     categoryKey: 'insights',
     isSorted: false,
     // eslint-disable-next-line camelcase
-    isRelevant: contextData => contextData?.metadata?.foreman_rh_cloud?.iop,
+    // Show column unless IoP is explicitly disabled (handles undefined during loading)
+    isRelevant: contextData => contextData?.metadata?.foreman_rh_cloud?.iop !== false,
   },
 ];
 

--- a/webpack/HostsIndexExtensions/VulnerabilityAnalysisActions.js
+++ b/webpack/HostsIndexExtensions/VulnerabilityAnalysisActions.js
@@ -1,5 +1,5 @@
 import { translate as __ } from 'foremanReact/common/I18n';
-import { patch } from 'foremanReact/redux/API';
+import { patch, get } from 'foremanReact/redux/API';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import store from 'foremanReact/redux';
 import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
@@ -8,9 +8,11 @@ import { updateHostVulnerabilityOptOut } from './hostVulnerabilityStoreUtils';
 const vulnerabilityApiPath = path =>
   insightsCloudUrl(`api/vulnerability/v1/${path}`);
 
-const handleToggle = (uuid, newOptOutValue, hostId) =>
-  patch({
-    key: `HOST_CVE_COUNT_${uuid}`,
+const handleToggle = (uuid, newOptOutValue, hostId) => {
+  const cacheKey = `HOST_CVE_COUNT_${uuid}`;
+
+  return patch({
+    key: cacheKey,
     url: vulnerabilityApiPath('systems/opt_out'),
     params: {
       inventory_id: uuid,
@@ -21,17 +23,27 @@ const handleToggle = (uuid, newOptOutValue, hostId) =>
     },
 
     // Update CVE API cache data to reflect new opt_out status
-    // This will cause CVECountCell to re-render with updated data
-    updateData: prevState => ({
-      ...prevState,
-      data: prevState.data.map(system => ({
-        ...system,
-        attributes: {
-          ...system.attributes,
-          opt_out: newOptOutValue,
-        },
-      })),
-    }),
+    // When disabling: optimistically update opt_out (cve_count will be null anyway)
+    // When enabling: skip optimistic update - we'll invalidate to fetch fresh data
+    updateData: newOptOutValue
+      ? prevState => {
+          // Disabling - safe to optimistically update
+          if (!prevState?.data) {
+            return prevState;
+          }
+
+          return {
+            ...prevState,
+            data: prevState.data.map(system => ({
+              ...system,
+              attributes: {
+                ...system.attributes,
+                opt_out: true,
+              },
+            })),
+          };
+        }
+      : undefined, // Enabling - skip optimistic update, rely on cache invalidation below
 
     // Show success toast
     successToast: () =>
@@ -43,6 +55,16 @@ const handleToggle = (uuid, newOptOutValue, hostId) =>
     // This ensures kebab actions recompute with correct opt_out value
     handleSuccess: () => {
       updateHostVulnerabilityOptOut(hostId, newOptOutValue);
+
+      // When enabling, refetch to get actual CVE count (not null)
+      if (!newOptOutValue) {
+        store.dispatch(
+          get({
+            key: cacheKey,
+            url: vulnerabilityApiPath(`systems?uuid=${uuid}`),
+          })
+        );
+      }
     },
 
     // Extract detail from JSON:API errors array if present
@@ -53,6 +75,7 @@ const handleToggle = (uuid, newOptOutValue, hostId) =>
       return __('Failed to update vulnerability analysis status');
     },
   });
+};
 
 const getVulnerabilityAnalysisActions = hostDetails => {
   // Check if we're in IoP mode by looking at insights attributes

--- a/webpack/HostsIndexExtensions/VulnerabilityAnalysisActions.js
+++ b/webpack/HostsIndexExtensions/VulnerabilityAnalysisActions.js
@@ -1,0 +1,158 @@
+import { translate as __ } from 'foremanReact/common/I18n';
+import { addToast } from 'foremanReact/components/ToastsList';
+import { propsToCamelCase } from 'foremanReact/common/helpers';
+import store from 'foremanReact/redux';
+import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
+
+const vulnerabilityApiPath = path =>
+  insightsCloudUrl(`api/vulnerability/v1/${path}`);
+
+const handleToggle = async (uuid, newOptOutValue, hostId) => {
+  try {
+    const csrfToken =
+      document.querySelector('meta[name="csrf-token"]')?.content || '';
+
+    const response = await fetch(vulnerabilityApiPath('systems/opt_out'), {
+      method: 'PATCH',
+      headers: {
+        // eslint-disable-next-line spellcheck/spell-checker
+        'Content-Type': 'application/vnd.api+json',
+        'X-CSRF-Token': csrfToken,
+      },
+      body: JSON.stringify({
+        inventory_id: uuid,
+        opt_out: newOptOutValue,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        errorText || 'Failed to update vulnerability analysis status'
+      );
+    }
+
+    // Show success toast
+    store.dispatch(
+      addToast({
+        type: 'success',
+        message: newOptOutValue
+          ? __('Vulnerability analysis disabled')
+          : __('Vulnerability analysis enabled'),
+      })
+    );
+
+    const state = store.getState();
+
+    // Update CVE API cache data to reflect new opt_out status
+    // This will cause CVECountCell to re-render with updated data
+    const apiKey = `HOST_CVE_COUNT_${uuid}`;
+    const cveData = state.API?.[apiKey];
+    if (cveData?.response?.data) {
+      store.dispatch({
+        type: `${apiKey}_SUCCESS`,
+        key: apiKey,
+        response: {
+          ...cveData.response,
+          data: cveData.response.data.map(system => ({
+            ...system,
+            attributes: {
+              ...system.attributes,
+              opt_out: newOptOutValue,
+            },
+          })),
+        },
+      });
+    }
+
+    // Update HOSTS Redux data to trigger table re-render
+    // This ensures kebab actions recompute with correct opt_out value
+    const hostsData = state.API?.HOSTS;
+    if (hostsData?.response?.results && hostId) {
+      store.dispatch({
+        type: 'HOSTS_SUCCESS',
+        key: 'HOSTS',
+        response: {
+          ...hostsData.response,
+          results: hostsData.response.results.map(host => {
+            if (host.id === hostId) {
+              return {
+                ...host,
+                insights_attributes: {
+                  ...host.insights_attributes,
+                  vulnerability_opt_out: newOptOutValue,
+                },
+              };
+            }
+            return host;
+          }),
+        },
+      });
+    }
+  } catch (error) {
+    const errorMessage =
+      error.message || __('Failed to update vulnerability analysis status');
+    store.dispatch(
+      addToast({
+        type: 'error',
+        message: errorMessage,
+      })
+    );
+  }
+};
+
+const getVulnerabilityAnalysisActions = hostDetails => {
+  // Check if we're in IoP mode by looking at insights attributes
+  // eslint-disable-next-line camelcase
+  const useIopMode = hostDetails?.insights_attributes?.use_iop_mode;
+
+  if (!useIopMode) {
+    return [];
+  }
+
+  // Check if host has subscription UUID (is registered)
+  // eslint-disable-next-line camelcase
+  const uuid = hostDetails?.subscription_facet_attributes?.uuid;
+
+  if (!uuid) {
+    return [];
+  }
+
+  // Try to get opt_out from host object (updated by CVECountCell or previous toggle)
+  let optOut = hostDetails?.insights_attributes?.vulnerability_opt_out;
+
+  // Fallback: check CVE API cache if not yet set on host object
+  if (optOut === undefined) {
+    const state = store.getState();
+    const apiData = state.API?.[`HOST_CVE_COUNT_${uuid}`];
+
+    // If API returned empty data, no system record exists - don't show actions
+    if (apiData?.response?.data && apiData.response.data.length === 0) {
+      return [];
+    }
+
+    optOut = propsToCamelCase(
+      (apiData?.response?.data || [])[0]?.attributes || {}
+    ).optOut;
+  }
+
+  // If still undefined (data not loaded yet), don't show actions until we have data
+  // Once CVE loads, it will update host object and trigger re-render with correct action
+  if (optOut === undefined) {
+    return [];
+  }
+
+  // Show correct action based on opt_out status
+  const actionLabel = optOut
+    ? __('Enable vulnerability analysis')
+    : __('Disable vulnerability analysis');
+
+  return [
+    {
+      title: actionLabel,
+      onClick: () => handleToggle(uuid, !optOut, hostDetails.id),
+    },
+  ];
+};
+
+export default getVulnerabilityAnalysisActions;

--- a/webpack/HostsIndexExtensions/VulnerabilityAnalysisActions.js
+++ b/webpack/HostsIndexExtensions/VulnerabilityAnalysisActions.js
@@ -1,5 +1,5 @@
 import { translate as __ } from 'foremanReact/common/I18n';
-import { addToast } from 'foremanReact/components/ToastsList';
+import { patch } from 'foremanReact/redux/API';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import store from 'foremanReact/redux';
 import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
@@ -8,92 +8,51 @@ import { updateHostVulnerabilityOptOut } from './hostVulnerabilityStoreUtils';
 const vulnerabilityApiPath = path =>
   insightsCloudUrl(`api/vulnerability/v1/${path}`);
 
-const handleToggle = async (uuid, newOptOutValue, hostId) => {
-  try {
-    const csrfToken =
-      document.querySelector('meta[name="csrf-token"]')?.content || '';
-
-    const response = await fetch(vulnerabilityApiPath('systems/opt_out'), {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/vnd.api+json', // eslint-disable-line spellcheck/spell-checker
-        'X-CSRF-Token': csrfToken,
-      },
-      body: JSON.stringify({
-        inventory_id: uuid,
-        opt_out: newOptOutValue,
-      }),
-    });
-
-    if (!response.ok) {
-      let errorMessage = __('Failed to update vulnerability analysis status');
-
-      try {
-        const errorBody = await response.json();
-        // Extract detail from JSON:API errors array if present
-        if (
-          errorBody &&
-          Array.isArray(errorBody.errors) &&
-          errorBody.errors[0] &&
-          typeof errorBody.errors[0].detail === 'string' &&
-          errorBody.errors[0].detail.trim() !== ''
-        ) {
-          errorMessage = errorBody.errors[0].detail;
-        }
-      } catch (e) {
-        // JSON parse failed, use generic message
-      }
-
-      throw new Error(errorMessage);
-    }
-
-    // Show success toast
-    store.dispatch(
-      addToast({
-        type: 'success',
-        message: newOptOutValue
-          ? __('Vulnerability analysis disabled')
-          : __('Vulnerability analysis enabled'),
-      })
-    );
-
-    const state = store.getState();
+const handleToggle = (uuid, newOptOutValue, hostId) =>
+  patch({
+    key: `HOST_CVE_COUNT_${uuid}`,
+    url: vulnerabilityApiPath('systems/opt_out'),
+    params: {
+      inventory_id: uuid,
+      opt_out: newOptOutValue,
+    },
+    headers: {
+      'Content-Type': 'application/vnd.api+json', // eslint-disable-line spellcheck/spell-checker
+    },
 
     // Update CVE API cache data to reflect new opt_out status
     // This will cause CVECountCell to re-render with updated data
-    const apiKey = `HOST_CVE_COUNT_${uuid}`;
-    const cveData = state.API?.[apiKey];
-    if (cveData?.response?.data) {
-      store.dispatch({
-        type: `${apiKey}_SUCCESS`,
-        key: apiKey,
-        response: {
-          ...cveData.response,
-          data: cveData.response.data.map(system => ({
-            ...system,
-            attributes: {
-              ...system.attributes,
-              opt_out: newOptOutValue,
-            },
-          })),
+    updateData: prevState => ({
+      ...prevState,
+      data: prevState.data.map(system => ({
+        ...system,
+        attributes: {
+          ...system.attributes,
+          opt_out: newOptOutValue,
         },
-      });
-    }
+      })),
+    }),
+
+    // Show success toast
+    successToast: () =>
+      newOptOutValue
+        ? __('Vulnerability analysis disabled')
+        : __('Vulnerability analysis enabled'),
 
     // Update HOSTS Redux data to trigger table re-render
     // This ensures kebab actions recompute with correct opt_out value
-    updateHostVulnerabilityOptOut(hostId, newOptOutValue);
-  } catch (error) {
-    const errorMessage =
-      error.message || __('Failed to update vulnerability analysis status');
-    store.dispatch(
-      addToast({
-        type: 'error',
-        message: errorMessage,
-      })
-    );
-  }
-};
+    handleSuccess: () => {
+      updateHostVulnerabilityOptOut(hostId, newOptOutValue);
+    },
+
+    // Extract detail from JSON:API errors array if present
+    errorToast: error => {
+      if (error.response?.data?.errors?.[0]?.detail) {
+        return error.response.data.errors[0].detail;
+      }
+      return __('Failed to update vulnerability analysis status');
+    },
+  });
 
 const getVulnerabilityAnalysisActions = hostDetails => {
   // Check if we're in IoP mode by looking at insights attributes
@@ -147,7 +106,8 @@ const getVulnerabilityAnalysisActions = hostDetails => {
   return [
     {
       title: actionLabel,
-      onClick: () => handleToggle(uuid, !optOut, hostDetails.id),
+      onClick: () =>
+        store.dispatch(handleToggle(uuid, !optOut, hostDetails.id)),
     },
   ];
 };

--- a/webpack/HostsIndexExtensions/VulnerabilityAnalysisActions.js
+++ b/webpack/HostsIndexExtensions/VulnerabilityAnalysisActions.js
@@ -3,6 +3,7 @@ import { addToast } from 'foremanReact/components/ToastsList';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import store from 'foremanReact/redux';
 import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
+import { updateHostVulnerabilityOptOut } from './hostVulnerabilityStoreUtils';
 
 const vulnerabilityApiPath = path =>
   insightsCloudUrl(`api/vulnerability/v1/${path}`);
@@ -15,8 +16,7 @@ const handleToggle = async (uuid, newOptOutValue, hostId) => {
     const response = await fetch(vulnerabilityApiPath('systems/opt_out'), {
       method: 'PATCH',
       headers: {
-        // eslint-disable-next-line spellcheck/spell-checker
-        'Content-Type': 'application/vnd.api+json',
+        'Content-Type': 'application/vnd.api+json', // eslint-disable-line spellcheck/spell-checker
         'X-CSRF-Token': csrfToken,
       },
       body: JSON.stringify({
@@ -26,10 +26,25 @@ const handleToggle = async (uuid, newOptOutValue, hostId) => {
     });
 
     if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(
-        errorText || 'Failed to update vulnerability analysis status'
-      );
+      let errorMessage = __('Failed to update vulnerability analysis status');
+
+      try {
+        const errorBody = await response.json();
+        // Extract detail from JSON:API errors array if present
+        if (
+          errorBody &&
+          Array.isArray(errorBody.errors) &&
+          errorBody.errors[0] &&
+          typeof errorBody.errors[0].detail === 'string' &&
+          errorBody.errors[0].detail.trim() !== ''
+        ) {
+          errorMessage = errorBody.errors[0].detail;
+        }
+      } catch (e) {
+        // JSON parse failed, use generic message
+      }
+
+      throw new Error(errorMessage);
     }
 
     // Show success toast
@@ -67,28 +82,7 @@ const handleToggle = async (uuid, newOptOutValue, hostId) => {
 
     // Update HOSTS Redux data to trigger table re-render
     // This ensures kebab actions recompute with correct opt_out value
-    const hostsData = state.API?.HOSTS;
-    if (hostsData?.response?.results && hostId) {
-      store.dispatch({
-        type: 'HOSTS_SUCCESS',
-        key: 'HOSTS',
-        response: {
-          ...hostsData.response,
-          results: hostsData.response.results.map(host => {
-            if (host.id === hostId) {
-              return {
-                ...host,
-                insights_attributes: {
-                  ...host.insights_attributes,
-                  vulnerability_opt_out: newOptOutValue,
-                },
-              };
-            }
-            return host;
-          }),
-        },
-      });
-    }
+    updateHostVulnerabilityOptOut(hostId, newOptOutValue);
   } catch (error) {
     const errorMessage =
       error.message || __('Failed to update vulnerability analysis status');
@@ -119,6 +113,7 @@ const getVulnerabilityAnalysisActions = hostDetails => {
   }
 
   // Try to get opt_out from host object (updated by CVECountCell or previous toggle)
+  // eslint-disable-next-line camelcase
   let optOut = hostDetails?.insights_attributes?.vulnerability_opt_out;
 
   // Fallback: check CVE API cache if not yet set on host object
@@ -131,9 +126,11 @@ const getVulnerabilityAnalysisActions = hostDetails => {
       return [];
     }
 
-    optOut = propsToCamelCase(
+    const attributes = propsToCamelCase(
       (apiData?.response?.data || [])[0]?.attributes || {}
-    ).optOut;
+    );
+    // eslint-disable-next-line prefer-destructuring
+    optOut = attributes.optOut;
   }
 
   // If still undefined (data not loaded yet), don't show actions until we have data

--- a/webpack/HostsIndexExtensions/__tests__/VulnerabilityAnalysisActions.test.js
+++ b/webpack/HostsIndexExtensions/__tests__/VulnerabilityAnalysisActions.test.js
@@ -1,0 +1,461 @@
+// Create mocks
+const mockGetState = jest.fn();
+const mockDispatch = jest.fn();
+const mockPatch = jest.fn();
+
+// Mock modules
+jest.mock('../hostVulnerabilityStoreUtils');
+jest.mock(
+  'foremanReact/redux',
+  () => ({
+    __esModule: true,
+    default: {
+      getState: () => mockGetState(),
+      dispatch: action => mockDispatch(action),
+    },
+  }),
+  { virtual: true }
+);
+jest.mock(
+  'foremanReact/redux/API',
+  () => ({
+    patch: (...args) => mockPatch(...args),
+  }),
+  { virtual: true }
+);
+
+// Import after mocking
+import * as storeUtils from '../hostVulnerabilityStoreUtils';
+import getVulnerabilityAnalysisActions from '../VulnerabilityAnalysisActions';
+
+describe('VulnerabilityAnalysisActions', () => {
+  beforeEach(() => {
+    mockGetState.mockReturnValue({ API: {} });
+    mockDispatch.mockImplementation(action => action);
+    jest.clearAllMocks();
+  });
+
+  describe('getVulnerabilityAnalysisActions', () => {
+    it('returns empty array when not in IoP mode', () => {
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: false,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+
+      expect(actions).toEqual([]);
+    });
+
+    it('returns empty array when host has no subscription UUID', () => {
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+        },
+        subscription_facet_attributes: {
+          uuid: null,
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+
+      expect(actions).toEqual([]);
+    });
+
+    it('returns empty array when API returned empty data (no system record)', () => {
+      mockGetState.mockReturnValue({
+        API: {
+          'HOST_CVE_COUNT_test-uuid': {
+            response: {
+              data: [], // Empty array means no system record exists
+            },
+          },
+        },
+      });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+
+      expect(actions).toEqual([]);
+    });
+
+    it('returns empty array when opt_out is undefined (data not loaded yet)', () => {
+      mockGetState.mockReturnValue({
+        API: {
+          'HOST_CVE_COUNT_test-uuid': {
+            response: null,
+          },
+        },
+      });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+
+      expect(actions).toEqual([]);
+    });
+
+    it('returns "Enable vulnerability analysis" action when opt_out is true', () => {
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: true,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0].title).toBe('Enable vulnerability analysis');
+      expect(actions[0].onClick).toBeDefined();
+
+      // Trigger onClick to verify it dispatches correctly
+      actions[0].onClick();
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'MOCK_PATCH_ACTION',
+      });
+      expect(mockPatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'HOST_CVE_COUNT_test-uuid',
+          params: {
+            inventory_id: 'test-uuid',
+            opt_out: false, // Should toggle to false
+          },
+        })
+      );
+    });
+
+    it('returns "Disable vulnerability analysis" action when opt_out is false', () => {
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: false,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0].title).toBe('Disable vulnerability analysis');
+      expect(actions[0].onClick).toBeDefined();
+
+      // Trigger onClick to verify it dispatches correctly
+      actions[0].onClick();
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'MOCK_PATCH_ACTION',
+      });
+      expect(mockPatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'HOST_CVE_COUNT_test-uuid',
+          params: {
+            inventory_id: 'test-uuid',
+            opt_out: true, // Should toggle to true
+          },
+        })
+      );
+    });
+
+    it('falls back to CVE API cache when opt_out not set on host object', () => {
+      mockGetState.mockReturnValue({
+        API: {
+          'HOST_CVE_COUNT_test-uuid': {
+            response: {
+              data: [
+                {
+                  attributes: {
+                    opt_out: true,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          // No vulnerability_opt_out set
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+
+      expect(actions).toHaveLength(1);
+      expect(actions[0].title).toBe('Enable vulnerability analysis');
+    });
+  });
+
+  describe('handleToggle action creator', () => {
+    it('creates patch action with correct parameters', () => {
+      const mockPatchAction = { type: 'MOCK_PATCH_ACTION' };
+      mockPatch.mockReturnValue(mockPatchAction);
+
+      const hostDetails = {
+        id: 123,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: false,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid-456',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick();
+
+      expect(mockPatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'HOST_CVE_COUNT_test-uuid-456',
+          url: expect.stringContaining('api/vulnerability/v1/systems/opt_out'),
+          params: {
+            inventory_id: 'test-uuid-456',
+            opt_out: true,
+          },
+          headers: {
+            'Content-Type': 'application/vnd.api+json',
+          },
+        })
+      );
+    });
+
+    it('includes updateData callback that updates opt_out in CVE cache', () => {
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: false,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick();
+
+      const patchCall = mockPatch.mock.calls[0][0];
+      expect(patchCall.updateData).toBeDefined();
+
+      // Test updateData callback
+      const prevState = {
+        data: [
+          {
+            id: 'system-1',
+            attributes: {
+              cve_count: 5,
+              opt_out: false,
+            },
+          },
+        ],
+        meta: { total: 1 },
+      };
+
+      const newState = patchCall.updateData(prevState);
+
+      expect(newState).toEqual({
+        data: [
+          {
+            id: 'system-1',
+            attributes: {
+              cve_count: 5,
+              opt_out: true, // Should be updated to true
+            },
+          },
+        ],
+        meta: { total: 1 },
+      });
+    });
+
+    it('includes successToast callback that returns correct message for disabling', () => {
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: false,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick();
+
+      const patchCall = mockPatch.mock.calls[0][0];
+      expect(patchCall.successToast).toBeDefined();
+
+      const message = patchCall.successToast();
+      expect(message).toBe('Vulnerability analysis disabled');
+    });
+
+    it('includes successToast callback that returns correct message for enabling', () => {
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: true,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick();
+
+      const patchCall = mockPatch.mock.calls[0][0];
+      const message = patchCall.successToast();
+      expect(message).toBe('Vulnerability analysis enabled');
+    });
+
+    it('includes handleSuccess callback that updates HOSTS Redux data', () => {
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+      storeUtils.updateHostVulnerabilityOptOut.mockImplementation(() => {});
+
+      const hostDetails = {
+        id: 123,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: false,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick();
+
+      const patchCall = mockPatch.mock.calls[0][0];
+      expect(patchCall.handleSuccess).toBeDefined();
+
+      // Call handleSuccess
+      patchCall.handleSuccess();
+
+      expect(storeUtils.updateHostVulnerabilityOptOut).toHaveBeenCalledWith(
+        123,
+        true
+      );
+    });
+
+    it('includes errorToast callback that extracts JSON:API error detail', () => {
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: false,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick();
+
+      const patchCall = mockPatch.mock.calls[0][0];
+      expect(patchCall.errorToast).toBeDefined();
+
+      // Test with JSON:API error format
+      const errorWithDetail = {
+        response: {
+          data: {
+            errors: [
+              {
+                detail: 'System not found in vulnerability service',
+              },
+            ],
+          },
+        },
+      };
+
+      const errorMessage = patchCall.errorToast(errorWithDetail);
+      expect(errorMessage).toBe('System not found in vulnerability service');
+    });
+
+    it('includes errorToast callback that falls back to generic message', () => {
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: false,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick();
+
+      const patchCall = mockPatch.mock.calls[0][0];
+
+      // Test with error that doesn't have JSON:API format
+      const genericError = {
+        response: {
+          data: {},
+        },
+      };
+
+      const errorMessage = patchCall.errorToast(genericError);
+      expect(errorMessage).toBe(
+        'Failed to update vulnerability analysis status'
+      );
+    });
+  });
+});

--- a/webpack/HostsIndexExtensions/__tests__/VulnerabilityAnalysisActions.test.js
+++ b/webpack/HostsIndexExtensions/__tests__/VulnerabilityAnalysisActions.test.js
@@ -2,6 +2,7 @@
 const mockGetState = jest.fn();
 const mockDispatch = jest.fn();
 const mockPatch = jest.fn();
+const mockGet = jest.fn();
 
 // Mock modules
 jest.mock('../hostVulnerabilityStoreUtils');
@@ -20,6 +21,7 @@ jest.mock(
   'foremanReact/redux/API',
   () => ({
     patch: (...args) => mockPatch(...args),
+    get: (...args) => mockGet(...args),
   }),
   { virtual: true }
 );
@@ -263,7 +265,7 @@ describe('VulnerabilityAnalysisActions', () => {
       );
     });
 
-    it('includes updateData callback that updates opt_out in CVE cache', () => {
+    it('includes updateData callback when disabling (optimistic update)', () => {
       mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
 
       const hostDetails = {
@@ -278,7 +280,7 @@ describe('VulnerabilityAnalysisActions', () => {
       };
 
       const actions = getVulnerabilityAnalysisActions(hostDetails);
-      actions[0].onClick();
+      actions[0].onClick(); // Clicking "Disable" action
 
       const patchCall = mockPatch.mock.calls[0][0];
       expect(patchCall.updateData).toBeDefined();
@@ -311,6 +313,57 @@ describe('VulnerabilityAnalysisActions', () => {
         ],
         meta: { total: 1 },
       });
+    });
+
+    it('skips updateData when enabling (will refetch instead)', () => {
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: true, // Currently disabled
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick(); // Clicking "Enable" action
+
+      const patchCall = mockPatch.mock.calls[0][0];
+      // When enabling, updateData should be undefined (no optimistic update)
+      expect(patchCall.updateData).toBeUndefined();
+    });
+
+    it('updateData handles missing data gracefully when disabling', () => {
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+
+      const hostDetails = {
+        id: 1,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: false,
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick();
+
+      const patchCall = mockPatch.mock.calls[0][0];
+
+      // Test with undefined prevState
+      expect(patchCall.updateData(undefined)).toBeUndefined();
+
+      // Test with missing data
+      expect(patchCall.updateData({})).toEqual({});
+
+      // Test with null data
+      expect(patchCall.updateData({ data: null })).toEqual({ data: null });
     });
 
     it('includes successToast callback that returns correct message for disabling', () => {
@@ -359,7 +412,7 @@ describe('VulnerabilityAnalysisActions', () => {
       expect(message).toBe('Vulnerability analysis enabled');
     });
 
-    it('includes handleSuccess callback that updates HOSTS Redux data', () => {
+    it('includes handleSuccess callback that updates HOSTS Redux data when disabling', () => {
       mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
       storeUtils.updateHostVulnerabilityOptOut.mockImplementation(() => {});
 
@@ -375,6 +428,11 @@ describe('VulnerabilityAnalysisActions', () => {
       };
 
       const actions = getVulnerabilityAnalysisActions(hostDetails);
+
+      // Clear dispatch mock before calling onClick (which dispatches the patch action)
+      mockDispatch.mockClear();
+      mockGet.mockClear();
+
       actions[0].onClick();
 
       const patchCall = mockPatch.mock.calls[0][0];
@@ -386,6 +444,51 @@ describe('VulnerabilityAnalysisActions', () => {
       expect(storeUtils.updateHostVulnerabilityOptOut).toHaveBeenCalledWith(
         123,
         true
+      );
+      // When disabling, should NOT dispatch GET (no refetch needed)
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it('includes handleSuccess callback that refetches data when enabling', () => {
+      mockPatch.mockReturnValue({ type: 'MOCK_PATCH_ACTION' });
+      mockGet.mockReturnValue({ type: 'MOCK_GET_ACTION' });
+      storeUtils.updateHostVulnerabilityOptOut.mockImplementation(() => {});
+
+      const hostDetails = {
+        id: 123,
+        insights_attributes: {
+          use_iop_mode: true,
+          vulnerability_opt_out: true, // Currently disabled
+        },
+        subscription_facet_attributes: {
+          uuid: 'test-uuid-456',
+        },
+      };
+
+      const actions = getVulnerabilityAnalysisActions(hostDetails);
+      actions[0].onClick(); // Click "Enable"
+
+      const patchCall = mockPatch.mock.calls[0][0];
+      expect(patchCall.handleSuccess).toBeDefined();
+
+      // Call handleSuccess
+      patchCall.handleSuccess();
+
+      // Should update HOSTS Redux data
+      expect(storeUtils.updateHostVulnerabilityOptOut).toHaveBeenCalledWith(
+        123,
+        false // Enabling sets to false
+      );
+
+      // Should dispatch GET to refetch CVE data
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'MOCK_GET_ACTION' });
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'HOST_CVE_COUNT_test-uuid-456',
+          url: expect.stringContaining(
+            'api/vulnerability/v1/systems?uuid=test-uuid-456'
+          ),
+        })
       );
     });
 

--- a/webpack/HostsIndexExtensions/__tests__/VulnerabilityAnalysisActions.test.js
+++ b/webpack/HostsIndexExtensions/__tests__/VulnerabilityAnalysisActions.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 // Create mocks
 const mockGetState = jest.fn();
 const mockDispatch = jest.fn();
@@ -27,7 +28,9 @@ jest.mock(
 );
 
 // Import after mocking
+// eslint-disable-next-line import/first
 import * as storeUtils from '../hostVulnerabilityStoreUtils';
+// eslint-disable-next-line import/first
 import getVulnerabilityAnalysisActions from '../VulnerabilityAnalysisActions';
 
 describe('VulnerabilityAnalysisActions', () => {

--- a/webpack/HostsIndexExtensions/hostVulnerabilityStoreUtils.js
+++ b/webpack/HostsIndexExtensions/hostVulnerabilityStoreUtils.js
@@ -1,0 +1,41 @@
+import store from 'foremanReact/redux';
+
+/**
+ * Updates a host's vulnerability_opt_out status in the HOSTS Redux cache
+ * @param {number} hostId - The host ID to update
+ * @param {boolean} optOutValue - The new opt_out status
+ * @param {function} dispatch - Redux dispatch function (optional, uses store.dispatch if not provided)
+ */
+export const updateHostVulnerabilityOptOut = (
+  hostId,
+  optOutValue,
+  dispatch = null
+) => {
+  const dispatchFn = dispatch || store.dispatch;
+  const state = store.getState();
+  const hostsData = state.API?.HOSTS;
+
+  if (!hostsData?.response?.results || !hostId) {
+    return;
+  }
+
+  dispatchFn({
+    type: 'HOSTS_SUCCESS',
+    key: 'HOSTS',
+    response: {
+      ...hostsData.response,
+      results: hostsData.response.results.map(host => {
+        if (host.id === hostId) {
+          return {
+            ...host,
+            insights_attributes: {
+              ...host.insights_attributes,
+              vulnerability_opt_out: optOutValue,
+            },
+          };
+        }
+        return host;
+      }),
+    },
+  });
+};

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import store from 'foremanReact/redux';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { Link } from 'react-router-dom';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
@@ -12,6 +14,7 @@ const vulnerabilityApiPath = path =>
 
 export const CVECountCell = ({ hostDetails }) => {
   const isIopEnabled = useIopConfig();
+  const dispatch = useDispatch();
 
   // eslint-disable-next-line camelcase
   const uuid = hostDetails?.subscription_facet_attributes?.uuid;
@@ -32,6 +35,36 @@ export const CVECountCell = ({ hostDetails }) => {
   const { cveCount, optOut } = propsToCamelCase(
     (response.response?.data || [])[0]?.attributes || {}
   );
+
+  // Update HOSTS Redux data when CVE data loads
+  // This triggers table re-render so kebab actions recompute with correct opt_out value
+  useEffect(() => {
+    if (optOut !== undefined && hostDetails?.id) {
+      const state = store.getState();
+      const hostsData = state.API?.HOSTS;
+      if (hostsData?.response?.results) {
+        dispatch({
+          type: 'HOSTS_SUCCESS',
+          key: 'HOSTS',
+          response: {
+            ...hostsData.response,
+            results: hostsData.response.results.map(host => {
+              if (host.id === hostDetails.id) {
+                return {
+                  ...host,
+                  insights_attributes: {
+                    ...host.insights_attributes,
+                    vulnerability_opt_out: optOut,
+                  },
+                };
+              }
+              return host;
+            }),
+          },
+        });
+      }
+    }
+  }, [optOut, hostDetails?.id, dispatch]);
 
   if (optOut === true) {
     return __('Analysis disabled');

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
@@ -1,13 +1,13 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import store from 'foremanReact/redux';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { Link } from 'react-router-dom';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
 import { propsToCamelCase } from 'foremanReact/common/helpers';
 import { insightsCloudUrl } from '../InsightsCloudSync/InsightsCloudSyncHelpers';
 import { useIopConfig } from '../common/Hooks/ConfigHooks';
+import { updateHostVulnerabilityOptOut } from '../HostsIndexExtensions/hostVulnerabilityStoreUtils';
 
 const vulnerabilityApiPath = path =>
   insightsCloudUrl(`api/vulnerability/v1/${path}`);
@@ -18,6 +18,7 @@ export const CVECountCell = ({ hostDetails }) => {
 
   // eslint-disable-next-line camelcase
   const uuid = hostDetails?.subscription_facet_attributes?.uuid;
+  const hostId = hostDetails?.id;
 
   const key = `HOST_CVE_COUNT_${uuid}`;
   const response = useAPI(
@@ -28,10 +29,6 @@ export const CVECountCell = ({ hostDetails }) => {
     }
   );
 
-  if (!isIopEnabled || uuid === undefined) {
-    return '—';
-  }
-
   const { cveCount, optOut } = propsToCamelCase(
     (response.response?.data || [])[0]?.attributes || {}
   );
@@ -39,32 +36,14 @@ export const CVECountCell = ({ hostDetails }) => {
   // Update HOSTS Redux data when CVE data loads
   // This triggers table re-render so kebab actions recompute with correct opt_out value
   useEffect(() => {
-    if (optOut !== undefined && hostDetails?.id) {
-      const state = store.getState();
-      const hostsData = state.API?.HOSTS;
-      if (hostsData?.response?.results) {
-        dispatch({
-          type: 'HOSTS_SUCCESS',
-          key: 'HOSTS',
-          response: {
-            ...hostsData.response,
-            results: hostsData.response.results.map(host => {
-              if (host.id === hostDetails.id) {
-                return {
-                  ...host,
-                  insights_attributes: {
-                    ...host.insights_attributes,
-                    vulnerability_opt_out: optOut,
-                  },
-                };
-              }
-              return host;
-            }),
-          },
-        });
-      }
+    if (optOut !== undefined && hostId) {
+      updateHostVulnerabilityOptOut(hostId, optOut, dispatch);
     }
-  }, [optOut, hostDetails?.id, dispatch]);
+  }, [optOut, hostId, dispatch]);
+
+  if (!isIopEnabled || uuid === undefined) {
+    return '—';
+  }
 
   if (optOut === true) {
     return __('Analysis disabled');

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/CVECountCell.js
@@ -53,7 +53,7 @@ export const CVECountCell = ({ hostDetails }) => {
     <Link to={`hosts/${hostDetails.name}#/Vulnerabilities`}>{cveCount}</Link>
   );
 
-  return cveCount === undefined ? '—' : cveLink;
+  return cveCount == null ? '—' : cveLink;
 };
 
 CVECountCell.propTypes = {

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
@@ -28,6 +28,7 @@ const store = mockStore({
 });
 
 const hostDetailsMock = {
+  id: 1,
   name: 'test-host.example.com',
   subscription_facet_attributes: {
     uuid: 'test-uuid-123',

--- a/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
+++ b/webpack/InsightsVulnerabilityHostIndexExtensions/__tests__/CVECountCell.test.js
@@ -152,4 +152,47 @@ describe('CVECountCell', () => {
       `/hosts/${hostDetailsMock.name}#/Vulnerabilities`
     );
   });
+
+  it('renders — when cve_count is null (analysis enabled but not scanned yet)', () => {
+    ConfigHooks.useIopConfig.mockReturnValue(true);
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.RESOLVED,
+      response: {
+        data: [
+          {
+            attributes: {
+              cve_count: null, // null when enabled but not scanned
+              opt_out: false,
+            },
+          },
+        ],
+      },
+    });
+
+    renderComponent();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('renders 0 CVE count link when count is 0', () => {
+    ConfigHooks.useIopConfig.mockReturnValue(true);
+    APIHooks.useAPI.mockReturnValue({
+      status: STATUS.RESOLVED,
+      response: {
+        data: [
+          {
+            attributes: {
+              cve_count: 0,
+            },
+          },
+        ],
+      },
+    });
+
+    renderComponent();
+
+    // Should render a link with 0
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent('0');
+  });
 });

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -1,10 +1,17 @@
 import { registerColumns } from 'foremanReact/components/HostsIndex/Columns/core';
+import { registerGetActions } from 'foremanReact/components/HostsIndex/TableRowActions/core';
 import { registerReducers } from './ForemanRhCloudReducers';
 import { registerFills } from './ForemanRhCloudFills';
 import { registerRoutes } from './ForemanRhCloudPages';
 import hostsIndexColumnExtensions from './ForemanColumnExtensions/index';
+import getVulnerabilityAnalysisActions from './HostsIndexExtensions/VulnerabilityAnalysisActions';
 
 registerReducers();
 registerFills();
 registerRoutes();
 registerColumns(hostsIndexColumnExtensions);
+registerGetActions({
+  pluginName: 'foreman_rh_cloud',
+  getActionsFunc: getVulnerabilityAnalysisActions,
+  tableName: 'hosts',
+});


### PR DESCRIPTION
## Summary
- Add actions to All Hosts table row kebab for enable and disable vulnerability analysis (IoP-only)
- Check current status and only show the relevant action
- No actions shown for unregistered hosts or hosts without system records

## Implementation
Uses Redux update pattern:
- CVECountCell updates HOSTS Redux data when CVE data loads
- Kebab actions read opt_out from host object or CVE cache as fallback
- After toggle, both CVE cache and HOSTS data are updated to trigger re-renders

## Behavior
- Initial load: No actions shown until CVE data loads (~500ms)
- After CVE loads: Shows only "Enable" OR "Disable" based on opt_out status
- After toggle: Both CVE column and kebab action update immediately
- Empty data: No actions shown if host not in vulnerability system

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note:** This branch is built on top of [another PR (Display 'Analysis disabled' in CVE column)
](https://github.com/theforeman/foreman_rh_cloud/pull/1141)
