### PR TITLE
Fix VmaasReposcanSync errors preventing parent task success

### DIFF
--- a/lib/insights_cloud/async/vmaas_reposcan_sync.rb
+++ b/lib/insights_cloud/async/vmaas_reposcan_sync.rb
@@ -49,15 +49,20 @@ module InsightsCloud
 
         response
       rescue RestClient::ExceptionWithResponse => e
-        message = "VMaaS reposcan sync failed: #{e.response&.code} - #{e.response&.body}"
-        logger.error(message)
+        if e.response&.code == 429
+          message = "VMaaS reposcan sync skipped: another sync already in progress (429)"
+          logger.warn(message)
+        else
+          message = "VMaaS reposcan sync failed: #{e.response&.code} - #{e.response&.body}"
+          logger.error(message)
+        end
         output[:message] = message
-        raise
+        # Do NOT raise - let rescue_strategy_for_self Skip handle this
       rescue StandardError => e
-        message = "Error triggering VMaaS reposcan sync: #{e.message}, response: #{e.respond_to?(:response) ? e.response : nil}"
+        message = "Error triggering VMaaS reposcan sync: #{e.message}"
         logger.error(message)
         output[:message] = message
-        raise
+        # Do NOT raise - let rescue_strategy_for_self Skip handle this
       end
 
       def rescue_strategy_for_self

--- a/lib/insights_cloud/async/vmaas_reposcan_sync.rb
+++ b/lib/insights_cloud/async/vmaas_reposcan_sync.rb
@@ -6,6 +6,8 @@ module InsightsCloud
     class VmaasReposcanSync < ::Actions::EntryAction
       include ::ForemanRhCloud::CertAuth
 
+      HTTP_TOO_MANY_REQUESTS = 429
+
       # Subscribe to Katello repository sync hook action, if available
       def self.subscribe
         'Actions::Katello::Repository::SyncHook'.constantize
@@ -49,20 +51,9 @@ module InsightsCloud
 
         response
       rescue RestClient::ExceptionWithResponse => e
-        if e.response&.code == 429
-          message = "VMaaS reposcan sync skipped: another sync already in progress (429)"
-          logger.warn(message)
-        else
-          message = "VMaaS reposcan sync failed: #{e.response&.code} - #{e.response&.body}"
-          logger.error(message)
-        end
-        output[:message] = message
-        # Do NOT raise - let rescue_strategy_for_self Skip handle this
+        handle_rest_client_error(e)
       rescue StandardError => e
-        message = "Error triggering VMaaS reposcan sync: #{e.message}"
-        logger.error(message)
-        output[:message] = message
-        # Do NOT raise - let rescue_strategy_for_self Skip handle this
+        handle_standard_error(e)
       end
 
       def rescue_strategy_for_self
@@ -74,6 +65,25 @@ module InsightsCloud
       end
 
       private
+
+      def handle_rest_client_error(exception)
+        if exception.response&.code == HTTP_TOO_MANY_REQUESTS
+          message = "VMaaS reposcan sync skipped: another sync already in progress (#{HTTP_TOO_MANY_REQUESTS})"
+          logger.warn(message)
+        else
+          message = "VMaaS reposcan sync failed: #{exception.response&.code} - #{exception.response&.body}"
+          logger.error(message)
+        end
+        output[:message] = message
+        # Do NOT raise - let rescue_strategy_for_self Skip handle this
+      end
+
+      def handle_standard_error(exception)
+        message = "Error triggering VMaaS reposcan sync: #{exception.message}"
+        logger.error(message)
+        output[:message] = message
+        # Do NOT raise - let rescue_strategy_for_self Skip handle this
+      end
 
       def logger
         action_logger

--- a/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
+++ b/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
@@ -5,19 +5,17 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
   include ForemanTasks::TestHelpers::WithInThreadExecutor
 
   setup do
-    @root = FactoryBot.build(:katello_root_repository, :fedora_17_x86_64_dev_root)
-    @root.save(validate: false)
-    @repo = FactoryBot.create(
-      :katello_repository,
-      :with_product,
-      distribution_family: 'Red Hat',
-      distribution_version: '7.5',
-      root: @root
-    )
+    @organization = FactoryBot.create(:organization)
+    # Create a simple repository - we only need id and organization_id for the action
+    @repo = ::Katello::Repository.new(id: 1)
+    @repo.stubs(:organization_id).returns(@organization.id)
+    ::Katello::Repository.stubs(:find).with(1).returns(@repo)
+
     @repo_payload = { id: @repo.id }
     @expected_url = 'https://example.com/api/v1/vmaas/reposcan/sync'
     InsightsCloud.stubs(:vmaas_reposcan_sync_url).returns(@expected_url)
     ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+    Organization.stubs(:find).with(@organization.id).returns(@organization)
   end
 
   teardown do
@@ -83,7 +81,7 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
         params[:url] == @expected_url &&
         params[:headers].is_a?(Hash) &&
         params[:headers]['Content-Type'] == 'application/json' &&
-        params[:organization] == @repo.organization
+        params[:organization] == @organization
     end
                                            .returns(mock_response)
 
@@ -116,11 +114,9 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
                                            .stubs(:execute_cloud_request)
                                            .raises(exception)
 
-    error = assert_raises(ForemanTasks::TaskError) do
-      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
-    end
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
 
-    assert_equal 'VMaaS reposcan sync failed: 500 - Server Error', error.task.output[:message]
+    assert_equal 'VMaaS reposcan sync failed: 500 - Server Error', task.output[:message]
   end
 
   test 'run sets error message in task output for StandardError exception' do
@@ -128,25 +124,63 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
                                            .stubs(:execute_cloud_request)
                                            .raises(StandardError.new('Network timeout'))
 
-    error = assert_raises(ForemanTasks::TaskError) do
-      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
-    end
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
 
-    # The task is available via main_action
-    assert_match(/Error triggering VMaaS reposcan sync: Network timeout, response: /,
-      error.task.main_action.output[:message])
+    assert_equal 'Error triggering VMaaS reposcan sync: Network timeout', task.output[:message]
   end
 
-  test 'run logs and re-raises when cloud request returns error response' do
-    error_response = mock('error_response', code: 500, body: 'error')
+  test 'run logs and handles error response without raising' do
+    error_response = mock('error_response')
+    error_response.stubs(:code).returns(500)
+    error_response.stubs(:body).returns('error')
     exception = RestClient::ExceptionWithResponse.new(error_response)
 
     InsightsCloud::Async::VmaasReposcanSync.any_instance
                                            .stubs(:execute_cloud_request)
                                            .raises(exception)
 
-    assert_raises(ForemanTasks::TaskError) do
-      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
-    end
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync failed: 500 - error', task.output[:message]
+  end
+
+  test 'run handles 429 error with warning log level' do
+    error_response = mock('error_response')
+    error_response.stubs(:code).returns(429)
+    error_response.stubs(:body).returns('{"msg": "Another task already in progress"}')
+    exception = RestClient::ExceptionWithResponse.new(error_response)
+
+    mock_logger = mock('logger')
+    mock_logger.expects(:warn).with('VMaaS reposcan sync skipped: another sync already in progress (429)')
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync skipped: another sync already in progress (429)',
+                 task.output[:message]
+  end
+
+  test 'run handles non-429 errors with error log level' do
+    error_response = mock('error_response')
+    error_response.stubs(:code).returns(500)
+    error_response.stubs(:body).returns('Internal Server Error')
+    exception = RestClient::ExceptionWithResponse.new(error_response)
+
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with('VMaaS reposcan sync failed: 500 - Internal Server Error')
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync failed: 500 - Internal Server Error',
+                 task.output[:message]
   end
 end

--- a/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
+++ b/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
@@ -161,7 +161,7 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
     task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
 
     assert_equal 'VMaaS reposcan sync skipped: another sync already in progress (429)',
-                 task.output[:message]
+      task.output[:message]
   end
 
   test 'run handles non-429 errors with error log level' do
@@ -181,6 +181,6 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
     task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
 
     assert_equal 'VMaaS reposcan sync failed: 500 - Internal Server Error',
-                 task.output[:message]
+      task.output[:message]
   end
 end

--- a/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
+++ b/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
@@ -120,6 +120,10 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
   end
 
   test 'run sets error message in task output for StandardError exception' do
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with('Error triggering VMaaS reposcan sync: Network timeout')
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+
     InsightsCloud::Async::VmaasReposcanSync.any_instance
                                            .stubs(:execute_cloud_request)
                                            .raises(StandardError.new('Network timeout'))
@@ -182,5 +186,22 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
 
     assert_equal 'VMaaS reposcan sync failed: 500 - Internal Server Error',
       task.output[:message]
+  end
+
+  test 'run handles RestClient::ExceptionWithResponse with nil response' do
+    exception = RestClient::ExceptionWithResponse.new(nil)
+
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with('VMaaS reposcan sync failed:  - ')
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    refute_nil task.output[:message]
+    assert_equal 'VMaaS reposcan sync failed:  - ', task.output[:message]
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When `VmaasReposcanSync` receives an error from the IoP service (especially HTTP 429 during concurrent repository syncs), the action was catching exceptions but then re-raising them. This prevented Dynflow's `rescue_strategy_for_self` Skip from working correctly, causing parent Katello repository sync tasks to fail.

This PR:
- Removes `raise` statements from both rescue blocks in the `run` method
- Adds special handling for 429 errors with WARN log level (expected during concurrent syncs)
- Logs other HTTP errors at ERROR level without propagating to parent tasks
- Updates tests to verify graceful error handling without task failures
- Adds new tests for 429-specific handling and log level verification

#### Considerations taken when implementing this change?

1. **429 errors are expected behavior** - When multiple repositories sync concurrently, the IoP service returns 429 (Too Many Requests) to prevent overload. This is not an error condition that should fail the repository sync.

2. **Preserve error visibility** - While errors no longer fail parent tasks, they're still logged at appropriate levels (WARN for 429, ERROR for other failures) and stored in `output[:message]` for task detail visibility.

3. **Dynflow rescue strategy** - The existing `rescue_strategy_for_self` Skip only works when exceptions are handled internally. By removing `raise`, we allow Dynflow to skip failed subtasks without failing the parent.

4. **Test simplification** - Simplified test setup to use stubs instead of complex Katello factory traits, avoiding environment-specific factory issues while maintaining test coverage.

#### What are the testing steps for this pull request?

**Automated testing:**
```bash
cd /home/vagrant/foreman
bundle exec rake test TEST=/home/vagrant/foreman_rh_cloud/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
```

Expected: All 12 tests pass (18 assertions, 0 failures, 0 errors)

**Manual testing in IoP environment:**

1. Set up IoP Smart Proxy in development environment
2. Trigger concurrent repository syncs:
   ```ruby
   # In Rails console
   org = Organization.first
   repos = org.repos.first(3)
   repos.each { |repo| ForemanTasks.async_task(Actions::Katello::Repository::Sync, repo) }
   ```
3. Verify:
   - Repository sync tasks succeed even if VMaaS reposcan returns 429
   - Check Foreman task details to see reposcan messages in subtask output
   - Tail logs to verify WARN vs ERROR logging:
     ```bash
     tail -f /var/log/foreman/production.log | grep -i vmaas
     ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle VMaaS reposcan sync errors without failing parent tasks and add dedicated handling for 429 responses.

Bug Fixes:
- Prevent VMaaS reposcan sync exceptions from propagating and causing parent repository sync tasks to fail.
- Treat 429 Too Many Requests responses from the VMaaS reposcan service as expected, non-fatal conditions.

Enhancements:
- Simplify repository setup in VMaaS reposcan sync tests by stubbing minimal dependencies instead of using complex Katello factories.
- Log 429 VMaaS reposcan sync responses at WARN level and other HTTP/standard errors at ERROR level while recording clear messages in task output.

Tests:
- Update existing VMaaS reposcan sync tests to assert on task output instead of raised task errors.
- Add new tests to verify 429-specific handling, log levels, and non-raising behavior for REST error responses.