### PR TITLE
Remove subscription facet pools references

### DIFF
--- a/lib/foreman_inventory_upload/generators/queries.rb
+++ b/lib/foreman_inventory_upload/generators/queries.rb
@@ -62,7 +62,7 @@ module ForemanInventoryUpload
             :content_facet,
             :host_statuses,
             :inventory_upload_facts,
-            subscription_facet: [:pools, :installed_products, :hypervisor_host]
+            subscription_facet: [:installed_products, :hypervisor_host]
           )
       end
 

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -192,7 +192,7 @@ module InsightsCloud::Api
           organization: env.organization
         )
 
-        @host.subscription_facet.pools << FactoryBot.create(:katello_pool, account_number: '5678', cp_id: 1)
+        @host.organization.pools << FactoryBot.create(:katello_pool, account_number: '5678', cp_id: 1)
 
         uuid = @host.subscription_facet.uuid
 

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -27,7 +27,7 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
 
     pool = FactoryBot.create(:katello_pool, account_number: '1234', cp_id: 1)
 
-    @host1.subscription_facet.pools << pool
+    @host1.organization.pools << pool
 
     # this host would pass our plugin queries, so it could be uploaded to the cloud.
     @host2 = FactoryBot.create(
@@ -39,7 +39,6 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
       organization: env.organization
     )
 
-    @host2.subscription_facet.pools << pool
     @host2_inventory_id = '4536bf5c-ff03-4154-a8c9-32ff4b40e40c'
 
     # this host would pass our plugin queries, so it could be uploaded to the cloud.
@@ -51,8 +50,6 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
       lifecycle_environment: env,
       organization: env.organization
     )
-
-    @host3.subscription_facet.pools << pool
 
     ForemanInventoryUpload::Generators::Queries.instance_variable_set(:@fact_names, nil)
 

--- a/test/jobs/inventory_hosts_sync_test.rb
+++ b/test/jobs/inventory_hosts_sync_test.rb
@@ -23,7 +23,7 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
 
     pool = FactoryBot.create(:katello_pool, account_number: '1234', cp_id: 1)
 
-    @host1.subscription_facet.pools << pool
+    @host1.organization.pools << pool
 
     # this host would pass our plugin queries, so it could be uploaded to the cloud.
     @host2 = FactoryBot.create(
@@ -34,8 +34,6 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
       lifecycle_environment: env,
       organization: env.organization
     )
-
-    @host2.subscription_facet.pools << pool
     @host2_inventory_id = '4536bf5c-ff03-4154-a8c9-32ff4b40e40c'
 
     ForemanInventoryUpload::Generators::Queries.instance_variable_set(:@fact_names, nil)

--- a/test/unit/archived_report_generator_test.rb
+++ b/test/unit/archived_report_generator_test.rb
@@ -18,7 +18,7 @@ class ArchivedReportGeneratorTest < ActiveSupport::TestCase
       organization: env.organization
     )
 
-    @host.subscription_facet.pools << FactoryBot.create(:katello_pool, account_number: '1234', cp_id: 1)
+    @host.organization.pools << FactoryBot.create(:katello_pool, account_number: '1234', cp_id: 1)
   end
 
   def interesting_facts

--- a/test/unit/services/foreman_rh_cloud/branch_info_test.rb
+++ b/test/unit/services/foreman_rh_cloud/branch_info_test.rb
@@ -19,7 +19,7 @@ class BranchInfoTest < ActiveSupport::TestCase
       organization: env.organization
     )
 
-    @host.subscription_facet.pools << FactoryBot.create(:katello_pool, account_number: '5678', cp_id: 1)
+    @host.organization.pools << FactoryBot.create(:katello_pool, account_number: '5678', cp_id: 1)
   end
 
   test 'should generate branch info for host' do

--- a/test/unit/services/foreman_rh_cloud/cloud_request_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/cloud_request_forwarder_test.rb
@@ -29,7 +29,7 @@ class CloudRequestForwarderTest < ActiveSupport::TestCase
       organization: env.organization
     )
 
-    @host.subscription_facet.pools << FactoryBot.create(:katello_pool, account_number: '5678', cp_id: 1)
+    @host.organization.pools << FactoryBot.create(:katello_pool, account_number: '5678', cp_id: 1)
   end
 
   test 'should prepare correct cloud url' do


### PR DESCRIPTION
## Summary
Remove references to `subscription_facet.pools` after Katello removed the `SubscriptionFacetPool` join table in commit 203846dad13886a499e5cd82a3b1b53119ffa221.

## Changes
- Remove `:pools` from subscription_facet preload in `lib/foreman_inventory_upload/generators/queries.rb`
- Update 6 test files to use `organization.pools` instead of `subscription_facet.pools` for test setup
- For multi-host tests, remove duplicate pool additions since pools belong to organizations

## Why This Works
The production code in `fact_helpers.rb` already retrieves `account_id` via `organization.pools`, not `subscription_facet.pools`. The preloaded subscription facet pools were never actually used, so removing them has no functional impact.

## Test Plan
- [ ] CI tests pass
- [ ] Verify affected test files run successfully
- [ ] Confirm no regression in inventory report generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove remaining references to subscription facet pools now that pools belong directly to organizations.

Bug Fixes:
- Align inventory query preloading and tests with the updated Katello data model by removing unused subscription_facet.pools associations.

Tests:
- Update inventory sync and cloud-related tests to associate pools via organizations instead of subscription facets, avoiding duplicate pool assignments for multi-host scenarios.