### PR TITLE
Fix CVE details page 400 error by respecting no-tags patterns

### DIFF
--- a/app/services/foreman_rh_cloud/insights_api_forwarder.rb
+++ b/app/services/foreman_rh_cloud/insights_api_forwarder.rb
@@ -224,14 +224,21 @@ module ForemanRhCloud
     def scope_request?(original_request, path)
       return nil unless original_request.get?
 
-      # Only consider patterns that define tag_name - this ensures patterns without
-      # tag_name (permission-only entries) cannot override tag-supporting patterns
-      matching_patterns = SCOPED_REQUESTS.select { |pattern| pattern[:tag_name] && pattern[:test].match?(path) }
+      # Find patterns that match this path AND are relevant for GET requests.
+      # A pattern is relevant if it either:
+      # - Has tag_name defined (supports scoping)
+      # - Has GET permissions defined (explicitly handles GET, even without tags)
+      # This ensures patterns like api/vulnerability/v1/cves/[^/]+$ (GET without tags)
+      # take precedence over general patterns, while POST-only patterns are ignored.
+      matching_patterns = SCOPED_REQUESTS.select do |pattern|
+        pattern[:test].match?(path) && (pattern[:tag_name] || pattern.dig(:permissions, 'GET'))
+      end
       return nil if matching_patterns.empty?
 
-      # Choose the most specific pattern by regex source length for consistency
-      # with required_permission_for behavior
+      # Choose the most specific pattern by regex source length
       request_pattern = matching_patterns.max_by { |pattern| pattern[:test].source.length }
+
+      # Return the tag_name (may be nil if the most specific pattern doesn't support tags)
       request_pattern[:tag_name]
     end
 


### PR DESCRIPTION
The scope_request? method was incorrectly filtering to only consider patterns with tag_name defined, which caused the CVE details endpoint pattern (api/vulnerability/v1/cves/[^/]+$) to be excluded.

This resulted in the more general pattern (api/vulnerability/v1/.*) being selected instead, which adds tags to the request. Since the CVE details API endpoint does not support tags per the OpenAPI spec, this caused a 400 Bad Request error:
"Extra query parameter(s) tags not in spec"

#### What are the changes introduced in this pull request?
The fix removes the tag_name filter so all matching patterns are considered, then the most specific pattern (longest regex) is selected. For the CVE details endpoint, this correctly returns nil for tag_name, meaning no tags are added to the request.

Fixes the "Cannot read properties of undefined (reading 'synopsis')" error that occurred when clicking on any CVE from the Vulnerabilities page or host details Vulnerabilities tab.

#### What are the testing steps for this pull request?
Scenario 1:
Navigation Path:
Insights → Vulnerability → Click on any CVE

Scenario 2:
Navigation Path:
Hosts → All Hosts → client.example.com → Vulnerabilities → Click on any CVE

Expected Result:
Clicking on any CVE should open the Vulnerability details page and display full CVE information, including synopsis, description, severity, affected packages, etc.

## Summary by Sourcery

Bug Fixes:
- Fix 400 errors and frontend failures on CVE detail pages by correctly handling tag-less vulnerability CVE endpoints in scoped request matching.