### PR TITLE
Release 13.2.1

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '13.2.0'.freeze
+  VERSION = '13.2.1'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "13.2.0",
+  "version": "13.2.1",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Bump the foreman_rh_cloud gem and package versions to 13.2.1 for the 13.2.1 release.

Build:
- Update package.json version field to 13.2.1.

Chores:
- Update Ruby gem version constant to 13.2.1.