### PR TITLE
Fix InsightsClientReportStatus when path has no trailing slash

### DIFF
--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -118,13 +118,10 @@ module InsightsCloud::Api
     end
 
     def update_host_insights_status
-      logger.info("update_host_insights_status called - @host: #{@host&.name}, upload_success?: #{upload_success?}, request.path: #{request.path}, @cloud_response.code: #{@cloud_response&.code}")
       return unless upload_success?
-      logger.info("Updating insights status for host #{@host.name}")
       # create insights status if it wasn't there in the first place and refresh its reporting date
       @host.get_status(InsightsClientReportStatus).refresh!
       @host.refresh_global_status!
-      logger.info("Insights status updated for host #{@host.name}")
     end
 
     def update_host_facet
@@ -139,11 +136,9 @@ module InsightsCloud::Api
     end
 
     def upload_success?
-      result = @cloud_response&.code&.to_s&.start_with?('2') &&
+      @cloud_response&.code&.to_s&.start_with?('2') &&
         (request.path == '/redhat_access/r/insights/platform/ingress/v1/upload' ||
-          request.path.include?('/redhat_access/r/insights/uploads/'))
-      logger.info("upload_success? result: #{result}, @cloud_response present: #{@cloud_response.present?}, code: #{@cloud_response&.code}, path: #{request.path}")
-      result
+          request.path.start_with?('/redhat_access/r/insights/uploads'))
     end
   end
 end

--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -118,10 +118,13 @@ module InsightsCloud::Api
     end
 
     def update_host_insights_status
+      logger.info("update_host_insights_status called - @host: #{@host&.name}, upload_success?: #{upload_success?}, request.path: #{request.path}, @cloud_response.code: #{@cloud_response&.code}")
       return unless upload_success?
+      logger.info("Updating insights status for host #{@host.name}")
       # create insights status if it wasn't there in the first place and refresh its reporting date
       @host.get_status(InsightsClientReportStatus).refresh!
       @host.refresh_global_status!
+      logger.info("Insights status updated for host #{@host.name}")
     end
 
     def update_host_facet
@@ -136,9 +139,11 @@ module InsightsCloud::Api
     end
 
     def upload_success?
-      @cloud_response&.code&.to_s&.start_with?('2') &&
+      result = @cloud_response&.code&.to_s&.start_with?('2') &&
         (request.path == '/redhat_access/r/insights/platform/ingress/v1/upload' ||
           request.path.include?('/redhat_access/r/insights/uploads/'))
+      logger.info("upload_success? result: #{result}, @cloud_response present: #{@cloud_response.present?}, code: #{@cloud_response&.code}, path: #{request.path}")
+      result
     end
   end
 end


### PR DESCRIPTION
## Summary
Fixes a bug where `InsightsClientReportStatus` shows "N/A" instead of "Reporting" after successful insights-client uploads.

## Root Cause
The `upload_success?` method in `MachineTelemetriesController` was checking for paths containing `/redhat_access/r/insights/uploads/` (with trailing slash). This failed to match upload requests with paths like `/redhat_access/r/insights/uploads` (without a UUID suffix). `insights-client --test-connection` makes requests to this path.

## The Fix
- Changed from `.include?('/redhat_access/r/insights/uploads/')` to `.start_with?('/redhat_access/r/insights/uploads')`
- Removed trailing slash requirement
- Now correctly matches both path formats:
  - `/redhat_access/r/insights/uploads` ✓
  - `/redhat_access/r/insights/uploads/UUID` ✓

## Impact
Instead of remaining "N/A", hosts will now correctly show "Reporting" status both after a successful insights-client upload, and after a run of `insights-client --test-connection`.

## Test Plan
- [x] Added debug logging to identify the issue
- [x] Confirmed path mismatch in CI logs
- [ ] Verify status updates correctly in robottelo test: `test_insights_registration_with_capsule[rhel9-ipv6]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)