### PR TITLE
SAT-42791 - Pass docs links through LinksController

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
@@ -7,6 +7,8 @@ import { getDocsURL } from 'foremanReact/common/helpers';
 import { FormattedMessage } from 'react-intl';
 import { selectSubscriptionConnectionEnabled } from '../../../InventorySettings/InventorySettingsSelectors';
 
+import { getSubscriptionServiceDocsUrl } from '../../../../ForemanInventoryHelpers';
+
 export const PageDescription = () => {
   const subscriptionConnectionEnabled = useSelector(
     selectSubscriptionConnectionEnabled
@@ -80,7 +82,7 @@ export const PageDescription = () => {
         {__('For more information about the Subscriptions service, see:')}
         &nbsp;
         <a
-          href="https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/index"
+          href={getSubscriptionServiceDocsUrl()}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
+++ b/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
@@ -11,6 +11,13 @@ export const getInventoryDocsUrl = () =>
     )}`
   );
 
+export const getSubscriptionServiceDocsUrl = () =>
+  foremanUrl(
+    `/links/manual/?root_url=${URI.encode(
+      'https://docs.redhat.com/en/documentation/subscription_central/1-latest/html-single/getting_started_with_the_subscriptions_service/index'
+    )}`
+  );
+
 export const getActionsHistoryUrl = () =>
   foremanUrl(
     '/foreman_tasks/tasks?search=label+%3D+ForemanInventoryUpload%3A%3AAsync%3A%3AHostInventoryReportJob+or+label+%3D+ForemanInventoryUpload%3A%3AAsync%3A%3AGenerateAllReportsJob&page=1'


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Wrapping a static link to subscription service docs via foremanUrl, so it goes through LinksController.

#### Considerations taken when implementing this change?

This is needed so we can properly redirect this link to RHOKP.

#### What are the testing steps for this pull request?

 - Use related PR in foreman_theme_satellite: https://github.com/RedHatSatellite/foreman_theme_satellite/pull/313
 - Spin RHOKP
 - Change Settings > satellite_documentation_url to the RHOKP
 - See if the links are being redirected there instead of docs.redhat.com

## Summary by Sourcery

Route the subscriptions service documentation link through Foreman’s LinksController instead of using a static URL.

New Features:
- Add helper to generate the subscriptions service docs URL via the Foreman links endpoint.

Enhancements:
- Update the inventory upload page description to use the new helper-based subscriptions docs link for redirect support.