### PR TITLE
Skip host_registration_insights_inventory parameter check in IoP mode

### DIFF
--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -47,8 +47,14 @@ module ForemanInventoryUpload
       end
 
       def self.for_slice(base)
-        base
-          .search_for("not params.#{InsightsCloud.enable_client_param_inventory} = f")
+        query = base
+
+        # In IoP mode, skip the parameter check - include all hosts regardless of opt-out setting
+        unless ForemanRhCloud.with_iop_smart_proxy?
+          query = query.search_for("not params.#{InsightsCloud.enable_client_param_inventory} = f")
+        end
+
+        query
           .joins(:subscription_facet)
           .preload(
             :interfaces,

--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -50,7 +50,7 @@ module ForemanInventoryUpload
         query = base
 
         # In IoP mode, skip the parameter check - include all hosts regardless of opt-out setting
-        unless ForemanRhCloud.with_iop_smart_proxy?
+        unless skip_inventory_parameter_filter?
           query = query.search_for("not params.#{InsightsCloud.enable_client_param_inventory} = f")
         end
 
@@ -64,6 +64,10 @@ module ForemanInventoryUpload
             :inventory_upload_facts,
             subscription_facet: [:pools, :installed_products, :hypervisor_host]
           )
+      end
+
+      def self.skip_inventory_parameter_filter?
+        ForemanRhCloud.with_iop_smart_proxy?
       end
 
       def self.for_org(organization_id, use_batches: true, hosts_query: '')

--- a/test/controllers/insights_cloud/api/advisor_engine_controller_test.rb
+++ b/test/controllers/insights_cloud/api/advisor_engine_controller_test.rb
@@ -12,6 +12,11 @@ module InsightsCloud
         @host3 = FactoryBot.create(:host, organization: @test_org)
       end
 
+      teardown do
+        # Ensure stubs are cleaned up to avoid leakage into other tests
+        ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+      end
+
       test 'shows hosts with uuids' do
         uuids = [@host1.insights_uuid, @host2.insights_uuid]
         get :host_details, params: { organization_id: @test_org.id, host_uuids: uuids }

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -9,6 +9,11 @@ module InsightsCloud::Api
       FactoryBot.create(:common_parameter, name: InsightsCloud.enable_client_param, key_type: 'boolean', value: true)
     end
 
+    teardown do
+      # Ensure stubs are cleaned up to avoid leakage into other tests
+      ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+    end
+
     context '#forward_request' do
       include MockCerts
 

--- a/test/controllers/insights_sync/settings_controller_test.rb
+++ b/test/controllers/insights_sync/settings_controller_test.rb
@@ -6,6 +6,11 @@ class SettingsControllerTest < ActionController::TestCase
     ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
   end
 
+  def teardown
+    # Ensure stubs are cleaned up to avoid leakage into other tests
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+  end
+
   test 'should return allow_auto_insights_sync setting' do
     Setting[:allow_auto_insights_sync] = false
 

--- a/test/jobs/host_inventory_report_job_test.rb
+++ b/test/jobs/host_inventory_report_job_test.rb
@@ -12,6 +12,8 @@ class HostInventoryReportJobTest < ActiveSupport::TestCase
 
   teardown do
     FileUtils.remove_entry base_folder if Dir.exist?(base_folder)
+    # Ensure stubs are cleaned up to avoid leakage into other tests
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
   end
 
   test 'plan schedules GenerateHostReport action' do

--- a/test/jobs/inventory_scheduled_sync_test.rb
+++ b/test/jobs/inventory_scheduled_sync_test.rb
@@ -4,6 +4,11 @@ require 'foreman_tasks/test_helpers'
 class InventoryScheduledSyncTest < ActiveSupport::TestCase
   include Dynflow::Testing::Factories
 
+  teardown do
+    # Ensure stubs are cleaned up to avoid leakage into other tests
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+  end
+
   test 'Schedules an execution if auto upload is enabled' do
     Setting[:allow_auto_inventory_upload] = true
     Setting[:allow_auto_insights_mismatch_delete] = true

--- a/test/jobs/single_host_report_job_test.rb
+++ b/test/jobs/single_host_report_job_test.rb
@@ -25,6 +25,8 @@ class SingleHostReportJobTest < ActiveSupport::TestCase
 
   teardown do
     FileUtils.remove_entry base_folder if Dir.exist?(base_folder)
+    # Ensure stubs are cleaned up to avoid leakage into other tests
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
   end
 
   test 'plan sets host_id in input' do

--- a/test/jobs/upload_report_direct_job_test.rb
+++ b/test/jobs/upload_report_direct_job_test.rb
@@ -30,6 +30,11 @@ class UploadReportDirectJobTest < ActiveSupport::TestCase
     Organization.any_instance.stubs(:owner_details).returns(@cert_data)
   end
 
+  teardown do
+    # Ensure stubs are cleaned up to avoid leakage into other tests
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+  end
+
   test 'plan sets input correctly' do
     action = create_action(ForemanInventoryUpload::Async::UploadReportDirectJob)
     action.expects(:action_subject).with(@organization)

--- a/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
+++ b/test/unit/lib/foreman_rh_cloud/registration_manager_extensions_test.rb
@@ -14,6 +14,11 @@ module ForemanRhCloud
       Katello::RegistrationManager.stubs(:execute_cloud_request).returns(true)
     end
 
+    teardown do
+      # Ensure stubs are cleaned up to avoid leakage into other tests
+      ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+    end
+
     context 'unregister_host' do
       test 'should call HBI delete in IoP mode when host has insights UUID' do
         ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)

--- a/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
+++ b/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
@@ -20,6 +20,11 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
     ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
   end
 
+  teardown do
+    # Ensure stubs are cleaned up to avoid leakage into other tests
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+  end
+
   # Planning behavior
   test 'plan plans_self when repo payload has id and IoP is available' do
     InsightsCloud::Async::VmaasReposcanSync.any_instance.expects(:plan_self).once

--- a/test/unit/rh_cloud_http_proxy_test.rb
+++ b/test/unit/rh_cloud_http_proxy_test.rb
@@ -7,6 +7,11 @@ class RhCloudHttpProxyTest < ActiveSupport::TestCase
     ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
   end
 
+  teardown do
+    # Ensure stubs are cleaned up to avoid leakage into other tests
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+  end
+
   test 'selects global content proxy' do
     setup_global_content_proxy
     setup_global_foreman_proxy

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -35,6 +35,11 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     ForemanInventoryUpload::Generators::Queries.instance_variable_set(:@fact_names, nil)
   end
 
+  teardown do
+    # Ensure stubs are cleaned up to avoid leakage into other tests
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+  end
+
   def create_fact_values(host, facts)
     facts.each do |fact_name, value|
       FactoryBot.create(:fact_value, fact_name: fact_names[fact_name], value: value, host: host)

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -749,7 +749,9 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     assert_equal 1, generator.hosts_count
   end
 
-  test 'excludes hosts with host_registration_insights_inventory set to false' do
+  test 'excludes hosts with host_registration_insights_inventory set to false in cloud mode' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
     @host.host_parameters << HostParameter.create(
       name: 'host_registration_insights_inventory',
       value: "false",
@@ -759,6 +761,39 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     count = ForemanInventoryUpload::Generators::Queries.for_org(@host.organization_id).count
 
     assert_equal 0, count
+  end
+
+  test 'includes hosts with host_registration_insights_inventory set to false in IoP mode' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+    @host.host_parameters << HostParameter.create(
+      name: 'host_registration_insights_inventory',
+      value: "false",
+      parameter_type: 'boolean'
+    )
+
+    count = ForemanInventoryUpload::Generators::Queries.for_org(@host.organization_id).count
+
+    assert_equal 1, count, 'IoP mode should include all hosts regardless of parameter value'
+  end
+
+  test 'parameter filter applies correctly when switching modes' do
+    @host.host_parameters << HostParameter.create(
+      name: 'host_registration_insights_inventory',
+      value: "false",
+      parameter_type: 'boolean'
+    )
+
+    # Cloud mode - should exclude
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+    cloud_count = ForemanInventoryUpload::Generators::Queries.for_org(@host.organization_id).count
+    assert_equal 0, cloud_count, 'Cloud mode should exclude opted-out hosts'
+
+    # IoP mode - should include
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+    iop_count = ForemanInventoryUpload::Generators::Queries.for_org(@host.organization_id).count
+    assert_equal 1, iop_count, 'IoP mode should include all hosts'
   end
 
   test 'includes hosts with host_registration_insights set to true' do


### PR DESCRIPTION
## Summary

- Modified `Queries.for_slice` to skip the `host_registration_insights_inventory` parameter filter when operating in IoP mode
- In IoP mode, all subscribed hosts should be included in inventory reports regardless of the opt-out parameter
- The parameter is designed for cloud mode uploads; IoP mode requires single-host reports for the Vulnerability service

## Test plan

- [x] Updated existing test to clarify cloud mode behavior with IoP stub
- [x] Added test for IoP mode behavior (hosts with parameter=false are included)
- [x] Added integration test for mode switching (cloud excludes, IoP includes)
- [x] All 394 tests pass with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust inventory query behavior to treat host opt-out parameters differently depending on cloud vs IoP mode.

Bug Fixes:
- Ensure IoP mode inventory uploads include all subscribed hosts regardless of the host_registration_insights_inventory opt-out parameter.

Tests:
- Extend unit tests to cover cloud vs IoP behavior for the host_registration_insights_inventory parameter and mode switching.