### PR TITLE
Fixes #39088 - Search generated_reports for report file paths

### DIFF
--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -1,10 +1,10 @@
 module ForemanInventoryUpload
   def self.base_folder
     # in production setup, where selinux is enabled, we only have rights to
-    # create folders under /ver/lib/foreman. If the folder does not exist, it's
-    # a dev setup, where we can use our current root
+    # create folders under /var/lib/foreman. If the folder does not exist, it's
+    # a dev setup, where we can use the parent of the current working directory
     @base_folder ||= File.join(
-      Dir.glob('/var/lib/foreman').first || Dir.getwd,
+      Dir.glob('/var/lib/foreman').first || File.dirname(Dir.getwd),
       'red_hat_inventory/'
     )
   end
@@ -30,11 +30,6 @@ module ForemanInventoryUpload
     File.join(ForemanInventoryUpload.done_folder, filename)
   end
 
-  def self.report_file_paths(organization_id)
-    filename = facts_archive_name(organization_id)
-    Dir[ForemanInventoryUpload.uploads_file_path(filename), ForemanInventoryUpload.done_file_path(filename)]
-  end
-
   def self.generated_reports_folder
     @generated_reports_folder ||= ensure_folder(
       File.join(
@@ -42,6 +37,26 @@ module ForemanInventoryUpload
         'generated_reports/'
       )
     )
+  end
+
+  def self.generated_reports_file_path(filename)
+    File.join(ForemanInventoryUpload.generated_reports_folder, filename)
+  end
+
+  def self.report_file_paths(organization_id)
+    filename = facts_archive_name(organization_id)
+    # Report files start in generated
+    # They are then MOVED (not copied) to uploads, then done.
+    # When they are moved to the new folder, they overwrite any file with the same name.
+    # If it's a generate-only, it will be in generated
+    # Failed or incomplete uploads will be in uploads
+    # Completed uploads will be in done
+    # The ordering here ensures we get the correct file path every time.
+    Dir[
+      ForemanInventoryUpload.generated_reports_file_path(filename),
+      ForemanInventoryUpload.uploads_file_path(filename),
+      ForemanInventoryUpload.done_file_path(filename),
+    ]
   end
 
   def self.outputs_folder


### PR DESCRIPTION
## Summary

Backport of #1155 to foreman_3_18 branch.

## Changes

- Updates `report_file_paths` to search for reports in priority order: generated_reports → uploads → done
- Adds `generated_reports_file_path` helper method
- Fixes `base_folder` to use parent directory in dev environments

## Original PR

https://github.com/theforeman/foreman_rh_cloud/pull/1155

## Summary by Sourcery

Search inventory report files in all expected locations and correct the base directory used in development environments.

Bug Fixes:
- Ensure report file lookup checks generated, uploads, and done folders in priority order so the latest report is found.
- Fix base folder selection in development environments to use the parent of the current working directory instead of the working directory itself.

Enhancements:
- Introduce a helper for building file paths in the generated_reports folder to simplify path handling.