### PR TITLE
Release 14.0.1

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '13.2.1'.freeze
+  VERSION = '14.0.1'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "13.2.1",
+  "version": "14.0.1",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Bump the project version to 14.0.1 for both the Ruby gem and the npm package metadata.

Build:
- Update Ruby gem version constant to 14.0.1.
- Update npm package.json version to 14.0.1.