### PR TITLE
Evaluate IoP status at runtime, not application start, and register Ping extension always (#1138)

### DIFF
--- a/app/models/foreman_rh_cloud/ping.rb
+++ b/app/models/foreman_rh_cloud/ping.rb
@@ -7,7 +7,7 @@ module ForemanRhCloud
       include ForemanRhCloud::CertAuth
 
       def iop_smart_proxy_url
-        @iop_smart_proxy_url ||= ForemanRhCloud.iop_smart_proxy.url
+        ForemanRhCloud.iop_smart_proxy&.url
       end
 
       def service_urls
@@ -33,6 +33,7 @@ module ForemanRhCloud
       end
 
       def ping
+        return {} unless ForemanRhCloud.with_iop_smart_proxy?
         ping_services
       end
 

--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -14,15 +14,15 @@ module ForemanRhCloud
 
   def self.base_url
     # for testing set ENV to 'https://ci.cloud.redhat.com'
-    @base_url ||= env_or_on_premise_url('SATELLITE_RH_CLOUD_URL') || 'https://cloud.redhat.com'
+    env_or_on_premise_url('SATELLITE_RH_CLOUD_URL') || 'https://cloud.redhat.com'
   end
 
   def self.cert_base_url
-    @cert_base_url ||= env_or_on_premise_url('SATELLITE_CERT_RH_CLOUD_URL') || 'https://cert.cloud.redhat.com'
+    env_or_on_premise_url('SATELLITE_CERT_RH_CLOUD_URL') || 'https://cert.cloud.redhat.com'
   end
 
   def self.legacy_insights_url
-    @legacy_insights_url ||= env_or_on_premise_url('SATELLITE_LEGACY_INSIGHTS_URL') || 'https://cert-api.access.redhat.com'
+    env_or_on_premise_url('SATELLITE_LEGACY_INSIGHTS_URL') || 'https://cert-api.access.redhat.com'
   end
 
   def self.verify_ssl_method

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -121,10 +121,8 @@ module ForemanRhCloud
 
         register_custom_status InventorySync::InventoryStatus
         register_custom_status InsightsClientReportStatus
-        if ForemanRhCloud.with_iop_smart_proxy?
-          register_ping_extension { ForemanRhCloud::Ping.ping }
-          register_status_extension { ForemanRhCloud::Ping.status }
-        end
+        register_ping_extension { ForemanRhCloud::Ping.ping }
+        register_status_extension { ForemanRhCloud::Ping.status }
 
         describe_host do
           overview_buttons_provider :insights_host_overview_buttons
@@ -145,6 +143,10 @@ module ForemanRhCloud
             add_pagelet :hosts_table_column_content, key: :insights_recommendations_count, callback: ->(host) { hits_counts_cell(host) }, class: 'hidden-xs ellipsis text-center', priority: 100
           end
         end
+
+        ::Foreman::Plugin.app_metadata_registry.register(:foreman_rh_cloud, {
+          iop: -> { ForemanRhCloud.with_iop_smart_proxy? },
+        })
 
         extend_template_helpers ForemanRhCloud::TemplateRendererHelper
         allowed_template_helpers :remediations_playbook, :download_rh_playbook

--- a/test/unit/foreman_rh_cloud_iop_metadata_test.rb
+++ b/test/unit/foreman_rh_cloud_iop_metadata_test.rb
@@ -1,0 +1,200 @@
+require 'test_plugin_helper'
+
+class ForemanRhCloudIopMetadataTest < ActiveSupport::TestCase
+  setup do
+    # Clean up any existing IoP smart proxies
+    SmartProxy.unscoped.with_features('iop').destroy_all
+  end
+
+  teardown do
+    # Clean up
+    SmartProxy.unscoped.with_features('iop').destroy_all
+  end
+
+  def create_iop_proxy(url: 'https://iop.example.com')
+    feature = Feature.find_or_create_by(name: 'iop')
+    proxy = FactoryBot.create(:smart_proxy, :url => url)
+    # Clear any existing associations for this feature
+    feature.reload
+    feature.smart_proxies.clear
+    proxy.features << feature
+    proxy
+  end
+
+  describe 'plugin metadata' do
+    test 'iop metadata is false when no IoP smart proxy exists' do
+      # Ensure no IoP proxy exists
+      refute ForemanRhCloud.with_iop_smart_proxy?
+
+      # Plugin metadata should reflect this
+      metadata = ::Foreman::Plugin.app_metadata_registry.all_plugin_metadata[:foreman_rh_cloud]
+
+      # The value is a lambda, so we need to call it
+      assert_kind_of Proc, metadata[:iop]
+      refute metadata[:iop].call
+    end
+
+    test 'iop metadata is true when IoP smart proxy exists' do
+      # Create an IoP smart proxy
+      create_iop_proxy
+
+      # Verify proxy exists
+      assert ForemanRhCloud.with_iop_smart_proxy?
+
+      # Plugin metadata should reflect this
+      metadata = ::Foreman::Plugin.app_metadata_registry.all_plugin_metadata[:foreman_rh_cloud]
+
+      # The value is a lambda, so we need to call it
+      assert_kind_of Proc, metadata[:iop]
+      assert metadata[:iop].call
+    end
+
+    test 'iop metadata updates when IoP smart proxy is created' do
+      # Initially no IoP proxy
+      metadata = ::Foreman::Plugin.app_metadata_registry.all_plugin_metadata[:foreman_rh_cloud]
+      refute metadata[:iop].call
+
+      # Create an IoP smart proxy
+      create_iop_proxy
+
+      # Metadata should now return true
+      assert metadata[:iop].call
+    end
+
+    test 'iop metadata updates when IoP smart proxy is destroyed' do
+      # Create an IoP smart proxy
+      proxy = create_iop_proxy
+
+      metadata = ::Foreman::Plugin.app_metadata_registry.all_plugin_metadata[:foreman_rh_cloud]
+      assert metadata[:iop].call
+
+      # Destroy the proxy
+      proxy.destroy
+
+      # Metadata should now return false
+      refute metadata[:iop].call
+    end
+  end
+
+  describe 'URL methods' do
+    test 'base_url returns cloud URL when no IoP smart proxy exists' do
+      assert_equal 'https://cloud.redhat.com', ForemanRhCloud.base_url
+    end
+
+    test 'cert_base_url returns cloud URL when no IoP smart proxy exists' do
+      assert_equal 'https://cert.cloud.redhat.com', ForemanRhCloud.cert_base_url
+    end
+
+    test 'legacy_insights_url returns cloud URL when no IoP smart proxy exists' do
+      assert_equal 'https://cert-api.access.redhat.com', ForemanRhCloud.legacy_insights_url
+    end
+
+    test 'base_url returns IoP URL when IoP smart proxy exists' do
+      create_iop_proxy
+
+      assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+    end
+
+    test 'cert_base_url returns IoP URL when IoP smart proxy exists' do
+      create_iop_proxy
+
+      assert_equal 'https://iop.example.com', ForemanRhCloud.cert_base_url
+    end
+
+    test 'legacy_insights_url returns IoP URL when IoP smart proxy exists' do
+      create_iop_proxy
+
+      assert_equal 'https://iop.example.com', ForemanRhCloud.legacy_insights_url
+    end
+
+    test 'base_url returns ENV var when set' do
+      ENV['SATELLITE_RH_CLOUD_URL'] = 'https://custom.example.com'
+
+      assert_equal 'https://custom.example.com', ForemanRhCloud.base_url
+    ensure
+      ENV.delete('SATELLITE_RH_CLOUD_URL')
+    end
+
+    test 'cert_base_url returns ENV var when set' do
+      ENV['SATELLITE_CERT_RH_CLOUD_URL'] = 'https://env-cert.cloud.test'
+
+      assert_equal 'https://env-cert.cloud.test', ForemanRhCloud.cert_base_url
+    ensure
+      ENV.delete('SATELLITE_CERT_RH_CLOUD_URL')
+    end
+
+    test 'legacy_insights_url returns ENV var when set' do
+      ENV['SATELLITE_LEGACY_INSIGHTS_URL'] = 'https://env-legacy.insights.test'
+
+      assert_equal 'https://env-legacy.insights.test', ForemanRhCloud.legacy_insights_url
+    ensure
+      ENV.delete('SATELLITE_LEGACY_INSIGHTS_URL')
+    end
+
+    test 'base_url prefers IoP URL over ENV var' do
+      ENV['SATELLITE_RH_CLOUD_URL'] = 'https://custom.example.com'
+
+      create_iop_proxy
+
+      # IoP URL should take precedence
+      assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+    ensure
+      ENV.delete('SATELLITE_RH_CLOUD_URL')
+    end
+
+    test 'cert_base_url prefers IoP URL over ENV var' do
+      ENV['SATELLITE_CERT_RH_CLOUD_URL'] = 'https://env-cert.cloud.test'
+
+      create_iop_proxy
+
+      # IoP URL should take precedence
+      assert_equal 'https://iop.example.com', ForemanRhCloud.cert_base_url
+    ensure
+      ENV.delete('SATELLITE_CERT_RH_CLOUD_URL')
+    end
+
+    test 'legacy_insights_url prefers IoP URL over ENV var' do
+      ENV['SATELLITE_LEGACY_INSIGHTS_URL'] = 'https://env-legacy.insights.test'
+
+      create_iop_proxy
+
+      # IoP URL should take precedence
+      assert_equal 'https://iop.example.com', ForemanRhCloud.legacy_insights_url
+    ensure
+      ENV.delete('SATELLITE_LEGACY_INSIGHTS_URL')
+    end
+
+    test 'URL methods update when IoP smart proxy is created' do
+      # Initially returns cloud URLs
+      assert_equal 'https://cloud.redhat.com', ForemanRhCloud.base_url
+      assert_equal 'https://cert.cloud.redhat.com', ForemanRhCloud.cert_base_url
+      assert_equal 'https://cert-api.access.redhat.com', ForemanRhCloud.legacy_insights_url
+
+      # Create an IoP smart proxy
+      create_iop_proxy
+
+      # Should now return IoP URL for all helpers
+      assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+      assert_equal 'https://iop.example.com', ForemanRhCloud.cert_base_url
+      assert_equal 'https://iop.example.com', ForemanRhCloud.legacy_insights_url
+    end
+
+    test 'URL methods update when IoP smart proxy is destroyed' do
+      # Create an IoP smart proxy
+      proxy = create_iop_proxy
+
+      # Initially returns IoP URL for all helpers
+      assert_equal 'https://iop.example.com', ForemanRhCloud.base_url
+      assert_equal 'https://iop.example.com', ForemanRhCloud.cert_base_url
+      assert_equal 'https://iop.example.com', ForemanRhCloud.legacy_insights_url
+
+      # Destroy the proxy
+      proxy.destroy
+
+      # Should now return cloud URLs again
+      assert_equal 'https://cloud.redhat.com', ForemanRhCloud.base_url
+      assert_equal 'https://cert.cloud.redhat.com', ForemanRhCloud.cert_base_url
+      assert_equal 'https://cert-api.access.redhat.com', ForemanRhCloud.legacy_insights_url
+    end
+  end
+end


### PR DESCRIPTION
(cherry picked from commit 51195ab6e0a03a23ebcf17fc466cbb567e37197f)

## Summary by Sourcery

Evaluate IoP-related state at runtime and expose it via plugin metadata while ensuring ping and URL helpers respond dynamically to IoP smart proxy presence.

Enhancements:
- Always register ping and status extensions and guard their behavior based on IoP smart proxy availability.
- Remove memoization from cloud URL helper methods so they always reflect the current IoP smart proxy or environment-variable configuration.
- Register IoP availability in the Foreman plugin app metadata registry for runtime inspection.
- Make IoP smart proxy URL lookup in ping logic tolerant of missing proxies and no-op when IoP is unavailable.

Tests:
- Add unit tests covering IoP metadata behavior, including dynamic updates as IoP smart proxies are created or destroyed.
- Add unit tests verifying URL helper precedence between IoP smart proxy URLs, environment variables, and default cloud URLs, including runtime updates when proxies change.