### PR TITLE
Fix single-commit check for stable branch PRs

### DIFF
--- a/.github/workflows/single-commit.yml
+++ b/.github/workflows/single-commit.yml
@@ -13,9 +13,9 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 30
-    - name: Checkout develop
-      run: git fetch origin develop
-    - name: create local develop branch
-      run: git branch develop origin/develop
+    - name: Checkout base branch
+      run: git fetch origin ${{ github.base_ref }}
+    - name: Create local base branch
+      run: git branch base_branch origin/${{ github.base_ref }}
     - name: Commit Count Check
-      run: test `git log  --oneline --no-merges HEAD ^develop | wc -l ` = 1
+      run: test `git log  --oneline --no-merges HEAD ^base_branch | wc -l ` = 1


### PR DESCRIPTION
## Summary

The single-commit workflow added in #1032 enforces one commit per PR to ensure squashed commits before merging. However, it was hardcoded to compare against `develop`, which breaks for PRs targeting stable branches like `foreman_3_18`.

This change uses `github.base_ref` to dynamically compare against the PR's actual target branch.

## Problem

PRs like #1166 (Release 13.2.3) targeting `foreman_3_18` fail the commit count check because the stable branch has diverged from `develop`.

## Solution

Replace hardcoded `develop` with `${{ github.base_ref }}` so the check works for PRs targeting any branch.

## Summary by Sourcery

CI:
- Adjust the single-commit check workflow to fetch and create a local branch from github.base_ref and use it as the reference for the commit count check.