### PR TITLE
Remove golden_ticket? method and simplify SCA handling

### DIFF
--- a/lib/foreman_inventory_upload/generators/fact_helpers.rb
+++ b/lib/foreman_inventory_upload/generators/fact_helpers.rb
@@ -28,14 +28,6 @@ module ForemanInventoryUpload
         @organization_accounts[organization.id] ||= organization.pools.where.not(account_number: nil).pluck(:account_number).first
       end
 
-      def golden_ticket?(organization)
-        result = organization.try(:golden_ticket?)
-        result = organization.content_access_mode == 'org_environment' if result.nil?
-
-        @organization_golden_tickets ||= {}
-        @organization_golden_tickets[organization.id] ||= result
-      end
-
       def cloud_provider(host)
         bios_version = fact_value(host, 'dmi::bios::version')
 

--- a/lib/foreman_inventory_upload/generators/slice.rb
+++ b/lib/foreman_inventory_upload/generators/slice.rb
@@ -230,7 +230,7 @@ module ForemanInventoryUpload
         @stream.simple_field('system_purpose_sla', host.subscription_facet.service_level)
         @stream.simple_field('distribution_version', fact_value(host, 'distribution::version'))
         @stream.simple_field('satellite_instance_id', Foreman.try(:instance_id))
-        @stream.simple_field('is_simple_content_access', golden_ticket?(host.organization))
+        @stream.simple_field('is_simple_content_access', true)
         @stream.simple_field('is_hostname_obfuscated', !!obfuscate_hostname?(host))
         @stream.simple_field('organization_id', host.organization_id, :last)
       end

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -85,7 +85,7 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
               "facts": {
                 "virtual_host_name": "virt-who-nobody.home-1",
                 "satellite_instance_id": "fc4d0cb0-a0b0-421e-b096-b028319b8e47",
-                "is_simple_content_access": false,
+                "is_simple_content_access": true,
                 "distribution_version": "7.3",
                 "satellite_version": "6.8.4",
                 "organization_id": 1,
@@ -136,7 +136,7 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
               "facts": {
                 "virtual_host_name": "virt-who-nobody.home-1",
                 "satellite_instance_id": "fc4d0cb0-a0b0-421e-b096-b028319b8e47",
-                "is_simple_content_access": false,
+                "is_simple_content_access": true,
                 "distribution_version": "8.3",
                 "satellite_version": "6.8.4",
                 "organization_id": 1,
@@ -189,7 +189,7 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
               "facts": {
                 "satellite_instance_id": "fb3643d8-9030-487b-b95c-684783806ffd",
                 "system_purpose_sla": "",
-                "is_simple_content_access": false,
+                "is_simple_content_access": true,
                 "distribution_version": "8.3",
                 "satellite_version": "6.8.1",
                 "organization_id": 1,

--- a/test/jobs/inventory_hosts_sync_test.rb
+++ b/test/jobs/inventory_hosts_sync_test.rb
@@ -69,7 +69,7 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
               "facts": {
                 "virtual_host_name": "virt-who-nobody.home-1",
                 "satellite_instance_id": "fc4d0cb0-a0b0-421e-b096-b028319b8e47",
-                "is_simple_content_access": false,
+                "is_simple_content_access": true,
                 "distribution_version": "7.3",
                 "satellite_version": "6.8.4",
                 "organization_id": 1,
@@ -120,7 +120,7 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
               "facts": {
                 "virtual_host_name": "virt-who-nobody.home-1",
                 "satellite_instance_id": "fc4d0cb0-a0b0-421e-b096-b028319b8e47",
-                "is_simple_content_access": false,
+                "is_simple_content_access": true,
                 "distribution_version": "7.3",
                 "satellite_version": "6.8.4",
                 "organization_id": 1,
@@ -171,7 +171,7 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
               "facts": {
                 "virtual_host_name": "virt-who-nobody.home-1",
                 "satellite_instance_id": "fc4d0cb0-a0b0-421e-b096-b028319b8e47",
-                "is_simple_content_access": false,
+                "is_simple_content_access": true,
                 "distribution_version": "8.3",
                 "satellite_version": "6.8.4",
                 "organization_id": 1,
@@ -224,7 +224,7 @@ class InventoryHostsSyncTest < ActiveSupport::TestCase
               "facts": {
                 "satellite_instance_id": "fb3643d8-9030-487b-b95c-684783806ffd",
                 "system_purpose_sla": "",
-                "is_simple_content_access": false,
+                "is_simple_content_access": true,
                 "distribution_version": "8.3",
                 "satellite_version": "6.8.1",
                 "organization_id": 1,

--- a/test/jobs/inventory_self_host_sync_test.rb
+++ b/test/jobs/inventory_self_host_sync_test.rb
@@ -53,7 +53,7 @@ class InventorySelfHostSyncTest < ActiveSupport::TestCase
               "facts": {
                 "virtual_host_name": "virt-who-nobody.home-1",
                 "satellite_instance_id": "fc4d0cb0-a0b0-421e-b096-b028319b8e47",
-                "is_simple_content_access": false,
+                "is_simple_content_access": true,
                 "distribution_version": "8.3",
                 "satellite_version": "6.8.4",
                 "organization_id": 1,

--- a/test/unit/archived_report_generator_test.rb
+++ b/test/unit/archived_report_generator_test.rb
@@ -51,7 +51,6 @@ class ArchivedReportGeneratorTest < ActiveSupport::TestCase
     test_org = FactoryBot.create(:organization)
 
     ForemanInventoryUpload::Generators::Queries.expects(:for_org).with(test_org.id, hosts_query: '').returns(batches)
-    ForemanInventoryUpload::Generators::Slice.any_instance.stubs(:golden_ticket?).returns(false)
     Dir.mktmpdir do |tmpdir|
       target = File.join(tmpdir, 'test.tar.gz')
       generator = ForemanInventoryUpload::Generators::ArchivedReport.new(target, Logger.new(STDOUT))

--- a/test/unit/fact_helpers_test.rb
+++ b/test/unit/fact_helpers_test.rb
@@ -12,22 +12,6 @@ class FactHelpersTest < ActiveSupport::TestCase
     @org = FactoryBot.create(:organization)
   end
 
-  test 'golden_ticket uses golden_ticket method when defined' do
-    @org.expects(:golden_ticket?).returns(true)
-
-    actual = @instance.golden_ticket?(@org)
-
-    assert actual
-  end
-
-  test 'golden_ticket uses content_access_mode method when golden_ticket not defined' do
-    @org.expects(:content_access_mode).returns('org_environment')
-
-    actual = @instance.golden_ticket?(@org)
-
-    assert actual
-  end
-
   test 'obfuscates ips with insights-client data' do
     host = mock('host')
     @instance.expects(:fact_value).with(host, 'insights_client::obfuscated_ipv4').returns(

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -702,22 +702,6 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     assert_equal 'test_sla', fact_values['system_purpose_sla']
   end
 
-  test 'generates a report for a golden ticket' do
-    batch = Host.where(id: @host.id).in_batches.first
-    generator = create_generator(batch) do |generator|
-      generator.stubs(:golden_ticket?).returns(true)
-    end
-
-    json_str = generator.render
-    actual = JSON.parse(json_str.join("\n"))
-
-    assert_equal '00000000-0000-0000-0000-000000000000', actual['report_slice_id']
-    assert_not_nil(actual_host = actual['hosts'].first)
-    assert_equal @host.fqdn, actual_host['fqdn']
-    assert_equal '1234', actual_host['account']
-    assert_equal 1, generator.hosts_count
-  end
-
   test 'skips hosts without subscription' do
     a_host = FactoryBot.create(
       :host,
@@ -1131,11 +1115,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
 
   def create_generator(batch, name = '00000000-0000-0000-0000-000000000000')
     generator = ForemanInventoryUpload::Generators::Slice.new(batch, [], name)
-    if block_given?
-      yield(generator)
-    else
-      generator.stubs(:golden_ticket?).returns(false)
-    end
+    yield(generator) if block_given?
     generator
   end
 

--- a/test/unit/slice_generator_test.rb
+++ b/test/unit/slice_generator_test.rb
@@ -641,6 +641,7 @@ class SliceGeneratorTest < ActiveSupport::TestCase
     assert_tag('1', actual_host, 'int_param', 'satellite_parameter')
 
     assert_equal false, satellite_facts['is_hostname_obfuscated']
+    assert_equal true, satellite_facts['is_simple_content_access']
 
     version = satellite_facts['satellite_version']
     if defined?(ForemanThemeSatellite)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This PR removes the obsolete `golden_ticket?` helper method and simplifies Simple Content Access (SCA) handling in inventory reports. The changes include:

- Removed the `golden_ticket?` method from `FactHelpers` which referenced Katello methods that no longer exist (`golden_ticket?` and `content_access_mode`)
- Changed `is_simple_content_access` field to always be `true` in inventory reports, since all organizations are now in SCA mode
- Removed associated tests for the obsolete method
- Updated test data in inventory sync tests to reflect that all organizations are in SCA mode

#### Considerations taken when implementing this change?

- Katello 4.12 removed entitlement mode and migrated all organizations to SCA-only mode (commits f174f2ed65, 16cbea2ed6, ec23330bd7)
- The `is_simple_content_access` field is still included in inventory reports (for cloud API compatibility), but is now always `true` instead of conditionally checking organization settings
- This is backward compatible since the field will always have the correct value for current Katello/Satellite installations

#### What are the testing steps for this pull request?

1. Run the full test suite to verify no regressions: `cd /home/vagrant/foreman && bundle exec rake test:foreman_rh_cloud`
2. (Optional) Generate an inventory report for an organization and verify `is_simple_content_access: true` appears in the satellite facts
3. (Optional) Upload an inventory report to verify the cloud API accepts it with the field set to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove legacy Simple Content Access (SCA) handling and always report SCA as enabled in inventory uploads.

Bug Fixes:
- Ensure the is_simple_content_access fact in generated inventory reports is consistently true to match current SCA-only behavior.

Enhancements:
- Remove the obsolete golden_ticket? helper and its caching, simplifying SCA-related logic in fact generation.
- Clean up tests and helpers that stub or depend on golden_ticket? to reflect the always-on SCA model.
- Update inventory sync test fixtures to expect is_simple_content_access to be true in all generated reports.