### PR TITLE
Add Compliance routes and required permissions

### DIFF
--- a/app/services/foreman_rh_cloud/insights_api_forwarder.rb
+++ b/app/services/foreman_rh_cloud/insights_api_forwarder.rb
@@ -48,12 +48,13 @@ module ForemanRhCloud
     #                      | POST /api/insights/v1/rule/{rule_id}/unack_hosts/
     #
     SCOPED_REQUESTS = [
-      # Inventory hosts - requires view_compliance for GET
+      # Inventory hosts - shared dependency;
+      #                 - requires view_compliance or view_vulnerability for GET
       {
         test: %r{api/inventory/v1/hosts(/.*)?$},
         tag_name: :tags,
         permissions: {
-          'GET' => :view_compliance,
+          'GET' => [:view_compliance, :view_vulnerability],
         },
       },
       # Policies - requires view_compliance for GET, edit_compliance for POST/DELETE/PATCH
@@ -183,14 +184,6 @@ module ForemanRhCloud
           'GET' => :view_compliance,
         },
       },
-      # Inventory hosts - requires view_vulnerability for GET
-      {
-        test: %r{api/inventory/v1/hosts(/.*)?$},
-        tag_name: :tags,
-        permissions: {
-          'GET' => :view_vulnerability,
-        },
-      },
       # Vulnerability CVEs list - POST requires view_vulnerability (no tags support per OpenAPI spec)
       {
         test: %r{api/vulnerability/v1/vulnerabilities/cves},
@@ -295,9 +288,9 @@ module ForemanRhCloud
 
     def forward_request(original_request, path, controller_name, user, organization, location)
       # Check permissions before forwarding
-      permission = required_permission_for(path, original_request.request_method)
-      if permission && !user&.can?(permission)
-        logger.warn("User #{user&.login || 'anonymous'} lacks permission #{permission} for #{original_request.request_method} #{path}")
+      permissions = required_permission_for(path, original_request.request_method)
+      if permissions && Array(permissions).none? { |p| user&.can?(p) }
+        logger.warn("User #{user&.login || 'anonymous'} lacks permissions #{Array(permissions).join(', ')} for #{original_request.request_method} #{path}")
         raise ::Foreman::PermissionMissingException.new(N_("You do not have permission to perform this action"))
       end
 

--- a/app/services/foreman_rh_cloud/insights_api_forwarder.rb
+++ b/app/services/foreman_rh_cloud/insights_api_forwarder.rb
@@ -8,6 +8,30 @@ module ForemanRhCloud
     #
     # Foreman Permission   | Paths
     # ---------------------|--------------------------------------------------
+    # view_compliance      | GET /api/inventory/v1/hosts(/*)
+    # view_compliance      | GET /api/compliance/v2/systems
+    # view_compliance      | GET /api/compliance/v2/systems/{system_id}
+    # view_compliance      | GET /api/compliance/v2/systems/os_versions
+    # view_compliance      | GET /api/compliance/v2/systems/{system_id}/policies
+    # view_compliance      | GET /api/compliance/v2/systems/{system_id}/reports
+    # view_compliance      | GET /api/compliance/v2/reports/{report_id}/systems
+    # view_compliance      | GET /api/compliance/v2/reports/{report_id}/systems/{system_id}
+    # view_compliance      | GET /api/compliance/v2/reports/{report_id}/systems/os_versions
+    # view_compliance      | GET /api/compliance/v2/policies/{policy_id}/systems/os_versions
+    # view_compliance      | GET /api/compliance/v2/*
+    # edit_compliance      | POST /api/compliance/v2/policies
+    # edit_compliance      | DELETE /api/compliance/v2/policies/{policy_id}
+    # edit_compliance      | PATCH /api/compliance/v2/policies/{policy_id}
+    # edit_compliance      | POST /api/compliance/v2/policies/{policy_id}/systems
+    # edit_compliance      | DELETE /api/compliance/v2/policies/{policy_id}/systems/{system_id}
+    # edit_compliance      | PATCH /api/compliance/v2/policies/{policy_id}/systems/{system_id}
+    # edit_compliance      | POST /api/compliance/v2/policies/{policy_id}/tailorings
+    # edit_compliance      | PATCH /api/compliance/v2/policies/{policy_id}/tailorings/{tailoring_id}
+    # edit_compliance      | POST /api/compliance/v2/policies/{policy_id}/tailorings/{tailoring_id}/rules
+    # edit_compliance      | DELETE /api/compliance/v2/policies/{policy_id}/tailorings/{tailoring_id}/rules/{rule_id}
+    # edit_compliance      | PATCH /api/compliance/v2/policies/{policy_id}/tailorings/{tailoring_id}/rules/{rule_id}
+    # edit_compliance      | DELETE /api/compliance/v2/reports/{report_id}
+    #
     # view_vulnerability   | GET /api/inventory/v1/hosts(/*)
     # view_vulnerability   | GET /api/vulnerability/v1/*
     #                      | POST /api/vulnerability/v1/vulnerabilities/cves
@@ -24,6 +48,141 @@ module ForemanRhCloud
     #                      | POST /api/insights/v1/rule/{rule_id}/unack_hosts/
     #
     SCOPED_REQUESTS = [
+      # Inventory hosts - requires view_compliance for GET
+      {
+        test: %r{api/inventory/v1/hosts(/.*)?$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # Policies - requires view_compliance for GET, edit_compliance for POST/DELETE/PATCH
+      {
+        test: %r{api/compliance/v2/policies(/[^/]*)?$},
+        permissions: {
+          'GET' => :view_compliance,
+          'POST' => :edit_compliance,
+          'DELETE' => :edit_compliance,
+          'PATCH' => :edit_compliance,
+        },
+      },
+      # System and policies assigned to them - requires view_compliance for GET, edit_compliance for POST/DELETE/PATCH
+      {
+        test: %r{api/compliance/v2/policies/[^/]+/systems(/[^/]*)?$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+          'POST' => :edit_compliance,
+          'DELETE' => :edit_compliance,
+          'PATCH' => :edit_compliance,
+        },
+      },
+      # Tailorings of assigned policies - requires view_compliance for GET, edit_compliance for POST/PATCH
+      {
+        test: %r{api/compliance/v2/policies/[^/]+/tailorings(/[^/]*)?$},
+        permissions: {
+          'GET' => :view_compliance,
+          'POST' => :edit_compliance,
+          'PATCH' => :edit_compliance,
+        },
+      },
+      # Rules of Tailorings - requires view_compliance for GET, edit_compliance for POST/DELETE/PATCH
+      {
+        test: %r{api/compliance/v2/policies/[^/]+/tailorings/[^/]+/rules(/[^/]*)?$},
+        permissions: {
+          'GET' => :view_compliance,
+          'POST' => :edit_compliance,
+          'DELETE' => :edit_compliance,
+          'PATCH' => :edit_compliance,
+        },
+      },
+      # Compliance Reports - requires view_compliance for GET, edit_compliance for DELETE
+      {
+        test: %r{api/compliance/v2/reports(/[^/]*)?$},
+        permissions: {
+          'GET' => :view_compliance,
+          'DELETE' => :edit_compliance,
+        },
+      },
+      # Systems assigned to a report - requires view_compliance for GET
+      {
+        test: %r{api/compliance/v2/reports/[^/]+/systems$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # Individual system in a report - requires view_compliance for GET
+      {
+        test: %r{api/compliance/v2/reports/[^/]+/systems/[^/]+$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # OS versions for systems in a report - requires view_compliance for GET
+      {
+        test: %r{api/compliance/v2/reports/[^/]+/systems/os_versions$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # OS versions for systems in a policy - requires view_compliance for GET
+      {
+        test: %r{api/compliance/v2/policies/[^/]+/systems/os_versions$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # Compliance Systems list - requires view_compliance for GET
+      {
+        test: %r{api/compliance/v2/systems$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # Individual compliance system - requires view_compliance for GET
+      {
+        test: %r{api/compliance/v2/systems/[^/]+$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # OS versions for all systems - requires view_compliance for GET
+      {
+        test: %r{api/compliance/v2/systems/os_versions$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # Policies for a specific system - requires view_compliance for GET
+      {
+        test: %r{api/compliance/v2/systems/[^/]+/policies$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # Reports for a specific system - requires view_compliance for GET
+      {
+        test: %r{api/compliance/v2/systems/[^/]+/reports$},
+        tag_name: :tags,
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
+      # Other compliance endpoints - GET requires view_compliance
+      {
+        test: %r{api/compliance/v2/.*},
+        permissions: {
+          'GET' => :view_compliance,
+        },
+      },
       # Inventory hosts - requires view_vulnerability for GET
       {
         test: %r{api/inventory/v1/hosts(/.*)?$},

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -71,6 +71,17 @@ module ForemanRhCloud
             :control_organization_insights,
             'insights_cloud/settings': [:set_org_parameter]
           )
+          # Insights Compliance permissions
+          permission(
+            :view_compliance,
+            {},
+            :resource_type => 'ForemanRhCloud'
+          )
+          permission(
+            :edit_compliance,
+            {},
+            :resource_type => 'ForemanRhCloud'
+          )
           # Insights Vulnerability permissions
           permission(
             :view_vulnerability,
@@ -98,19 +109,19 @@ module ForemanRhCloud
         # Core RH Cloud permissions for inventory upload and sync
         rh_cloud_permissions = [:view_foreman_rh_cloud, :generate_foreman_rh_cloud, :view_insights_hits, :dispatch_cloud_requests, :control_organization_insights]
 
-        # Insights application permissions (Vulnerability, Advisor)
-        insights_permissions = [:view_vulnerability, :edit_vulnerability, :view_advisor, :edit_advisor]
+        # Insights application permissions (Compliance, Vulnerability, Advisor)
+        insights_permissions = [:view_compliance, :edit_compliance, :view_vulnerability, :edit_vulnerability, :view_advisor, :edit_advisor]
 
         plugin_permissions = rh_cloud_permissions + insights_permissions
 
-        read_only_permissions = [:view_foreman_rh_cloud, :view_insights_hits, :view_vulnerability, :view_advisor]
+        read_only_permissions = [:view_foreman_rh_cloud, :view_insights_hits, :view_compliance, :view_vulnerability, :view_advisor]
 
         role 'ForemanRhCloud', plugin_permissions, 'Role granting permissions to view the hosts inventory,
                                                     generate a report, upload it to the cloud, download it locally,
-                                                    and manage Insights Vulnerability and Advisor features'
+                                                    and manage Insights Compliance, Vulnerability and Advisor features'
 
         role 'ForemanRhCloud Read Only', read_only_permissions, 'Role granting read-only permissions to view
-                                                                 Insights Vulnerability, Advisor, and host inventory'
+                                                                 Insights Compliance, Vulnerability, Advisor, and host inventory'
 
         add_permissions_to_default_roles Role::ORG_ADMIN => plugin_permissions,
           Role::MANAGER => plugin_permissions,

--- a/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
@@ -178,6 +178,61 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     assert_nil result
   end
 
+  test 'scope_request? should return tag_name for compliance systems endpoint' do
+    get_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/compliance/v2/systems',
+      'REQUEST_METHOD' => 'GET',
+      'rack.input' => ::Puma::NullIO.new
+    )
+
+    result = @forwarder.send(:scope_request?, get_req, 'api/compliance/v2/systems')
+    assert_equal :tags, result
+  end
+
+  test 'scope_request? should return tag_name for compliance report systems endpoint' do
+    get_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/compliance/v2/reports/report-123/systems',
+      'REQUEST_METHOD' => 'GET',
+      'rack.input' => ::Puma::NullIO.new
+    )
+
+    result = @forwarder.send(:scope_request?, get_req, 'api/compliance/v2/reports/report-123/systems')
+    assert_equal :tags, result
+  end
+
+  test 'scope_request? should return tag_name for individual compliance system endpoint' do
+    get_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/compliance/v2/systems/system-456',
+      'REQUEST_METHOD' => 'GET',
+      'rack.input' => ::Puma::NullIO.new
+    )
+
+    result = @forwarder.send(:scope_request?, get_req, 'api/compliance/v2/systems/system-456')
+    assert_equal :tags, result
+  end
+
+  test 'scope_request? should return tag_name for system policies endpoint' do
+    get_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/compliance/v2/systems/system-456/policies',
+      'REQUEST_METHOD' => 'GET',
+      'rack.input' => ::Puma::NullIO.new
+    )
+
+    result = @forwarder.send(:scope_request?, get_req, 'api/compliance/v2/systems/system-456/policies')
+    assert_equal :tags, result
+  end
+
+  test 'scope_request? should return tag_name for system reports endpoint' do
+    get_req = ActionDispatch::Request.new(
+      'REQUEST_URI' => '/api/compliance/v2/systems/system-456/reports',
+      'REQUEST_METHOD' => 'GET',
+      'rack.input' => ::Puma::NullIO.new
+    )
+
+    result = @forwarder.send(:scope_request?, get_req, 'api/compliance/v2/systems/system-456/reports')
+    assert_equal :tags, result
+  end
+
   test 'prepare_tags should use provided tag_name' do
     result = @forwarder.send(:prepare_tags, @user, @organization, @location, :custom_tag)
 
@@ -307,6 +362,41 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
 
   # Data-driven tests for required_permission_for
   PERMISSION_MAPPINGS = [
+    # Compliance endpoints
+    { path: 'api/inventory/v1/hosts', method: 'GET', expected: :view_compliance },
+    { path: 'api/inventory/v1/hosts/abc-123', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies', method: 'POST', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies/policy-123', method: 'DELETE', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123', method: 'PATCH', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/systems', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/systems', method: 'POST', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/systems/system-456', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/systems/system-456', method: 'DELETE', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/systems/system-456', method: 'PATCH', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/tailorings', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/tailorings', method: 'POST', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/tailorings/tailoring-789', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/tailorings/tailoring-789', method: 'PATCH', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/tailorings/tailoring-789/rules', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/tailorings/tailoring-789/rules', method: 'POST', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/tailorings/tailoring-789/rules/rule-999', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/tailorings/tailoring-789/rules/rule-999', method: 'DELETE', expected: :edit_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/tailorings/tailoring-789/rules/rule-999', method: 'PATCH', expected: :edit_compliance },
+    { path: 'api/compliance/v2/reports', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/reports/report-123', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/reports/report-123', method: 'DELETE', expected: :edit_compliance },
+    { path: 'api/compliance/v2/reports/report-123/systems', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/reports/report-123/systems/system-456', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/reports/report-123/systems/os_versions', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/policies/policy-123/systems/os_versions', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/systems', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/systems/system-456', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/systems/os_versions', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/systems/system-456/policies', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/systems/system-456/reports', method: 'GET', expected: :view_compliance },
+    { path: 'api/compliance/v2/profiles', method: 'GET', expected: :view_compliance },
     # Vulnerability endpoints
     { path: 'api/inventory/v1/hosts', method: 'GET', expected: :view_vulnerability },
     { path: 'api/inventory/v1/hosts/abc-123', method: 'GET', expected: :view_vulnerability },
@@ -380,6 +470,140 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
 
     assert_raises(::Foreman::PermissionMissingException) do
       @forwarder.forward_request(req, 'api/insights/v1/ack/', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  # Compliance permission integration tests
+  test 'should allow GET request to compliance policies when user has view_compliance permission' do
+    req = build_request(method: 'GET', uri: '/api/compliance/v2/policies')
+
+    @user.stubs(:can?).with(:view_compliance).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/compliance/v2/policies', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny GET request to compliance policies when user lacks view_compliance permission' do
+    req = build_request(method: 'GET', uri: '/api/compliance/v2/policies')
+
+    @user.stubs(:can?).with(:view_compliance).returns(false)
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/compliance/v2/policies', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  test 'should allow POST request to compliance policies when user has edit_compliance permission' do
+    req = build_request(method: 'POST', uri: '/api/compliance/v2/policies', data: '{"name": "test-policy"}')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/compliance/v2/policies', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny POST request to compliance policies when user lacks edit_compliance permission' do
+    req = build_request(method: 'POST', uri: '/api/compliance/v2/policies', data: '{"name": "test-policy"}')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(false)
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/compliance/v2/policies', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  test 'should allow PATCH request to compliance policy when user has edit_compliance permission' do
+    req = build_request(method: 'PATCH', uri: '/api/compliance/v2/policies/policy-123', data: '{"name": "updated-policy"}')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/compliance/v2/policies/policy-123', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny PATCH request to compliance policy when user lacks edit_compliance permission' do
+    req = build_request(method: 'PATCH', uri: '/api/compliance/v2/policies/policy-123', data: '{"name": "updated-policy"}')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(false)
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/compliance/v2/policies/policy-123', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  test 'should allow DELETE request to compliance policy when user has edit_compliance permission' do
+    req = build_request(method: 'DELETE', uri: '/api/compliance/v2/policies/policy-123')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/compliance/v2/policies/policy-123', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny DELETE request to compliance policy when user lacks edit_compliance permission' do
+    req = build_request(method: 'DELETE', uri: '/api/compliance/v2/policies/policy-123')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(false)
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/compliance/v2/policies/policy-123', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  test 'should allow POST request to compliance policy systems when user has edit_compliance permission' do
+    req = build_request(method: 'POST', uri: '/api/compliance/v2/policies/policy-123/systems', data: '{"id": "system-456"}')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/compliance/v2/policies/policy-123/systems', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny POST request to compliance policy systems when user lacks edit_compliance permission' do
+    req = build_request(method: 'POST', uri: '/api/compliance/v2/policies/policy-123/systems', data: '{"id": "system-456"}')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(false)
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/compliance/v2/policies/policy-123/systems', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  test 'should allow DELETE request to compliance report when user has edit_compliance permission' do
+    req = build_request(method: 'DELETE', uri: '/api/compliance/v2/reports/report-123')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/compliance/v2/reports/report-123', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny DELETE request to compliance report when user lacks edit_compliance permission' do
+    req = build_request(method: 'DELETE', uri: '/api/compliance/v2/reports/report-123')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(false)
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/compliance/v2/reports/report-123', 'test_controller', @user, @organization, @location)
+    end
+  end
+
+  test 'should allow DELETE request to compliance tailoring rule when user has edit_compliance permission' do
+    req = build_request(method: 'DELETE', uri: '/api/compliance/v2/policies/policy-123/tailorings/tailoring-789/rules/rule-999')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(true)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/compliance/v2/policies/policy-123/tailorings/tailoring-789/rules/rule-999', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny DELETE request to compliance tailoring rule when user lacks edit_compliance permission' do
+    req = build_request(method: 'DELETE', uri: '/api/compliance/v2/policies/policy-123/tailorings/tailoring-789/rules/rule-999')
+
+    @user.stubs(:can?).with(:edit_compliance).returns(false)
+
+    assert_raises(::Foreman::PermissionMissingException) do
+      @forwarder.forward_request(req, 'api/compliance/v2/policies/policy-123/tailorings/tailoring-789/rules/rule-999', 'test_controller', @user, @organization, @location)
     end
   end
 

--- a/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
+++ b/test/unit/services/foreman_rh_cloud/insights_api_forwarder_test.rb
@@ -270,7 +270,7 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
 
   # Permission enforcement tests
 
-  # GET /api/inventory/v1/hosts requires view_vulnerability
+  # GET /api/inventory/v1/hosts is a shared dependency - view_compliance OR view_vulnerability grants access
   test 'should allow GET request to inventory hosts when user has view_vulnerability permission' do
     user_agent = { :foo => :bar }
     params = {}
@@ -283,6 +283,7 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
       'action_dispatch.request.query_parameters' => params
     )
 
+    @user.stubs(:can?).with(:view_compliance).returns(false)
     @user.stubs(:can?).with(:view_vulnerability).returns(true)
     ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
     @forwarder.expects(:execute_cloud_request).returns(true)
@@ -290,7 +291,18 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     @forwarder.forward_request(req, 'api/inventory/v1/hosts', 'test_controller', @user, @organization, @location)
   end
 
-  test 'should deny GET request to inventory hosts when user lacks view_vulnerability permission' do
+  test 'should allow GET request to inventory hosts when user has view_compliance permission' do
+    req = build_request(method: 'GET', uri: '/api/inventory/v1/hosts')
+
+    @user.stubs(:can?).with(:view_compliance).returns(true)
+    @user.stubs(:can?).with(:view_vulnerability).returns(false)
+    ::ForemanRhCloud::TagsAuth.any_instance.expects(:update_tag)
+    @forwarder.expects(:execute_cloud_request).returns(true)
+
+    @forwarder.forward_request(req, 'api/inventory/v1/hosts', 'test_controller', @user, @organization, @location)
+  end
+
+  test 'should deny GET request to inventory hosts when user lacks both view_compliance and view_vulnerability' do
     user_agent = { :foo => :bar }
     params = {}
 
@@ -302,6 +314,7 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
       'action_dispatch.request.query_parameters' => params
     )
 
+    @user.stubs(:can?).with(:view_compliance).returns(false)
     @user.stubs(:can?).with(:view_vulnerability).returns(false)
 
     assert_raises(::Foreman::PermissionMissingException) do
@@ -362,9 +375,10 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
 
   # Data-driven tests for required_permission_for
   PERMISSION_MAPPINGS = [
+    # Shared inventory hosts endpoint - either view_compliance or view_vulnerability grants GET access
+    { path: 'api/inventory/v1/hosts', method: 'GET', expected: [:view_compliance, :view_vulnerability] },
+    { path: 'api/inventory/v1/hosts/abc-123', method: 'GET', expected: [:view_compliance, :view_vulnerability] },
     # Compliance endpoints
-    { path: 'api/inventory/v1/hosts', method: 'GET', expected: :view_compliance },
-    { path: 'api/inventory/v1/hosts/abc-123', method: 'GET', expected: :view_compliance },
     { path: 'api/compliance/v2/policies', method: 'GET', expected: :view_compliance },
     { path: 'api/compliance/v2/policies', method: 'POST', expected: :edit_compliance },
     { path: 'api/compliance/v2/policies/policy-123', method: 'GET', expected: :view_compliance },
@@ -398,8 +412,6 @@ class UIRequestForwarderTest < ActiveSupport::TestCase
     { path: 'api/compliance/v2/systems/system-456/reports', method: 'GET', expected: :view_compliance },
     { path: 'api/compliance/v2/profiles', method: 'GET', expected: :view_compliance },
     # Vulnerability endpoints
-    { path: 'api/inventory/v1/hosts', method: 'GET', expected: :view_vulnerability },
-    { path: 'api/inventory/v1/hosts/abc-123', method: 'GET', expected: :view_vulnerability },
     { path: 'api/vulnerability/v1/vulnerabilities/cves', method: 'POST', expected: :view_vulnerability },
     { path: 'api/vulnerability/v1/status', method: 'PATCH', expected: :edit_vulnerability },
     { path: 'api/vulnerability/v1/cves/status', method: 'PATCH', expected: :edit_vulnerability },


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHINENG-24275

As a part of integration of Insights Compliance into Foreman, this PR is describing the [permissions](https://github.com/search?q=repo%3ARedHatInsights%2Fcompliance-backend%20kessel_permission_for_action&type=code) needed by Insights Compliance endpoint [routes](https://github.com/RedHatInsights/compliance-backend/blob/3b64c1aa87b43f7a9009453290d764c706ebf016/config/routes.rb).  

#### What are the changes introduced in this pull request?

List of accessible URLs for Compliance and list of their appropriate permissions.

#### Considerations taken when implementing this change?

One difference from Insights Compliance permissions and those implemented in this PR is that `new` and `remove` actions are grouped under `edit`.

#### What are the testing steps for this pull request

This will be testable, once the rest of integration pieces are brought together.

## Summary by Sourcery

Introduce Compliance-specific permission handling for forwarded API requests and integrate these permissions into the Foreman RH Cloud plugin roles.

New Features:
- Add Compliance permission mappings for inventory and /api/compliance/v2 endpoints in the Insights API forwarder.
- Define new ForemanRhCloud permissions :view_compliance and :edit_compliance and include them in plugin roles and default role assignments.

Tests:
- Extend data-driven permission mapping tests to cover Compliance endpoints for view and edit actions.
- Add integration-style tests verifying that Compliance requests are allowed or denied based on view_compliance and edit_compliance permissions.