### PR TITLE
Release 13.2.3

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '13.2.2'.freeze
+  VERSION = '13.2.3'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "13.2.2",
+  "version": "13.2.3",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Bump the foreman_rh_cloud plugin/package version to 13.2.3 for a new release.

Build:
- Update Ruby gem version constant to 13.2.3.
- Update npm package.json version to 13.2.3.