### PR TITLE
SAT-42791 - Pass docs links through LinksController

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/PageDescription/PageDescription.js
@@ -7,6 +7,8 @@ import { getDocsURL } from 'foremanReact/common/helpers';
 import { FormattedMessage } from 'react-intl';
 import { selectSubscriptionConnectionEnabled } from '../../../InventorySettings/InventorySettingsSelectors';
 
+import { getSubscriptionServiceDocsUrl } from '../../../../ForemanInventoryHelpers';
+
 export const PageDescription = () => {
   const subscriptionConnectionEnabled = useSelector(
     selectSubscriptionConnectionEnabled
@@ -80,7 +82,7 @@ export const PageDescription = () => {
         {__('For more information about the Subscriptions service, see:')}
         &nbsp;
         <a
-          href="https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/index"
+          href={getSubscriptionServiceDocsUrl()}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
+++ b/webpack/ForemanInventoryUpload/ForemanInventoryHelpers.js
@@ -11,6 +11,13 @@ export const getInventoryDocsUrl = () =>
     )}`
   );
 
+export const getSubscriptionServiceDocsUrl = () =>
+  foremanUrl(
+    `/links/manual/?root_url=${URI.encode(
+      'https://docs.redhat.com/en/documentation/subscription_central/1-latest/html-single/getting_started_with_the_subscriptions_service/index'
+    )}`
+  );
+
 export const getActionsHistoryUrl = () =>
   foremanUrl(
     '/foreman_tasks/tasks?search=label+%3D+ForemanInventoryUpload%3A%3AAsync%3A%3AHostInventoryReportJob+or+label+%3D+ForemanInventoryUpload%3A%3AAsync%3A%3AGenerateAllReportsJob&page=1'


### PR DESCRIPTION
(cherry picked from commit f2d29a00d9c581ddbb6865f044afd4a7a74a2d4b)

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Route the Subscriptions service documentation link through the centralized links controller for the Foreman inventory upload UI.

New Features:
- Expose a helper to generate the Subscriptions service documentation URL via the links controller.

Enhancements:
- Update the Subscriptions service help link in the inventory upload page description to use the centralized docs URL helper instead of a hardcoded URL.