### PR TITLE
Release 12.2.16

### DIFF
--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -150,7 +150,7 @@ module ForemanRhCloud
         end
 
         ::Foreman::Plugin.app_metadata_registry.register(:foreman_rh_cloud, {
-          iop: ForemanRhCloud.with_iop_smart_proxy?,
+          iop: -> { ForemanRhCloud.with_iop_smart_proxy? },
         })
 
         extend_template_helpers ForemanRhCloud::TemplateRendererHelper

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.2.15'.freeze
+  VERSION = '12.2.16'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.2.15",
+  "version": "12.2.16",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Prepare the 12.2.16 release of foreman_rh_cloud.

Bug Fixes:
- Register the iop app metadata entry as a callable to ensure ForemanRhCloud.with_iop_smart_proxy? is evaluated lazily.

Build:
- Bump foreman_rh_cloud Ruby and npm package versions to 12.2.16.