### PR TITLE
SAT-42831 - Fix stale recommendations/CVEs data when switching hosts on All Hosts page

### DIFF
--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -10,7 +10,12 @@ const CVEsHostDetailsTab = ({ systemId }) => {
   const module = './SystemDetailTable';
   return (
     <div className="rh-cloud-insights-vulnerability-host-details-component vulnerability">
-      <ScalprumComponent scope={scope} module={module} systemId={systemId} />
+      <ScalprumComponent
+        key={systemId}
+        scope={scope}
+        module={module}
+        systemId={systemId}
+      />
     </div>
   );
 };

--- a/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
+++ b/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
@@ -11,14 +11,25 @@ jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
   useForemanPermissions: () => new Set(['view_vulnerability']),
 }));
 
-jest.mock('@scalprum/react-core', () => ({
-  ScalprumComponent: jest.fn(props => (
-    <div data-testid="mock-scalprum-component">{JSON.stringify(props)}</div>
-  )),
-  ScalprumProvider: jest.fn(({ children }) => <div>{children}</div>),
-}));
+const mockUnmountTracker = jest.fn();
+jest.mock('@scalprum/react-core', () => {
+  const ReactMock = require('react');
+  return {
+    ScalprumComponent: jest.fn(props => {
+      ReactMock.useEffect(() => mockUnmountTracker, []);
+      return (
+        <div data-testid="mock-scalprum-component">{JSON.stringify(props)}</div>
+      );
+    }),
+    ScalprumProvider: jest.fn(({ children }) => <div>{children}</div>),
+  };
+});
 
 describe('CVEsHostDetailsTabWrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders without crashing', () => {
     const { container } = render(
       <CVEsHostDetailsTabWrapper
@@ -30,5 +41,33 @@ describe('CVEsHostDetailsTabWrapper', () => {
         '.rh-cloud-insights-vulnerability-host-details-component'
       )
     ).toBeTruthy();
+  });
+
+  it('remounts ScalprumComponent when systemId changes', () => {
+    const { ScalprumComponent } = require('@scalprum/react-core');
+
+    const { rerender } = render(
+      <CVEsHostDetailsTabWrapper
+        response={{ subscription_facet_attributes: { uuid: 'uuid-host-A' } }}
+      />
+    );
+
+    expect(mockUnmountTracker).not.toHaveBeenCalled();
+    expect(ScalprumComponent).toHaveBeenLastCalledWith(
+      expect.objectContaining({ systemId: 'uuid-host-A' }),
+      expect.anything()
+    );
+
+    rerender(
+      <CVEsHostDetailsTabWrapper
+        response={{ subscription_facet_attributes: { uuid: 'uuid-host-B' } }}
+      />
+    );
+
+    expect(mockUnmountTracker).toHaveBeenCalledTimes(1);
+    expect(ScalprumComponent).toHaveBeenLastCalledWith(
+      expect.objectContaining({ systemId: 'uuid-host-B' }),
+      expect.anything()
+    );
   });
 });

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -128,17 +128,32 @@ NewHostDetailsTab.defaultProps = {
 const scope = 'advisor';
 const module = './SystemDetailWrapped';
 
-const IopInsightsTab = props => (
-  <div className="advisor">
-    <ScalprumComponent
-      scope={scope}
-      module={module}
-      IopRemediationModal={RemediationModal}
-      generateRuleUrl={generateRuleUrl}
-      {...props}
-    />
-  </div>
-);
+const IopInsightsTab = props => {
+  // eslint-disable-next-line camelcase
+  const systemId = props.response?.subscription_facet_attributes?.uuid;
+  return (
+    <div className="advisor">
+      <ScalprumComponent
+        key={systemId || props.hostName}
+        scope={scope}
+        module={module}
+        IopRemediationModal={RemediationModal}
+        generateRuleUrl={generateRuleUrl}
+        {...props}
+      />
+    </div>
+  );
+};
+
+IopInsightsTab.propTypes = {
+  hostName: PropTypes.string,
+  response: PropTypes.object,
+};
+
+IopInsightsTab.defaultProps = {
+  hostName: '',
+  response: {},
+};
 
 const IopInsightsTabWrapped = props => {
   const permissions = useInsightsPermissions();


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add `key` props to `ScalprumComponent` instances so they remount when navigating between different hosts, instead of keeping stale internal state from the previously viewed host.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
All hosts -> Manage columns -> select recommendations as a column and save

Now All hosts page shows the number of recommendations for each host.

Click on the number of recommendation for host A -> Click all hosts again -> Click the number of recommendation for host B

**Before**
It shows the recommendations for host A instead of host B
Same happens for CVEs as well
(I could not see the behavior with my testing environments - both stream iop devel box and 6.19 iop devel box)

**After**
Correct recommendations/CVEs for each host should be displayed

## Summary by Sourcery

Ensure host details Scalprum components remount when switching between hosts to prevent stale vulnerability and recommendations data.

Bug Fixes:
- Fix stale CVEs and recommendations data shown when navigating between different hosts on the All Hosts page and host details tabs.

Tests:
- Add tests to verify that the CVEs host details Scalprum component unmounts and remounts when the system ID changes.