### PR TITLE
SAT-38683 - Support any location

### DIFF
--- a/app/controllers/insights_cloud/ui_requests_controller.rb
+++ b/app/controllers/insights_cloud/ui_requests_controller.rb
@@ -2,7 +2,7 @@ module InsightsCloud
   class UIRequestsController < ::ApplicationController
     layout false
 
-    before_action :ensure_org, :ensure_loc, :only => [:forward_request]
+    before_action :ensure_org, :find_location, :only => [:forward_request]
 
     # The method that "proxies" requests over to Cloud
     def forward_request
@@ -93,9 +93,8 @@ module InsightsCloud
       return render_message 'Organization not found or invalid', :status => 400 unless @organization
     end
 
-    def ensure_loc
+    def find_location
       @location = Location.current
-      return render_message 'Location not found or invalid', :status => 400 unless @location
     end
 
     def base_url

--- a/app/services/foreman_rh_cloud/tags_auth.rb
+++ b/app/services/foreman_rh_cloud/tags_auth.rb
@@ -20,7 +20,8 @@ module ForemanRhCloud
     end
 
     def update_tag
-      logger.debug("Updating tags for user: #{@user}, org: #{@org.name}, loc: #{@loc.name}")
+      loc_name = location_name_for_tag
+      logger.debug("Updating tags for user: #{@user}, org: #{@org.name}, loc: #{loc_name}")
 
       payload = tags_query_payload
       params = {
@@ -36,7 +37,9 @@ module ForemanRhCloud
     end
 
     def allowed_hosts
-      Host.authorized_as(@user, nil, nil).where(organization: @org, location: @loc).joins(:subscription_facet).pluck('katello_subscription_facets.uuid')
+      query = Host.authorized_as(@user, nil, nil).where(organization: @org)
+      query = query.where(location: @loc) if @loc
+      query.joins(:subscription_facet).pluck('katello_subscription_facets.uuid')
     end
 
     def tags_query_payload
@@ -47,11 +50,18 @@ module ForemanRhCloud
     end
 
     def tag_value
-      "U:\"#{@user.login}\"O:\"#{@org.name}\"L:\"#{@loc.name}\""
+      location_part = "L:\"#{location_name_for_tag}\""
+      "U:\"#{@user.login}\"O:\"#{@org.name}\"#{location_part}"
     end
 
     def auth_tag
       "#{TAG_NAME}=#{tag_value}"
+    end
+
+    private
+
+    def location_name_for_tag
+      @loc ? @loc.name : '*'
     end
   end
 end

--- a/test/controllers/insights_cloud/ui_requests_controller_test.rb
+++ b/test/controllers/insights_cloud/ui_requests_controller_test.rb
@@ -180,6 +180,32 @@ module InsightsCloud
         assert_equal 'Cloud request failed', JSON.parse(@response.body)['message']
         assert_match(/#{@body}/, JSON.parse(@response.body)['response'])
       end
+
+      test "should allow forward_request with nil location (Any location)" do
+        net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
+        res = RestClient::Response.create(@body, net_http_resp, @http_req)
+        ::ForemanRhCloud::InsightsApiForwarder.any_instance.stubs(:forward_request).returns(res)
+
+        # Set session with nil location_id to simulate "Any location"
+        session_with_nil_location = set_session_user.merge(
+          organization_id: @org.id,
+          location_id: nil
+        )
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: session_with_nil_location
+        assert_equal 200, @response.status
+        assert_equal @body, @response.body
+      end
+
+      test "should allow forward_request with location set" do
+        net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
+        res = RestClient::Response.create(@body, net_http_resp, @http_req)
+        ::ForemanRhCloud::InsightsApiForwarder.any_instance.stubs(:forward_request).returns(res)
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
+        assert_equal 200, @response.status
+        assert_equal @body, @response.body
+      end
     end
 
     def set_session

--- a/test/unit/services/foreman_rh_cloud/tags_auth_test.rb
+++ b/test/unit/services/foreman_rh_cloud/tags_auth_test.rb
@@ -40,4 +40,18 @@ class TagsAuthTest < ActiveSupport::TestCase
 
     @auth.update_tag
   end
+
+  test 'Generates tags with wildcard location when location is nil' do
+    auth_with_nil_loc = ::ForemanRhCloud::TagsAuth.new(@user, @org, nil, @logger)
+    uuid1 = 'test_uuid1'
+
+    auth_with_nil_loc.expects(:allowed_hosts).returns([uuid1])
+    auth_with_nil_loc.expects(:execute_cloud_request).with do |actual_params|
+      actual = JSON.parse(actual_params[:payload])
+      assert_includes actual['host_id_list'], uuid1
+      assert_equal "U:\"#{@user.login}\"O:\"#{@org.name}\"L:\"*\"", actual['tags'].first['value']
+    end
+
+    auth_with_nil_loc.update_tag
+  end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When setting "Any location" on the location dropdown menu, accessing either Remediations or Vulnerabilities menu should work.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Get an IoP server.
Change the location to "Any location" and visit either the Remediations or Vulnerabilities menu.
Data should be displayed.

## Summary by Sourcery

Allow Insights Cloud requests and tag updates to work when a user selects Any location (nil location).

New Features:
- Support forwarding Insights Cloud UI requests when the session has no location selected (Any location).

Bug Fixes:
- Ensure tag generation works when location is nil by using a wildcard location tag and relaxing host filtering on location.

Tests:
- Add controller tests for forwarding requests with nil and non-nil locations, and a unit test for tag generation with a wildcard location.