### PR TITLE
Search generated_reports and other improvements to report file paths and dev setup

### DIFF
--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -1,10 +1,10 @@
 module ForemanInventoryUpload
   def self.base_folder
     # in production setup, where selinux is enabled, we only have rights to
-    # create folders under /ver/lib/foreman. If the folder does not exist, it's
-    # a dev setup, where we can use our current root
+    # create folders under /var/lib/foreman. If the folder does not exist, it's
+    # a dev setup, where we can use the parent of the current working directory
     @base_folder ||= File.join(
-      Dir.glob('/var/lib/foreman').first || Dir.getwd,
+      Dir.glob('/var/lib/foreman').first || File.dirname(Dir.getwd),
       'red_hat_inventory/'
     )
   end
@@ -30,11 +30,6 @@ module ForemanInventoryUpload
     File.join(ForemanInventoryUpload.done_folder, filename)
   end
 
-  def self.report_file_paths(organization_id)
-    filename = facts_archive_name(organization_id)
-    Dir[ForemanInventoryUpload.uploads_file_path(filename), ForemanInventoryUpload.done_file_path(filename)]
-  end
-
   def self.generated_reports_folder
     @generated_reports_folder ||= ensure_folder(
       File.join(
@@ -42,6 +37,19 @@ module ForemanInventoryUpload
         'generated_reports/'
       )
     )
+  end
+
+  def self.generated_reports_file_path(filename)
+    File.join(ForemanInventoryUpload.generated_reports_folder, filename)
+  end
+
+  def self.report_file_paths(organization_id)
+    filename = facts_archive_name(organization_id)
+    Dir[
+      ForemanInventoryUpload.done_file_path(filename),
+      ForemanInventoryUpload.uploads_file_path(filename),
+      ForemanInventoryUpload.generated_reports_file_path(filename)
+    ]
   end
 
   def self.outputs_folder

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -45,10 +45,17 @@ module ForemanInventoryUpload
 
   def self.report_file_paths(organization_id)
     filename = facts_archive_name(organization_id)
+    # Report files start in generated
+    # They are then MOVED (not copied) to uploads, then done.
+    # When they are moved to the new folder, they overwrite any file with the same name.
+    # If it's a generate-only, it will be in generated
+    # Failed or incomplete uploads will be in uploads
+    # Completed uploads will be in done
+    # The ordering here ensures we get the correct file path every time.
     Dir[
-      ForemanInventoryUpload.done_file_path(filename),
+      ForemanInventoryUpload.generated_reports_file_path(filename),
       ForemanInventoryUpload.uploads_file_path(filename),
-      ForemanInventoryUpload.generated_reports_file_path(filename)
+      ForemanInventoryUpload.done_file_path(filename),
     ]
   end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- Updates `report_file_paths` to search for reports in priority order: generated_reports → uploads → done, ensuring downloads return the most recent/complete report. Previously, `generated_reports` was not searched at all.
- Adds `generated_reports_file_path` helper method for consistency
- Fixes `base_folder` to use parent directory in dev environments, keeping generated files in `/home/vagrant/red_hat_inventory/` instead of polluting the Foreman repo directory
- Fixes typo in comment: `/ver/lib/foreman` → `/var/lib/foreman`

#### Considerations taken when implementing this change?

The priority order reflects the report lifecycle:
1. generated - Reports end up here if the user chose not to upload them, or if the upload fails completely
2. uploads - Reports end up here if the upload is in progress or interrupted
3. done - Reports end up here if the upload is complete

The report files are moved (not copied) from generated > uploaded > done, and overwrite any file with the same name in the destination folder. For this reason:

- if the most recent report was generated only, it will be in the generated folder
- if the most recent report was uploaded, it will probably be in the done folder, and there will be _nothing_ in the generated folder.

Hence the ordering above.

This ensures hammer CLI and the frontend download button serve the most up-to-date report available.

#### Change 2 - Dev environment report location

For dev environments, using `File.dirname(Dir.getwd)` instead of `Dir.getwd` moves the `red_hat_inventory/` folder location to keep report files outside the git repository, avoiding clutter in `git status`.

#### What are the testing steps for this pull request?

- [ ] Generate a report for an organization
- [ ] Verify the report appears in `generated_reports/` folder
- [ ] Download the report via hammer CLI: `hammer insights inventory download-report --organization-id 1 --path /tmp`
- [ ] Verify the correct report file is downloaded
- [ ] In dev environment, verify reports are created in `/home/vagrant/red_hat_inventory/` instead of `/home/vagrant/foreman/red_hat_inventory/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust report storage and lookup to prioritize completed reports and keep development artifacts out of the Foreman repo directory.

New Features:
- Add a helper to build file paths for generated reports for consistent report handling.

Bug Fixes:
- Correct the base folder path comment from /ver/lib/foreman to /var/lib/foreman.

Enhancements:
- Change the base folder resolution in development to use the parent of the current working directory so generated files are stored outside the Foreman repository.
- Update report file path discovery to search done, uploads, then generated_reports folders in priority order to return the most complete report available.