### PR TITLE
Fix host details tab navigation when switching from Recommendations

### DIFF
--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -36,11 +36,13 @@ const NewHostDetailsTab = ({ hostName, router }) => {
   useEffect(
     () => () => {
       // Preserve hash when clearing search params to prevent tab navigation bugs
-      const replaceOptions = { search: null };
-      if (router.location?.hash) {
-        replaceOptions.hash = router.location.hash;
+      if (router && typeof router.replace === 'function') {
+        const replaceOptions = { search: null };
+        if (router.location && router.location.hash) {
+          replaceOptions.hash = router.location.hash;
+        }
+        router.replace(replaceOptions);
       }
-      router.replace(replaceOptions);
     },
     [router]
   );
@@ -48,8 +50,11 @@ const NewHostDetailsTab = ({ hostName, router }) => {
   const onSearch = q => dispatch(fetchInsights({ query: q, page: 1 }));
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const onSatInsightsClick = () =>
-    router.push({ pathname: '/foreman_rh_cloud/insights_cloud' });
+  const onSatInsightsClick = () => {
+    if (router && typeof router.push === 'function') {
+      router.push({ pathname: '/foreman_rh_cloud/insights_cloud' });
+    }
+  };
 
   const dropdownItems = [
     <DropdownItem key="insights-link" ouiaId="insights-link">

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -33,7 +33,17 @@ const NewHostDetailsTab = ({ hostName, router }) => {
   const hits = useSelector(selectHits);
   const isIop = useIopConfig();
 
-  useEffect(() => () => router.replace({ search: null }), [router]);
+  useEffect(
+    () => () => {
+      // Preserve hash when clearing search params to prevent tab navigation bugs
+      const replaceOptions = { search: null };
+      if (router.location?.hash) {
+        replaceOptions.hash = router.location.hash;
+      }
+      router.replace(replaceOptions);
+    },
+    [router]
+  );
 
   const onSearch = q => dispatch(fetchInsights({ query: q, page: 1 }));
 

--- a/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
@@ -109,5 +109,27 @@ describe('NewHostDetailsTab', () => {
         search: null,
       });
     });
+
+    it('should use the latest hash value at unmount time, not a stale captured value', () => {
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={mockRouter}
+          />
+        </Provider>
+      );
+
+      // Change the hash after mount, before unmount
+      mockRouter.location.hash = '#/Overview';
+
+      unmount();
+
+      // Verify router.replace was called with the UPDATED hash, not the initial '#/Insights'
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+        search: null,
+        hash: '#/Overview',
+      });
+    });
   });
 });

--- a/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import NewHostDetailsTab from '../NewHostDetailsTab';
+
+jest.mock('../../common/Hooks/ConfigHooks', () => ({
+  useIopConfig: jest.fn(() => false),
+}));
+
+jest.mock('foremanReact/common/I18n', () => ({
+  translate: jest.fn(str => str),
+}));
+
+const mockStore = configureMockStore([thunk]);
+
+describe('NewHostDetailsTab', () => {
+  let store;
+  let mockRouter;
+
+  beforeEach(() => {
+    store = mockStore({
+      insightsHostDetailsTab: {
+        query: '',
+        hits: [],
+        selectedIds: {},
+        error: null,
+      },
+    });
+
+    mockRouter = {
+      push: jest.fn(),
+      replace: jest.fn(),
+      location: {
+        pathname: '/new/hosts/test-host.example.com',
+        search: '?page=1&per_page=20',
+        hash: '#/Insights',
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('cleanup effect', () => {
+    it('should preserve hash when clearing search params on unmount', () => {
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={mockRouter}
+          />
+        </Provider>
+      );
+
+      // Unmount the component to trigger cleanup
+      unmount();
+
+      // Verify router.replace was called with both search: null AND the existing hash
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+        search: null,
+        hash: '#/Insights',
+      });
+    });
+
+    it('should only clear search params when no hash exists', () => {
+      mockRouter.location.hash = '';
+
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={mockRouter}
+          />
+        </Provider>
+      );
+
+      unmount();
+
+      // When there's no hash, should only pass search: null
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+        search: null,
+      });
+    });
+
+    it('should handle router.location being undefined gracefully', () => {
+      const routerWithoutLocation = {
+        push: jest.fn(),
+        replace: jest.fn(),
+        location: undefined,
+      };
+
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={routerWithoutLocation}
+          />
+        </Provider>
+      );
+
+      unmount();
+
+      // Should still call replace with search: null even if location is undefined
+      expect(routerWithoutLocation.replace).toHaveBeenCalledWith({
+        search: null,
+      });
+    });
+  });
+});

--- a/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
@@ -21,15 +21,6 @@ describe('NewHostDetailsTab', () => {
   let mockRouter;
 
   beforeEach(() => {
-    store = mockStore({
-      insightsHostDetailsTab: {
-        query: '',
-        hits: [],
-        selectedIds: {},
-        error: null,
-      },
-    });
-
     mockRouter = {
       push: jest.fn(),
       replace: jest.fn(),
@@ -37,8 +28,36 @@ describe('NewHostDetailsTab', () => {
         pathname: '/new/hosts/test-host.example.com',
         search: '?page=1&per_page=20',
         hash: '#/Insights',
+        query: { page: '1', per_page: '20' },
       },
     };
+
+    store = mockStore({
+      API: {},
+      ForemanRhCloud: {
+        InsightsCloudSync: {
+          table: {
+            selectedIds: {},
+            isAllSelected: false,
+            showSelectAllAlert: false,
+          },
+        },
+      },
+      insightsHostDetailsTab: {
+        query: '',
+        hits: [],
+        selectedIds: {},
+        error: null,
+      },
+      router: {
+        location: {
+          pathname: '/new/hosts/test-host.example.com',
+          search: '?page=1&per_page=20',
+          hash: '#/Insights',
+          query: { page: '1', per_page: '20' },
+        },
+      },
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Fixes bug where switching from Recommendations tab to another tab (like Parameters) would incorrectly show Overview tab with no tab highlighted
- Modified cleanup effect in NewHostDetailsTab to preserve hash fragment when clearing search parameters
- Added unit tests for the cleanup effect behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Testing steps (human-written)
1. Get a non-IoP setup and a host registered to Insights
2. Go to host details > click Recommendations tab
3. Click Parameters tab

Before:
- Overview tab is displayed
- Parameters tab is highlighted in grey

After:
- Parameters tab is properly highlighted in blue and displayed



## Summary by Sourcery

Preserve host details tab navigation state when leaving the Insights recommendations view.

Bug Fixes:
- Fix incorrect tab display and missing tab highlight when switching from the Recommendations tab to other host detail tabs by retaining the URL hash on cleanup.

Tests:
- Add unit tests verifying that the NewHostDetailsTab cleanup effect preserves the hash fragment when present and safely handles cases with no hash or missing router location.