### PR TITLE
Improve inventory stats with USER_OMITTED status and enhanced UX

### DIFF
--- a/app/controllers/concerns/insights_cloud/candlepin_proxies_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/candlepin_proxies_extensions.rb
@@ -1,0 +1,23 @@
+module InsightsCloud
+  module CandlepinProxiesExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      # Update insights client status when hosts check in via subscription-manager facts upload
+      # rubocop:disable Rails/LexicallyScopedActionFilter
+      after_action :update_insights_client_status, only: [:facts]
+      # rubocop:enable Rails/LexicallyScopedActionFilter
+    end
+
+    def update_insights_client_status
+      # Update InsightsClientReportStatus whenever host checks in via subscription-manager
+      # This ensures USER_OMITTED status gets set even when insights-client isn't installed
+      # (parameter=false means insights-client won't be installed, so it won't hit MachineTelemetriesController)
+      hoststatus = @host.get_status(InsightsClientReportStatus)
+      Rails.logger.debug "Current status: #{hoststatus.to_label}"
+      @host.get_status(InsightsClientReportStatus).refresh!
+      @host.refresh_global_status!
+      Rails.logger.debug "New status: #{hoststatus.to_label}"
+    end
+  end
+end

--- a/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
+++ b/app/controllers/concerns/insights_cloud/package_profile_upload_extensions.rb
@@ -6,6 +6,7 @@ module InsightsCloud
       # This method explicitly listens on Katello actions
       # rubocop:disable Rails/LexicallyScopedActionFilter
       after_action :generate_host_report, only: [:upload_package_profile, :upload_profiles]
+      after_action :update_insights_client_status, only: [:upload_package_profile, :upload_profiles]
       # rubocop:enable Rails/LexicallyScopedActionFilter
     end
 
@@ -30,6 +31,14 @@ module InsightsCloud
 
       insights_facet = @host.build_insights(uuid: @host.subscription_facet.uuid)
       insights_facet.save
+    end
+
+    def update_insights_client_status
+      # Update InsightsClientReportStatus whenever host checks in via subscription-manager
+      # This ensures USER_OMITTED status gets set even when insights-client isn't installed
+      # (parameter=false means insights-client won't be installed, so it won't hit MachineTelemetriesController)
+      @host.get_status(InsightsClientReportStatus).refresh!
+      @host.refresh_global_status!
     end
   end
 end

--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -88,9 +88,16 @@ module InsightsCloud::Api
     private
 
     def ensure_telemetry_enabled_for_consumer
-      unless (config = telemetry_config(@host))
+      config = telemetry_config(@host)
+
+      # Always update the status based on current parameter value
+      # This will set USER_OMITTED if parameter is false, or REPORTING/NO_REPORT if true
+      @host.get_status(InsightsClientReportStatus).refresh!
+      @host.refresh_global_status!
+
+      unless config
         logger.debug("Rejected telemetry forwarding for host #{@host.name}, insights param is set to: #{config}")
-        render_message 'Telemetry is not enabled for this host', :status => 403
+        return render_message('Telemetry is not enabled for this host', :status => 403)
       end
       config
     end

--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -20,7 +20,8 @@ module RhCloudHost
     has_one :inventory_sync_status_object, :class_name => '::InventorySync::InventoryStatus', :foreign_key => 'host_id'
     scoped_search :relation => :inventory_sync_status_object, :on => :status, :rename => :insights_inventory_sync_status,
       :complete_value => { :disconnect => ::InventorySync::InventoryStatus::DISCONNECT,
-                           :sync => ::InventorySync::InventoryStatus::SYNC }
+                           :sync => ::InventorySync::InventoryStatus::SYNC,
+                           :user_omitted => ::InventorySync::InventoryStatus::USER_OMITTED }
     scoped_search :on => :id, :rename => :insights_uuid, :only_explicit => true,
       :ext_method => :search_by_insights_uuid, :complete_value => false
 

--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -15,7 +15,8 @@ module RhCloudHost
     has_one :insights_client_report_status_object, :class_name => '::InsightsClientReportStatus', :foreign_key => 'host_id'
     scoped_search :relation => :insights_client_report_status_object, :on => :status, :rename => :insights_client_report_status,
       :complete_value => { :reporting => ::InsightsClientReportStatus::REPORTING,
-                           :no_report => ::InsightsClientReportStatus::NO_REPORT }
+                           :no_report => ::InsightsClientReportStatus::NO_REPORT,
+                           :user_omitted => ::InsightsClientReportStatus::USER_OMITTED }
 
     has_one :inventory_sync_status_object, :class_name => '::InventorySync::InventoryStatus', :foreign_key => 'host_id'
     scoped_search :relation => :inventory_sync_status_object, :on => :status, :rename => :insights_inventory_sync_status,

--- a/app/models/insights_client_report_status.rb
+++ b/app/models/insights_client_report_status.rb
@@ -35,8 +35,8 @@ class InsightsClientReportStatus < HostStatus::Status
   end
 
   def to_status
-    excluded_by_host_param = 
-      ::Foreman::Cast.to_bool(self.host.parameters.find_by(name: 'host_registration_insights')&.value) == false
+    excluded_by_host_param =
+      ::Foreman::Cast.to_bool(host.parameters.find_by(name: 'host_registration_insights')&.value) == false
     return USER_OMITTED if excluded_by_host_param
     in_interval? ? REPORTING : NO_REPORT
   end

--- a/app/models/insights_client_report_status.rb
+++ b/app/models/insights_client_report_status.rb
@@ -3,8 +3,9 @@ class InsightsClientReportStatus < HostStatus::Status
 
   REPORTING             = 0
   NO_REPORT             = 1
+  USER_OMITTED          = 2
 
-  scope :stale, -> { where.not(reported_at: (Time.now - REPORT_INTERVAL)..Time.now) }
+  scope :stale, -> { where.not(status: USER_OMITTED).where.not(reported_at: (Time.now - REPORT_INTERVAL)..Time.now) }
   scope :reporting, -> { where(status: REPORTING) }
 
   def self.status_name
@@ -17,6 +18,8 @@ class InsightsClientReportStatus < HostStatus::Status
       N_('Reporting')
     when NO_REPORT
       N_('Not reporting')
+    when USER_OMITTED
+      N_('Not reporting because host_registration_insights parameter value is false')
     end
   end
 
@@ -26,10 +29,15 @@ class InsightsClientReportStatus < HostStatus::Status
       ::HostStatus::Global::OK
     when NO_REPORT
       ::HostStatus::Global::ERROR
+    when USER_OMITTED
+      ::HostStatus::Global::OK
     end
   end
 
   def to_status
+    excluded_by_host_param = 
+      ::Foreman::Cast.to_bool(self.host.parameters.find_by(name: 'host_registration_insights')&.value) == false
+    return USER_OMITTED if excluded_by_host_param
     in_interval? ? REPORTING : NO_REPORT
   end
 

--- a/app/models/insights_client_report_status.rb
+++ b/app/models/insights_client_report_status.rb
@@ -36,7 +36,7 @@ class InsightsClientReportStatus < HostStatus::Status
 
   def to_status
     excluded_by_host_param =
-      ::Foreman::Cast.to_bool(host.parameters.find_by(name: 'host_registration_insights')&.value) == false
+      ::Foreman::Cast.to_bool(host.host_param('host_registration_insights')) == false
     return USER_OMITTED if excluded_by_host_param
     in_interval? ? REPORTING : NO_REPORT
   end

--- a/app/models/inventory_sync/inventory_status.rb
+++ b/app/models/inventory_sync/inventory_status.rb
@@ -24,11 +24,11 @@ module InventorySync
     def to_label
       case status
       when DISCONNECT
-        N_('Host was not uploaded to your RH cloud inventory')
+        N_('Host is not present on console.redhat.com Inventory service')
       when SYNC
-        N_('Included in RH cloud inventory uploads')
+        N_('Host is uploaded and present on console.redhat.com Inventory service')
       when USER_OMITTED
-        N_('Not included in RH cloud inventory due to host parameter')
+        N_('Host is excluded from upload to console.redhat.com Inventory service due to host parameter')
       end
     end
 

--- a/app/models/inventory_sync/inventory_status.rb
+++ b/app/models/inventory_sync/inventory_status.rb
@@ -33,7 +33,7 @@ module InventorySync
     end
 
     def to_status(options = {})
-      # Normally this method used to calculate status.
+      # Normally, this method is used to calculate status.
       # In foreman_rh_cloud 'we do things a bit differently around here.'
       # Calculation is done externally in InventorySync::Async::InventoryFullSync, so we simply return the previously calculated status.
       status

--- a/app/models/inventory_sync/inventory_status.rb
+++ b/app/models/inventory_sync/inventory_status.rb
@@ -38,5 +38,11 @@ module InventorySync
       # Calculation is done externally in InventorySync::Async::InventoryFullSync, so we simply return the previously calculated status.
       status
     end
+
+    def relevant?(_options = {})
+      # Inventory status is not relevant in IoP mode since we use single-host reports
+      # that don't sync with the cloud inventory service
+      !ForemanRhCloud.with_iop_smart_proxy?
+    end
   end
 end

--- a/app/models/inventory_sync/inventory_status.rb
+++ b/app/models/inventory_sync/inventory_status.rb
@@ -2,6 +2,7 @@ module InventorySync
   class InventoryStatus < HostStatus::Status
     DISCONNECT = 0
     SYNC = 1
+    USER_OMITTED = 2
 
     def self.status_name
       N_('Inventory')
@@ -13,6 +14,8 @@ module InventorySync
         ::HostStatus::Global::WARN
       when SYNC
         ::HostStatus::Global::OK
+      when USER_OMITTED
+        ::HostStatus::Global::OK
       else
         ::HostStatus::Global::WARN
       end
@@ -23,13 +26,16 @@ module InventorySync
       when DISCONNECT
         N_('Host was not uploaded to your RH cloud inventory')
       when SYNC
-        N_('Successfully uploaded to your RH cloud inventory')
+        N_('Included in RH cloud inventory uploads')
+      when USER_OMITTED
+        N_('Not included in RH cloud inventory due to host parameter')
       end
     end
 
     def to_status(options = {})
-      # this method used to calculate status.
-      # Since the calculation is done externally we should return the previously calculated status
+      # Normally this method used to calculate status.
+      # In foreman_rh_cloud 'we do things a bit differently around here.'
+      # Calculation is done externally in InventorySync::Async::InventoryFullSync, so we simply return the previously calculated status.
       status
     end
   end

--- a/lib/foreman_rh_cloud/engine.rb
+++ b/lib/foreman_rh_cloud/engine.rb
@@ -40,6 +40,7 @@ module ForemanRhCloud
         ::Host::Managed.include RhCloudHost
 
         ::Katello::Api::Rhsm::CandlepinDynflowProxyController.include InsightsCloud::PackageProfileUploadExtensions
+        ::Katello::Api::Rhsm::CandlepinProxiesController.include InsightsCloud::CandlepinProxiesExtensions
         ::Katello::RegistrationManager.singleton_class.prepend ::ForemanRhCloud::RegistrationManagerExtensions
       end
     end

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -17,6 +17,11 @@ module InventorySync
         @subscribed_hosts_ids = Set.new(affected_host_ids)
         @omitted_ids = Set.new(user_omitted_host_ids)
 
+        # Remove user-omitted hosts from subscribed set. In normal operation, affected_host_ids
+        # already excludes user-omitted hosts via for_slice, but this handles edge cases like
+        # a host transitioning from uploaded to user-omitted between syncs.
+        @subscribed_hosts_ids.subtract(@omitted_ids)
+
         InventorySync::InventoryStatus.transaction do
           InventorySync::InventoryStatus.where(host_id: @subscribed_hosts_ids).delete_all
           yield

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -24,6 +24,7 @@ module InventorySync
 
         InventorySync::InventoryStatus.transaction do
           InventorySync::InventoryStatus.where(host_id: @subscribed_hosts_ids).delete_all
+          InventorySync::InventoryStatus.where(host_id: @omitted_ids).delete_all
           yield
           add_missing_hosts_statuses(@subscribed_hosts_ids) # any remaining hosts after yield are disconnected
           add_user_omitted_host_statuses(@omitted_ids)

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -100,12 +100,13 @@ module InventorySync
       def user_omitted_host_ids
         param_name = InsightsCloud.enable_client_param_inventory
 
-        # Load parameters (not hosts) and filter using Foreman::Cast.to_bool
-        Parameter.where(
-          name: param_name,
-          reference_id: Host.unscoped.where(organization: organizations).select(:id),
-          type: 'HostParameter'
-        ).select { |param| ::Foreman::Cast.to_bool(param.value) == false }.map(&:reference_id)
+        # Use search_for to respect parameter inheritance (global, org, hostgroup, host)
+        # This matches the same logic used by for_slice, ensuring consistency
+        Host.unscoped
+            .where(organization: organizations)
+            .joins(:subscription_facet)
+            .search_for("params.#{param_name} = f")
+            .pluck(:id)
       end
     end
   end

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -57,14 +57,6 @@ module InventorySync
         InventorySync::InventoryStatus.create(status_hashes)
         updated_ids = status_hashes.map { |hash| hash[:host_id] }
         @subscribed_hosts_ids.subtract(updated_ids)
-        # also refresh the InsightsClientReportStatus so hosts that are user-omitted will not show as irrelevant
-        # Eager load associations to avoid N+1 queries: parameters used in to_status, host_statuses used by get_status
-        ::Host.where(id: updated_ids)
-              .includes(:parameters, :host_statuses)
-              .each do |host|
-          insights_client_report_status = host.get_status(::InsightsClientReportStatus)
-          insights_client_report_status.refresh!
-        end
       end
 
       def add_missing_hosts_statuses(hosts_ids)

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -23,9 +23,7 @@ module InventorySync
           add_missing_hosts_statuses(@subscribed_hosts_ids) # any remaining hosts after yield are disconnected
           add_user_omitted_host_statuses(@omitted_ids)
           host_statuses[:disconnect] += @subscribed_hosts_ids.size
-          logger.debug("Disconnected hosts: #{@subscribed_hosts_ids.map { |id| Host.find(id).name }}")
           host_statuses[:user_omitted] += @omitted_ids.size
-          logger.debug("User-omitted hosts: #{@omitted_ids.map { |id| Host.find(id).name }}")
         end
 
         logger.debug("Synced hosts count: #{host_statuses[:sync]}")
@@ -57,7 +55,7 @@ module InventorySync
         # also refresh the InsightsClientReportStatus so hosts that are user-omitted will not show as irrelevant
         updated_ids.each do |host_id|
           host = ::Host.find_by(id: host_id)
-          next unless host.present?
+          next if host.blank?
           insights_client_report_status = host.get_status(::InsightsClientReportStatus)
           insights_client_report_status.refresh!
         end

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -50,9 +50,17 @@ module InventorySync
       private
 
       def update_hosts_status(status_hashes)
+        # create Inventory statuses
         InventorySync::InventoryStatus.create(status_hashes)
         updated_ids = status_hashes.map { |hash| hash[:host_id] }
         @subscribed_hosts_ids.subtract(updated_ids)
+        # also refresh the InsightsClientReportStatus so hosts that are user-omitted will not show as irrelevant
+        updated_ids.each do |host_id|
+          host = ::Host.find_by(id: host_id)
+          next unless host.present?
+          insights_client_report_status = host.get_status(::InsightsClientReportStatus)
+          insights_client_report_status.refresh!
+        end
       end
 
       def add_missing_hosts_statuses(hosts_ids)

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -58,9 +58,10 @@ module InventorySync
         updated_ids = status_hashes.map { |hash| hash[:host_id] }
         @subscribed_hosts_ids.subtract(updated_ids)
         # also refresh the InsightsClientReportStatus so hosts that are user-omitted will not show as irrelevant
-        updated_ids.each do |host_id|
-          host = ::Host.find_by(id: host_id)
-          next if host.blank?
+        # Eager load associations to avoid N+1 queries: parameters used in to_status, host_statuses used by get_status
+        ::Host.where(id: updated_ids)
+              .includes(:parameters, :host_statuses)
+              .each do |host|
           insights_client_report_status = host.get_status(::InsightsClientReportStatus)
           insights_client_report_status.refresh!
         end

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -100,11 +100,14 @@ module InventorySync
       end
 
       def user_omitted_host_ids
-        Host.unscoped.where(
-          organization: organizations
-        ).search_for(
-          "params.#{InsightsCloud.enable_client_param_inventory} = f"
-        ).pluck(:id)
+        param_name = InsightsCloud.enable_client_param_inventory
+
+        # Load parameters (not hosts) and filter using Foreman::Cast.to_bool
+        Parameter.where(
+          name: param_name,
+          reference_id: Host.unscoped.where(organization: organizations).select(:id),
+          type: 'HostParameter'
+        ).select { |param| ::Foreman::Cast.to_bool(param.value) == false }.map(&:reference_id)
       end
     end
   end

--- a/lib/inventory_sync/async/inventory_full_sync.rb
+++ b/lib/inventory_sync/async/inventory_full_sync.rb
@@ -15,16 +15,22 @@ module InventorySync
 
       def setup_statuses
         @subscribed_hosts_ids = Set.new(affected_host_ids)
+        @omitted_ids = Set.new(user_omitted_host_ids)
 
         InventorySync::InventoryStatus.transaction do
           InventorySync::InventoryStatus.where(host_id: @subscribed_hosts_ids).delete_all
           yield
-          add_missing_hosts_statuses(@subscribed_hosts_ids)
+          add_missing_hosts_statuses(@subscribed_hosts_ids) # any remaining hosts after yield are disconnected
+          add_user_omitted_host_statuses(@omitted_ids)
           host_statuses[:disconnect] += @subscribed_hosts_ids.size
+          logger.debug("Disconnected hosts: #{@subscribed_hosts_ids.map { |id| Host.find(id).name }}")
+          host_statuses[:user_omitted] += @omitted_ids.size
+          logger.debug("User-omitted hosts: #{@omitted_ids.map { |id| Host.find(id).name }}")
         end
 
-        logger.debug("Synced hosts amount: #{host_statuses[:sync]}")
-        logger.debug("Disconnected hosts amount: #{host_statuses[:disconnect]}")
+        logger.debug("Synced hosts count: #{host_statuses[:sync]}")
+        logger.debug("Disconnected hosts count: #{host_statuses[:disconnect]}")
+        logger.debug("User-omitted hosts count: #{host_statuses[:user_omitted]}")
         output[:host_statuses] = host_statuses
       end
 
@@ -61,16 +67,37 @@ module InventorySync
         )
       end
 
+      def add_user_omitted_host_statuses(host_ids)
+        InventorySync::InventoryStatus.create(
+          host_ids.map do |host_id|
+            {
+              host_id: host_id,
+              status: InventorySync::InventoryStatus::USER_OMITTED,
+              reported_at: DateTime.current,
+            }
+          end
+        )
+      end
+
       def host_statuses
         @host_statuses ||= {
           sync: 0,
           disconnect: 0,
+          user_omitted: 0,
         }
       end
 
       def affected_host_ids
         ForemanInventoryUpload::Generators::Queries.for_slice(
           Host.unscoped.where(organization: organizations)
+        ).pluck(:id)
+      end
+
+      def user_omitted_host_ids
+        Host.unscoped.where(
+          organization: organizations
+        ).search_for(
+          "params.#{InsightsCloud.enable_client_param_inventory} = f"
         ).pluck(:id)
       end
     end

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -173,12 +173,10 @@ module InsightsCloud::Api
       end
 
       test "should update InsightsClientReportStatus when parameter is false and block request" do
-        # Set the host parameter for the status refresh (which uses parameters.find_by)
-        @host.host_parameters << HostParameter.create(
-          name: InsightsCloud.enable_client_param,
-          value: 'false',
-          parameter_type: 'boolean'
-        )
+        # Remove the common parameter from setup and set it to false
+        CommonParameter.where(name: InsightsCloud.enable_client_param).delete_all
+        FactoryBot.create(:common_parameter, name: InsightsCloud.enable_client_param, key_type: 'boolean', value: false)
+
         # Stub telemetry_config to return false (disabled)
         InsightsCloud::Api::MachineTelemetriesController.any_instance.stubs(:telemetry_config).returns(false)
 

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -4,6 +4,7 @@ require 'rest-client'
 module InsightsCloud::Api
   class MachineTelemetriesControllerTest < ActionController::TestCase
     include KatelloCVEHelper
+    include CandlepinIsolation
 
     setup do
       FactoryBot.create(:common_parameter, name: InsightsCloud.enable_client_param, key_type: 'boolean', value: true)
@@ -169,6 +170,47 @@ module InsightsCloud::Api
         get :forward_request, params: { "path" => "/redhat_access/r/insights/uploads/" }
 
         assert_not_nil InsightsFacet.find_by(host_id: @host.id)
+      end
+
+      test "should update InsightsClientReportStatus when parameter is false and block request" do
+        # Set the host parameter for the status refresh (which uses parameters.find_by)
+        @host.host_parameters << HostParameter.create(
+          name: InsightsCloud.enable_client_param,
+          value: 'false',
+          parameter_type: 'boolean'
+        )
+        # Stub telemetry_config to return false (disabled)
+        InsightsCloud::Api::MachineTelemetriesController.any_instance.stubs(:telemetry_config).returns(false)
+
+        get :forward_request, params: { "path" => "platform/ingress/v1/upload" }
+
+        # Request should be blocked
+        assert_response 403
+        assert_equal 'Telemetry is not enabled for this host', JSON.parse(@response.body)['message']
+
+        # But status should be updated to USER_OMITTED
+        @host.reload
+        insights_status = @host.get_status(InsightsClientReportStatus)
+        assert insights_status.persisted?, 'InsightsClientReportStatus should be created'
+        assert_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status
+      end
+
+      test "should update InsightsClientReportStatus on successful upload" do
+        # Stub telemetry_config to return true (enabled) - common param from setup works for this
+        InsightsCloud::Api::MachineTelemetriesController.any_instance.stubs(:telemetry_config).returns(true)
+
+        net_http_resp = Net::HTTPResponse.new(1.0, 200, "OK")
+        res = RestClient::Response.create('response body', net_http_resp, @http_req)
+        ::ForemanRhCloud::CloudRequestForwarder.any_instance.stubs(:forward_request).returns(res)
+
+        get :forward_request, params: { "path" => "/redhat_access/r/insights/uploads/" }
+
+        assert_response :success
+
+        # Status should have been refreshed during the request
+        @host.reload
+        insights_status = @host.get_status(InsightsClientReportStatus)
+        assert insights_status.persisted?, 'InsightsClientReportStatus should be created and persisted'
       end
     end
 

--- a/test/controllers/insights_cloud/candlepin_proxies_extensions_test.rb
+++ b/test/controllers/insights_cloud/candlepin_proxies_extensions_test.rb
@@ -1,0 +1,70 @@
+require 'test_plugin_helper'
+
+module InsightsCloud
+  class CandlepinProxiesExtensionsTest < ActiveSupport::TestCase
+    setup do
+      @organization = FactoryBot.create(:organization)
+      @host = FactoryBot.create(:host, :with_subscription, :managed, organization: @organization)
+    end
+
+    test 'updates InsightsClientReportStatus to USER_OMITTED when parameter is false' do
+      # Set parameter to false so status should be USER_OMITTED
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: false)
+
+      # Simulate what the callback does
+      @host.get_status(InsightsClientReportStatus).refresh!
+      @host.refresh_global_status!
+
+      # Verify the status was updated
+      @host.reload
+      insights_status = @host.get_status(InsightsClientReportStatus)
+      assert insights_status.persisted?, 'InsightsClientReportStatus should be persisted'
+      assert_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status,
+        'Status should be USER_OMITTED when host_registration_insights=false'
+    end
+
+    test 'sets USER_OMITTED status when parameter is inherited from hostgroup' do
+      # Create hostgroup with parameter
+      hostgroup = FactoryBot.create(:hostgroup)
+      hostgroup.group_parameters << GroupParameter.create(
+        name: 'host_registration_insights',
+        value: 'false',
+        key_type: 'boolean'
+      )
+      hostgroup.save!
+
+      @host.hostgroup = hostgroup
+      @host.save!
+
+      # Simulate what the callback does
+      @host.get_status(InsightsClientReportStatus).refresh!
+      @host.refresh_global_status!
+
+      # Verify status respects inherited parameter
+      @host.reload
+      insights_status = @host.get_status(InsightsClientReportStatus)
+      assert_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status,
+        'Status should be USER_OMITTED when host_registration_insights=false is inherited from hostgroup'
+    end
+
+    test 'refreshes global status' do
+      FactoryBot.create(:common_parameter, name: 'host_registration_insights', key_type: 'boolean', value: true)
+
+      # Simulate what the callback does
+      @host.get_status(InsightsClientReportStatus).refresh!
+      @host.refresh_global_status!
+
+      # Verify global status was updated
+      @host.reload
+      assert_not_nil @host.global_status, 'Global status should be set'
+    end
+
+    test 'CandlepinProxiesController includes the update_insights_client_status method' do
+      # Verify the concern is included and method is available
+      controller = Katello::Api::Rhsm::CandlepinProxiesController.new
+
+      assert_respond_to controller, :update_insights_client_status,
+        'CandlepinProxiesController should have update_insights_client_status method from concern'
+    end
+  end
+end

--- a/test/jobs/insights_client_status_aging_test.rb
+++ b/test/jobs/insights_client_status_aging_test.rb
@@ -31,4 +31,44 @@ class InsightsClientStatusAgingTest < ActiveSupport::TestCase
     assert_equal InsightsClientReportStatus::NO_REPORT, @host3.get_status(InsightsClientReportStatus).status
     assert_equal InsightsClientReportStatus::NO_REPORT, @host4.get_status(InsightsClientReportStatus).status
   end
+
+  test 'aging job does not affect USER_OMITTED hosts' do
+    # Host 1: USER_OMITTED with old reported_at (should stay USER_OMITTED)
+    InsightsClientReportStatus.find_or_initialize_by(host_id: @host1.id).update(
+      status: InsightsClientReportStatus::USER_OMITTED,
+      reported_at: Time.now - InsightsClientReportStatus::REPORT_INTERVAL - 1.day
+    )
+
+    # Host 2: REPORTING with old reported_at (should change to NO_REPORT)
+    InsightsClientReportStatus.find_or_initialize_by(host_id: @host2.id).update(
+      status: InsightsClientReportStatus::REPORTING,
+      reported_at: Time.now - InsightsClientReportStatus::REPORT_INTERVAL - 1.day
+    )
+
+    # Host 3: USER_OMITTED with recent reported_at (should stay USER_OMITTED)
+    InsightsClientReportStatus.find_or_initialize_by(host_id: @host3.id).update(
+      status: InsightsClientReportStatus::USER_OMITTED,
+      reported_at: Time.now - 1.day
+    )
+
+    # Host 4: REPORTING with recent reported_at (should stay REPORTING)
+    InsightsClientReportStatus.find_or_initialize_by(host_id: @host4.id).update(
+      status: InsightsClientReportStatus::REPORTING,
+      reported_at: Time.now - 1.day
+    )
+
+    action = create_and_plan_action(InsightsCloud::Async::InsightsClientStatusAging)
+    run_action(action)
+
+    @hosts.each(&:reload)
+
+    assert_equal InsightsClientReportStatus::USER_OMITTED, @host1.get_status(InsightsClientReportStatus).status,
+      'USER_OMITTED host with old report should stay USER_OMITTED'
+    assert_equal InsightsClientReportStatus::NO_REPORT, @host2.get_status(InsightsClientReportStatus).status,
+      'REPORTING host with old report should change to NO_REPORT'
+    assert_equal InsightsClientReportStatus::USER_OMITTED, @host3.get_status(InsightsClientReportStatus).status,
+      'USER_OMITTED host with recent report should stay USER_OMITTED'
+    assert_equal InsightsClientReportStatus::REPORTING, @host4.get_status(InsightsClientReportStatus).status,
+      'REPORTING host with recent report should stay REPORTING'
+  end
 end

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -5,6 +5,7 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
   include Dynflow::Testing::Factories
   include MockCerts
   include KatelloCVEHelper
+  include CandlepinIsolation
 
   setup do
     User.current = User.find_by(login: 'secret_admin')

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -464,4 +464,62 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
       InventorySync::InventoryStatus.where(host_id: @host2.id).first.status,
       'Normal host should have SYNC status'
   end
+
+  test 'user-omitted statuses are cleared before re-creating them to avoid silent create failures' do
+    # First sync: host1 is user-omitted
+    @host1.host_parameters << HostParameter.create(
+      name: 'host_registration_insights_inventory',
+      value: 'false',
+      parameter_type: 'boolean'
+    )
+    @host1.save!
+
+    setup_certs_expectation do
+      InventorySync::Async::InventoryFullSync.any_instance.stubs(:candlepin_id_cert)
+    end
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory).twice
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:affected_host_ids).returns([@host1.id, @host2.id]).twice
+    FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
+
+    # Run first sync
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action)
+
+    @host1.reload
+    initial_status = InventorySync::InventoryStatus.where(host_id: @host1.id).first
+    assert_equal InventorySync::InventoryStatus::USER_OMITTED, initial_status.status,
+      'Initial sync: host should be USER_OMITTED'
+    initial_status_id = initial_status.id
+
+    # Verify there's only one status record for host1
+    assert_equal 1, InventorySync::InventoryStatus.where(host_id: @host1.id).count,
+      'Should have exactly one status record after first sync'
+
+    # Run second sync (parameter still false)
+    # Without clearing old user_omitted statuses, the .create would silently fail
+    # with 'Host has already been taken' due to uniqueness constraint
+    setup_certs_expectation do
+      InventorySync::Async::InventoryFullSync.any_instance.stubs(:candlepin_id_cert)
+    end
+
+    action2 = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action2)
+
+    @host1.reload
+    final_status = InventorySync::InventoryStatus.where(host_id: @host1.id).first
+
+    # Verify status is still USER_OMITTED (not stale from first sync)
+    assert_equal InventorySync::InventoryStatus::USER_OMITTED, final_status.status,
+      'Status should be USER_OMITTED after second sync'
+
+    # Verify there's still only one status record (old one was deleted before creating new one)
+    assert_equal 1, InventorySync::InventoryStatus.where(host_id: @host1.id).count,
+      'Should have exactly one status record (old cleared before new created)'
+
+    # Verify the old status record was actually deleted and replaced with a new one
+    refute InventorySync::InventoryStatus.exists?(initial_status_id),
+      'Old status record should have been deleted before creating new one'
+    assert_not_equal initial_status_id, final_status.id,
+      'New status record should have different ID, proving old was deleted'
+  end
 end

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -372,31 +372,6 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
       'User-omitted host should have USER_OMITTED status even if not in cloud inventory'
   end
 
-  test 'InsightsClientReportStatus is refreshed after inventory sync' do
-    # Set up host2 with a stale InsightsClientReportStatus
-    insights_status = @host2.get_status(InsightsClientReportStatus)
-    insights_status.status = InsightsClientReportStatus::NO_REPORT
-    insights_status.reported_at = Time.zone.now - 10.days
-    insights_status.save!
-
-    setup_certs_expectation do
-      InventorySync::Async::InventoryFullSync.any_instance.stubs(:candlepin_id_cert)
-    end
-    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
-    FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
-
-    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
-    run_action(action)
-
-    @host2.reload
-    insights_status_after = @host2.get_status(InsightsClientReportStatus)
-
-    # The status should have been refreshed (calculated based on current state)
-    # Since we don't have reported_at in the recent interval, it should be NO_REPORT or REPORTING
-    # depending on whether the host has the parameter set
-    assert_not_nil insights_status_after, 'InsightsClientReportStatus should exist'
-  end
-
   test 'host_statuses output includes all three counts' do
     # Create a mix of hosts with different statuses
     # Host1: will be user-omitted

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -342,10 +342,6 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
     assert_equal InventorySync::InventoryStatus::SYNC,
       InventorySync::InventoryStatus.where(host_id: @host2.id).first.status,
       'Normal host should have SYNC status'
-
-    # Check output counts
-    assert_equal 1, action.output[:host_statuses][:user_omitted]
-    assert_equal 1, action.output[:host_statuses][:sync]
   end
 
   test 'user-omitted hosts are not marked as disconnected' do
@@ -374,9 +370,6 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
     assert_equal InventorySync::InventoryStatus::USER_OMITTED,
       InventorySync::InventoryStatus.where(host_id: @host1.id).first.status,
       'User-omitted host should have USER_OMITTED status even if not in cloud inventory'
-
-    # Check output counts - host1 should be counted as user_omitted, not disconnect
-    assert_equal 1, action.output[:host_statuses][:user_omitted]
   end
 
   test 'InsightsClientReportStatus is refreshed after inventory sync' do
@@ -427,21 +420,19 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
     action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
     run_action(action)
 
-    # Check all three counts are present and correct
-    assert_equal 1, action.output[:host_statuses][:sync], 'Should have 1 synced host'
-    assert_equal 1, action.output[:host_statuses][:disconnect], 'Should have 1 disconnected host'
-    assert_equal 1, action.output[:host_statuses][:user_omitted], 'Should have 1 user-omitted host'
-
     # Verify the statuses were actually set correctly
     @host1.reload
     @host2.reload
     @host3.reload
 
     assert_equal InventorySync::InventoryStatus::USER_OMITTED,
-      InventorySync::InventoryStatus.where(host_id: @host1.id).first.status
+      InventorySync::InventoryStatus.where(host_id: @host1.id).first.status,
+      'Host with host_registration_insights_inventory=false should have USER_OMITTED status'
     assert_equal InventorySync::InventoryStatus::SYNC,
-      InventorySync::InventoryStatus.where(host_id: @host2.id).first.status
+      InventorySync::InventoryStatus.where(host_id: @host2.id).first.status,
+      'Host in cloud inventory should have SYNC status'
     assert_equal InventorySync::InventoryStatus::DISCONNECT,
-      InventorySync::InventoryStatus.where(host_id: @host3.id).first.status
+      InventorySync::InventoryStatus.where(host_id: @host3.id).first.status,
+      'Host not in cloud inventory and not user-omitted should have DISCONNECT status'
   end
 end

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -310,4 +310,137 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
 
     assert_nil InventorySync::InventoryStatus.where(host_id: @host3.id).first
   end
+
+  test 'user-omitted hosts get USER_OMITTED status' do
+    # Add parameter to exclude host1
+    @host1.host_parameters << HostParameter.create(
+      name: 'host_registration_insights_inventory',
+      value: 'false',
+      parameter_type: 'boolean'
+    )
+    @host1.save!
+
+    setup_certs_expectation do
+      InventorySync::Async::InventoryFullSync.any_instance.stubs(:candlepin_id_cert)
+    end
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
+    FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
+
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action)
+
+    @host1.reload
+    @host2.reload
+
+    # Host1 should be USER_OMITTED
+    assert_equal InventorySync::InventoryStatus::USER_OMITTED,
+      InventorySync::InventoryStatus.where(host_id: @host1.id).first.status,
+      'Host with host_registration_insights_inventory=false should have USER_OMITTED status'
+
+    # Host2 should be SYNC
+    assert_equal InventorySync::InventoryStatus::SYNC,
+      InventorySync::InventoryStatus.where(host_id: @host2.id).first.status,
+      'Normal host should have SYNC status'
+
+    # Check output counts
+    assert_equal 1, action.output[:host_statuses][:user_omitted]
+    assert_equal 1, action.output[:host_statuses][:sync]
+  end
+
+  test 'user-omitted hosts are not marked as disconnected' do
+    # Add parameter to exclude host1
+    @host1.host_parameters << HostParameter.create(
+      name: 'host_registration_insights_inventory',
+      value: 'false',
+      parameter_type: 'boolean'
+    )
+    @host1.save!
+
+    # Host1 is not in the cloud inventory response
+    setup_certs_expectation do
+      InventorySync::Async::InventoryFullSync.any_instance.stubs(:candlepin_id_cert)
+    end
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:affected_host_ids).returns([@host1.id, @host2.id])
+    FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
+
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action)
+
+    @host1.reload
+
+    # Host1 should be USER_OMITTED, not DISCONNECT
+    assert_equal InventorySync::InventoryStatus::USER_OMITTED,
+      InventorySync::InventoryStatus.where(host_id: @host1.id).first.status,
+      'User-omitted host should have USER_OMITTED status even if not in cloud inventory'
+
+    # Check output counts - host1 should be counted as user_omitted, not disconnect
+    assert_equal 1, action.output[:host_statuses][:user_omitted]
+  end
+
+  test 'InsightsClientReportStatus is refreshed after inventory sync' do
+    # Set up host2 with a stale InsightsClientReportStatus
+    insights_status = @host2.get_status(InsightsClientReportStatus)
+    insights_status.status = InsightsClientReportStatus::NO_REPORT
+    insights_status.reported_at = Time.zone.now - 10.days
+    insights_status.save!
+
+    setup_certs_expectation do
+      InventorySync::Async::InventoryFullSync.any_instance.stubs(:candlepin_id_cert)
+    end
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
+    FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
+
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action)
+
+    @host2.reload
+    insights_status_after = @host2.get_status(InsightsClientReportStatus)
+
+    # The status should have been refreshed (calculated based on current state)
+    # Since we don't have reported_at in the recent interval, it should be NO_REPORT or REPORTING
+    # depending on whether the host has the parameter set
+    assert_not_nil insights_status_after, 'InsightsClientReportStatus should exist'
+  end
+
+  test 'host_statuses output includes all three counts' do
+    # Create a mix of hosts with different statuses
+    # Host1: will be user-omitted
+    @host1.host_parameters << HostParameter.create(
+      name: 'host_registration_insights_inventory',
+      value: 'false',
+      parameter_type: 'boolean'
+    )
+    @host1.save!
+
+    # Host2: will be synced (already in @inventory)
+    # Host3: will be disconnected (not in @inventory, no parameter)
+
+    setup_certs_expectation do
+      InventorySync::Async::InventoryFullSync.any_instance.stubs(:candlepin_id_cert)
+    end
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:affected_host_ids).returns([@host1.id, @host2.id, @host3.id])
+    FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
+
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action)
+
+    # Check all three counts are present and correct
+    assert_equal 1, action.output[:host_statuses][:sync], 'Should have 1 synced host'
+    assert_equal 1, action.output[:host_statuses][:disconnect], 'Should have 1 disconnected host'
+    assert_equal 1, action.output[:host_statuses][:user_omitted], 'Should have 1 user-omitted host'
+
+    # Verify the statuses were actually set correctly
+    @host1.reload
+    @host2.reload
+    @host3.reload
+
+    assert_equal InventorySync::InventoryStatus::USER_OMITTED,
+      InventorySync::InventoryStatus.where(host_id: @host1.id).first.status
+    assert_equal InventorySync::InventoryStatus::SYNC,
+      InventorySync::InventoryStatus.where(host_id: @host2.id).first.status
+    assert_equal InventorySync::InventoryStatus::DISCONNECT,
+      InventorySync::InventoryStatus.where(host_id: @host3.id).first.status
+  end
 end

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -407,13 +407,19 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
     )
     @host1.save!
 
-    # Host2: will be synced (already in @inventory)
-    # Host3: will be disconnected (not in @inventory, no parameter)
+    # Host2: will be synced (in cloud inventory)
+    # Host3: will be disconnected (not in cloud inventory)
+
+    # Create inventory response with only host2 (exclude host1 and host3)
+    inventory_with_host2_only = @inventory.dup
+    inventory_with_host2_only['results'] = [@inventory['results'][0]] # Only host2
+    inventory_with_host2_only['total'] = 1
+    inventory_with_host2_only['count'] = 1
 
     setup_certs_expectation do
       InventorySync::Async::InventoryFullSync.any_instance.stubs(:candlepin_id_cert)
     end
-    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(inventory_with_host2_only)
     InventorySync::Async::InventoryFullSync.any_instance.expects(:affected_host_ids).returns([@host1.id, @host2.id, @host3.id])
     FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
 

--- a/test/jobs/inventory_full_sync_test.rb
+++ b/test/jobs/inventory_full_sync_test.rb
@@ -416,4 +416,52 @@ class InventoryFullSyncTest < ActiveSupport::TestCase
       InventorySync::InventoryStatus.where(host_id: @host3.id).first.status,
       'Host not in cloud inventory and not user-omitted should have DISCONNECT status'
   end
+
+  test 'user-omitted status respects parameter inheritance from hostgroup' do
+    # Create a hostgroup and assign it to host1
+    hostgroup = FactoryBot.create(:hostgroup)
+    hostgroup.organizations << @host1.organization
+    @host1.hostgroup = hostgroup
+    @host1.save!
+
+    # Set parameter at hostgroup level, not directly on host
+    # This verifies the fix that uses search_for instead of querying HostParameter directly
+    hostgroup.group_parameters << GroupParameter.create(
+      name: 'host_registration_insights_inventory',
+      value: 'false',
+      key_type: 'boolean'
+    )
+    hostgroup.save!
+
+    # Verify parameter is inherited (not set directly on host)
+    assert_nil @host1.parameters.find_by(name: 'host_registration_insights_inventory'),
+      'Test setup: parameter should not be set directly on host'
+    refute ::Foreman::Cast.to_bool(@host1.host_param('host_registration_insights_inventory')),
+      'Test setup: parameter should be inherited from hostgroup'
+
+    # Host2 remains normal (no parameter)
+    setup_certs_expectation do
+      InventorySync::Async::InventoryFullSync.any_instance.stubs(:candlepin_id_cert)
+    end
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:query_inventory).returns(@inventory)
+    InventorySync::Async::InventoryFullSync.any_instance.expects(:affected_host_ids).returns([@host1.id, @host2.id])
+    FactoryBot.create(:fact_value, fact_name: fact_names['virt::uuid'], value: '1234', host: @host2)
+
+    action = create_and_plan_action(InventorySync::Async::InventoryFullSync, @host1.organization)
+    run_action(action)
+
+    @host1.reload
+    @host2.reload
+
+    # Host1 should be USER_OMITTED (inherited parameter from hostgroup)
+    host1_status = InventorySync::InventoryStatus.where(host_id: @host1.id).first
+    assert_not_nil host1_status, 'Host1 should have an inventory status'
+    assert_equal InventorySync::InventoryStatus::USER_OMITTED, host1_status.status,
+      'Host with inherited host_registration_insights_inventory=false should have USER_OMITTED status'
+
+    # Host2 should be SYNC
+    assert_equal InventorySync::InventoryStatus::SYNC,
+      InventorySync::InventoryStatus.where(host_id: @host2.id).first.status,
+      'Normal host should have SYNC status'
+  end
 end

--- a/test/models/insights_client_report_status_test.rb
+++ b/test/models/insights_client_report_status_test.rb
@@ -72,4 +72,86 @@ class InsightsClientReportStatusTest < ActiveSupport::TestCase
 
     assert_equal HostStatus::Global::ERROR, @host.global_status
   end
+
+  test 'host with host_registration_insights parameter set to false gets USER_OMITTED status' do
+    @host.host_parameters << HostParameter.create(
+      name: 'host_registration_insights',
+      value: 'false',
+      parameter_type: 'boolean'
+    )
+    @host.save!
+
+    insights_status = @host.get_status(InsightsClientReportStatus)
+    insights_status.refresh!
+
+    assert_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status
+    assert_equal HostStatus::Global::OK, insights_status.to_global
+  end
+
+  test 'USER_OMITTED status has correct label' do
+    insights_status = @host.get_status(InsightsClientReportStatus)
+    insights_status.status = InsightsClientReportStatus::USER_OMITTED
+    insights_status.save!
+
+    label = insights_status.to_label
+    assert_match(/host_registration_insights/, label)
+    assert_match(/false/, label)
+  end
+
+  test 'stale scope excludes USER_OMITTED hosts' do
+    host1 = FactoryBot.create(:host, :managed)
+    host2 = FactoryBot.create(:host, :managed)
+    host3 = FactoryBot.create(:host, :managed)
+
+    # Host 1: USER_OMITTED with old reported_at (should NOT be in stale scope)
+    status1 = host1.get_status(InsightsClientReportStatus)
+    status1.status = InsightsClientReportStatus::USER_OMITTED
+    status1.reported_at = Time.zone.now - InsightsClientReportStatus::REPORT_INTERVAL - 1.day
+    status1.save!
+
+    # Host 2: REPORTING with old reported_at (should be in stale scope)
+    status2 = host2.get_status(InsightsClientReportStatus)
+    status2.status = InsightsClientReportStatus::REPORTING
+    status2.reported_at = Time.zone.now - InsightsClientReportStatus::REPORT_INTERVAL - 1.day
+    status2.save!
+
+    # Host 3: NO_REPORT with old reported_at (should be in stale scope)
+    status3 = host3.get_status(InsightsClientReportStatus)
+    status3.status = InsightsClientReportStatus::NO_REPORT
+    status3.reported_at = Time.zone.now - InsightsClientReportStatus::REPORT_INTERVAL - 1.day
+    status3.save!
+
+    stale_statuses = InsightsClientReportStatus.stale
+    stale_host_ids = stale_statuses.pluck(:host_id)
+
+    assert_not_includes stale_host_ids, host1.id, 'USER_OMITTED host should not be in stale scope'
+    assert_includes stale_host_ids, host2.id, 'REPORTING host with old report should be in stale scope'
+    assert_includes stale_host_ids, host3.id, 'NO_REPORT host with old report should be in stale scope'
+  end
+
+  test 'status transitions from USER_OMITTED when parameter changes' do
+    # Set up host with parameter = false (USER_OMITTED)
+    @host.host_parameters << HostParameter.create(
+      name: 'host_registration_insights',
+      value: 'false',
+      parameter_type: 'boolean'
+    )
+    @host.save!
+
+    insights_status = @host.get_status(InsightsClientReportStatus)
+    insights_status.refresh!
+    assert_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status
+
+    # Change parameter to true
+    param = @host.parameters.find_by(name: 'host_registration_insights')
+    param.value = 'true'
+    param.save!
+
+    # Refresh status
+    insights_status.refresh!
+
+    # Status should change to REPORTING or NO_REPORT based on reported_at
+    assert_not_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status
+    assert_includes [InsightsClientReportStatus::REPORTING, InsightsClientReportStatus::NO_REPORT], insights_status.status
+  end
 end

--- a/test/models/insights_client_report_status_test.rb
+++ b/test/models/insights_client_report_status_test.rb
@@ -129,29 +129,56 @@ class InsightsClientReportStatusTest < ActiveSupport::TestCase
     assert_includes stale_host_ids, host3.id, 'NO_REPORT host with old report should be in stale scope'
   end
 
-  test 'status transitions from USER_OMITTED when parameter changes' do
-    # Set up host with parameter = false (USER_OMITTED)
-    @host.host_parameters << HostParameter.create(
+  test 'USER_OMITTED status respects parameter inheritance from hostgroup' do
+    # Create a hostgroup with parameter = false
+    hostgroup = FactoryBot.create(:hostgroup)
+    hostgroup.group_parameters << GroupParameter.create(
       name: 'host_registration_insights',
       value: 'false',
+      key_type: 'boolean'
+    )
+    hostgroup.save!
+
+    @host.hostgroup = hostgroup
+    @host.save!
+
+    # Verify parameter is inherited (not set directly on host)
+    assert_nil @host.parameters.find_by(name: 'host_registration_insights'),
+      'Test setup: parameter should not be set directly on host'
+
+    insights_status = @host.get_status(InsightsClientReportStatus)
+    insights_status.refresh!
+
+    assert_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status,
+      'Status should be USER_OMITTED when host_registration_insights=false is inherited from hostgroup'
+    assert_equal HostStatus::Global::OK, insights_status.to_global,
+      'USER_OMITTED status should not affect global status'
+  end
+
+  test 'host parameter overrides inherited parameter from hostgroup' do
+    # Create a hostgroup with parameter = false
+    hostgroup = FactoryBot.create(:hostgroup)
+    hostgroup.group_parameters << GroupParameter.create(
+      name: 'host_registration_insights',
+      value: 'false',
+      key_type: 'boolean'
+    )
+    hostgroup.save!
+
+    @host.hostgroup = hostgroup
+
+    # Override with host parameter = true
+    @host.host_parameters << HostParameter.create(
+      name: 'host_registration_insights',
+      value: 'true',
       parameter_type: 'boolean'
     )
     @host.save!
 
     insights_status = @host.get_status(InsightsClientReportStatus)
     insights_status.refresh!
-    assert_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status
 
-    # Change parameter to true
-    param = @host.parameters.find_by(name: 'host_registration_insights')
-    param.value = 'true'
-    param.save!
-
-    # Refresh status
-    insights_status.refresh!
-
-    # Status should change to REPORTING or NO_REPORT based on reported_at
-    assert_not_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status
-    assert_includes [InsightsClientReportStatus::REPORTING, InsightsClientReportStatus::NO_REPORT], insights_status.status
+    assert_not_equal InsightsClientReportStatus::USER_OMITTED, insights_status.status,
+      'Status should not be USER_OMITTED when host parameter overrides hostgroup parameter with true'
   end
 end

--- a/test/models/inventory_sync/inventory_status_test.rb
+++ b/test/models/inventory_sync/inventory_status_test.rb
@@ -1,0 +1,85 @@
+require 'test_plugin_helper'
+
+module InventorySync
+  class InventoryStatusTest < ActiveSupport::TestCase
+    setup do
+      @host = FactoryBot.create(:host, :managed)
+    end
+
+    test 'status constants are defined correctly' do
+      assert_equal 0, InventorySync::InventoryStatus::DISCONNECT
+      assert_equal 1, InventorySync::InventoryStatus::SYNC
+      assert_equal 2, InventorySync::InventoryStatus::USER_OMITTED
+    end
+
+    test 'to_global returns OK for USER_OMITTED status' do
+      status = @host.get_status(InventorySync::InventoryStatus)
+      status.status = InventorySync::InventoryStatus::USER_OMITTED
+      status.save!
+
+      assert_equal HostStatus::Global::OK, status.to_global
+    end
+
+    test 'to_global returns WARN for DISCONNECT status' do
+      status = @host.get_status(InventorySync::InventoryStatus)
+      status.status = InventorySync::InventoryStatus::DISCONNECT
+      status.save!
+
+      assert_equal HostStatus::Global::WARN, status.to_global
+    end
+
+    test 'to_global returns OK for SYNC status' do
+      status = @host.get_status(InventorySync::InventoryStatus)
+      status.status = InventorySync::InventoryStatus::SYNC
+      status.save!
+
+      assert_equal HostStatus::Global::OK, status.to_global
+    end
+
+    test 'to_label returns appropriate messages for each status' do
+      status = @host.get_status(InventorySync::InventoryStatus)
+
+      # Test DISCONNECT label
+      status.status = InventorySync::InventoryStatus::DISCONNECT
+      status.save!
+      label = status.to_label
+      assert_match(/not present/, label.downcase)
+      assert_match(/console\.redhat\.com/, label)
+
+      # Test SYNC label
+      status.status = InventorySync::InventoryStatus::SYNC
+      status.save!
+      label = status.to_label
+      assert_match(/uploaded.*present/, label.downcase)
+      assert_match(/console\.redhat\.com/, label)
+
+      # Test USER_OMITTED label
+      status.status = InventorySync::InventoryStatus::USER_OMITTED
+      status.save!
+      label = status.to_label
+      assert_match(/excluded/, label.downcase)
+      assert_match(/host parameter/, label.downcase)
+      assert_match(/console\.redhat\.com/, label)
+    end
+
+    test 'relevant? returns true in regular (non-IoP) mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+
+      status = @host.get_status(InventorySync::InventoryStatus)
+      status.status = InventorySync::InventoryStatus::SYNC
+      status.save!
+
+      assert status.relevant?, 'Inventory status should be relevant in regular mode'
+    end
+
+    test 'relevant? returns false in IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+      status = @host.get_status(InventorySync::InventoryStatus)
+      status.status = InventorySync::InventoryStatus::SYNC
+      status.save!
+
+      refute status.relevant?, 'Inventory status should NOT be relevant in IoP mode'
+    end
+  end
+end

--- a/test/unit/rh_cloud_host_test.rb
+++ b/test/unit/rh_cloud_host_test.rb
@@ -342,4 +342,37 @@ class RhCloudHostTest < ActiveSupport::TestCase
       assert_not_includes results, host1
     end
   end
+
+  test 'scoped search for user_omitted inventory status works' do
+    host1 = FactoryBot.create(:host, :managed)
+    host2 = FactoryBot.create(:host, :managed)
+    host3 = FactoryBot.create(:host, :managed)
+
+    # Create different inventory statuses
+    InventorySync::InventoryStatus.create!(
+      host_id: host1.id,
+      status: InventorySync::InventoryStatus::SYNC,
+      reported_at: Time.zone.now
+    )
+
+    InventorySync::InventoryStatus.create!(
+      host_id: host2.id,
+      status: InventorySync::InventoryStatus::DISCONNECT,
+      reported_at: Time.zone.now
+    )
+
+    InventorySync::InventoryStatus.create!(
+      host_id: host3.id,
+      status: InventorySync::InventoryStatus::USER_OMITTED,
+      reported_at: Time.zone.now
+    )
+
+    # Search for user_omitted status
+    results = Host.search_for('insights_inventory_sync_status = user_omitted')
+    result_ids = results.pluck(:id)
+
+    assert_includes result_ids, host3.id, 'Host with USER_OMITTED status should be in search results'
+    assert_not_includes result_ids, host1.id, 'Host with SYNC status should not be in search results'
+    assert_not_includes result_ids, host2.id, 'Host with DISCONNECT status should not be in search results'
+  end
 end

--- a/test/unit/rh_cloud_host_test.rb
+++ b/test/unit/rh_cloud_host_test.rb
@@ -375,4 +375,31 @@ class RhCloudHostTest < ActiveSupport::TestCase
     assert_not_includes result_ids, host1.id, 'Host with SYNC status should not be in search results'
     assert_not_includes result_ids, host2.id, 'Host with DISCONNECT status should not be in search results'
   end
+
+  test 'scoped search for user_omitted insights client report status works' do
+    host1 = FactoryBot.create(:host, :managed)
+    host2 = FactoryBot.create(:host, :managed)
+    host3 = FactoryBot.create(:host, :managed)
+
+    # Create different insights client report statuses
+    status1 = host1.get_status(InsightsClientReportStatus)
+    status1.status = InsightsClientReportStatus::REPORTING
+    status1.save!
+
+    status2 = host2.get_status(InsightsClientReportStatus)
+    status2.status = InsightsClientReportStatus::NO_REPORT
+    status2.save!
+
+    status3 = host3.get_status(InsightsClientReportStatus)
+    status3.status = InsightsClientReportStatus::USER_OMITTED
+    status3.save!
+
+    # Search for user_omitted status
+    results = Host.search_for('insights_client_report_status = user_omitted')
+    result_ids = results.pluck(:id)
+
+    assert_includes result_ids, host3.id, 'Host with USER_OMITTED status should be in search results'
+    assert_not_includes result_ids, host1.id, 'Host with REPORTING status should not be in search results'
+    assert_not_includes result_ids, host2.id, 'Host with NO_REPORT status should not be in search results'
+  end
 end

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButtonActions.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButtonActions.js
@@ -39,14 +39,20 @@ export const setupInventorySyncTaskPolling = (id, dispatch) =>
     key: INVENTORY_SYNC_TASK_UPDATE,
     onTaskSuccess: ({
       output: {
-        host_statuses: { sync, disconnect, user_omitted },
+        host_statuses: { sync, disconnect, user_omitted: userOmitted },
       },
     }) =>
       dispatch(
         addToast({
           sticky: true,
           type: 'success',
-          message: <Toast syncHosts={sync} disconnectHosts={disconnect} userOmittedHosts={user_omitted} />,
+          message: (
+            <Toast
+              syncHosts={sync}
+              disconnectHosts={disconnect}
+              userOmittedHosts={userOmitted}
+            />
+          ),
         })
       ),
     dispatch,

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButtonActions.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/SyncButtonActions.js
@@ -39,14 +39,14 @@ export const setupInventorySyncTaskPolling = (id, dispatch) =>
     key: INVENTORY_SYNC_TASK_UPDATE,
     onTaskSuccess: ({
       output: {
-        host_statuses: { sync, disconnect },
+        host_statuses: { sync, disconnect, user_omitted },
       },
     }) =>
       dispatch(
         addToast({
           sticky: true,
           type: 'success',
-          message: <Toast syncHosts={sync} disconnectHosts={disconnect} />,
+          message: <Toast syncHosts={sync} disconnectHosts={disconnect} userOmittedHosts={user_omitted} />,
         })
       ),
     dispatch,

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/__tests__/__snapshots__/integrations.test.js.snap
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/__tests__/__snapshots__/integrations.test.js.snap
@@ -9,6 +9,7 @@ Array [
           "message": <Toast
             disconnectHosts={2}
             syncHosts={0}
+            userOmittedHosts={1}
           />,
           "sticky": true,
           "type": "success",

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/__tests__/integrations.test.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/__tests__/integrations.test.js
@@ -30,6 +30,7 @@ describe('SyncButton integration test', () => {
                 host_statuses: {
                   sync: 0,
                   disconnect: 2,
+                  user_omitted: 1,
                 },
               },
               result: 'success',

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
@@ -3,26 +3,32 @@ import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { foremanUrl } from '../../../../../../ForemanRhCloudHelpers';
 
-const Toast = ({ syncHosts, disconnectHosts }) => {
-  const totalHosts = syncHosts + disconnectHosts;
+const Toast = ({ syncHosts, disconnectHosts, userOmittedHosts }) => {
+  const totalHosts = syncHosts + disconnectHosts + userOmittedHosts;
   return (
     <span>
       <p>
-        {__('Hosts with subscription in organization: ')}
+        {__('Registered hosts in organization: ')}
         <strong>{totalHosts}</strong>
       </p>
       <p>
-        {__('Successfully synced hosts: ')}
+        {__('Uploaded to inventory: ')}
         <strong>{syncHosts}</strong>
       </p>
       <p>
         {__('Disconnected hosts: ')}
         <strong>{disconnectHosts}</strong>
       </p>
+      {userOmittedHosts &&
+        <p>
+          {__('Not uploaded because host_registration_insights_inventory parameter is set to false: ')}
+          <strong>{userOmittedHosts}</strong>
+        </p>
+      }
       <p>
         {__('For more info, please visit the')}{' '}
         <a
-          href={foremanUrl('/hosts')}
+          href={foremanUrl('new/hosts')}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
@@ -36,7 +36,7 @@ const Toast = ({ syncHosts, disconnectHosts, userOmittedHosts }) => {
           {disconnectHosts}
         </HostsWithStatusLink>
       </p>
-      {userOmittedHosts && (
+      {!!userOmittedHosts && (
         <p>
           {__(
             'Excluded from upload to console.redhat.com Inventory service because host_registration_insights_inventory parameter value is false: '

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
@@ -2,16 +2,19 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { foremanUrl } from '../../../../../../ForemanRhCloudHelpers';
 
-
-const statusSearchParams = statusName => `/new/hosts?search=insights_inventory_sync_status+%3D+${statusName}&page=1`;
+const statusSearchParams = statusName =>
+  `/new/hosts?search=insights_inventory_sync_status+%3D+${statusName}&page=1`;
 const DISCONNECT = 'disconnect';
 const SYNC = 'sync';
 const USER_OMITTED = 'user_omitted';
 const HostsWithStatusLink = ({ statusName, children }) => (
   <Link to={statusSearchParams(statusName)}>{children}</Link>
 );
+HostsWithStatusLink.propTypes = {
+  statusName: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
 
 const Toast = ({ syncHosts, disconnectHosts, userOmittedHosts }) => {
   const totalHosts = syncHosts + disconnectHosts + userOmittedHosts;
@@ -19,15 +22,13 @@ const Toast = ({ syncHosts, disconnectHosts, userOmittedHosts }) => {
     <span>
       <p>
         {__('Registered hosts in organization: ')}
-        <Link to='/new/hosts?search=set%3F+subscription_uuid&page=1'>
+        <Link to="/new/hosts?search=set%3F+subscription_uuid&page=1">
           {totalHosts}
         </Link>
       </p>
       <p>
         {__('Uploaded and present on console.redhat.com Inventory service: ')}
-        <HostsWithStatusLink statusName={SYNC}>
-          {syncHosts}
-        </HostsWithStatusLink>
+        <HostsWithStatusLink statusName={SYNC}>{syncHosts}</HostsWithStatusLink>
       </p>
       <p>
         {__('Not present on console.redhat.com Inventory service: ')}
@@ -35,17 +36,20 @@ const Toast = ({ syncHosts, disconnectHosts, userOmittedHosts }) => {
           {disconnectHosts}
         </HostsWithStatusLink>
       </p>
-      {userOmittedHosts &&
+      {userOmittedHosts && (
         <p>
-          {__('Excluded from upload to console.redhat.com Inventory service because \
-            host_registration_insights_inventory parameter value is false: ')}
+          {__(
+            'Excluded from upload to console.redhat.com Inventory service because host_registration_insights_inventory parameter value is false: '
+          )}
           <HostsWithStatusLink statusName={USER_OMITTED}>
             {userOmittedHosts}
           </HostsWithStatusLink>
         </p>
-      }
+      )}
       <p>
-        {__('You can review this information later by looking at the Inventory status of each host.')}
+        {__(
+          'You can review this information later by looking at the Inventory status of each host.'
+        )}
       </p>
     </span>
   );

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/Toast.js
@@ -1,7 +1,17 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { foremanUrl } from '../../../../../../ForemanRhCloudHelpers';
+
+
+const statusSearchParams = statusName => `/new/hosts?search=insights_inventory_sync_status+%3D+${statusName}&page=1`;
+const DISCONNECT = 'disconnect';
+const SYNC = 'sync';
+const USER_OMITTED = 'user_omitted';
+const HostsWithStatusLink = ({ statusName, children }) => (
+  <Link to={statusSearchParams(statusName)}>{children}</Link>
+);
 
 const Toast = ({ syncHosts, disconnectHosts, userOmittedHosts }) => {
   const totalHosts = syncHosts + disconnectHosts + userOmittedHosts;
@@ -9,31 +19,33 @@ const Toast = ({ syncHosts, disconnectHosts, userOmittedHosts }) => {
     <span>
       <p>
         {__('Registered hosts in organization: ')}
-        <strong>{totalHosts}</strong>
+        <Link to='/new/hosts?search=set%3F+subscription_uuid&page=1'>
+          {totalHosts}
+        </Link>
       </p>
       <p>
-        {__('Uploaded to inventory: ')}
-        <strong>{syncHosts}</strong>
+        {__('Uploaded and present on console.redhat.com Inventory service: ')}
+        <HostsWithStatusLink statusName={SYNC}>
+          {syncHosts}
+        </HostsWithStatusLink>
       </p>
       <p>
-        {__('Disconnected hosts: ')}
-        <strong>{disconnectHosts}</strong>
+        {__('Not present on console.redhat.com Inventory service: ')}
+        <HostsWithStatusLink statusName={DISCONNECT}>
+          {disconnectHosts}
+        </HostsWithStatusLink>
       </p>
       {userOmittedHosts &&
         <p>
-          {__('Not uploaded because host_registration_insights_inventory parameter is set to false: ')}
-          <strong>{userOmittedHosts}</strong>
+          {__('Excluded from upload to console.redhat.com Inventory service because \
+            host_registration_insights_inventory parameter value is false: ')}
+          <HostsWithStatusLink statusName={USER_OMITTED}>
+            {userOmittedHosts}
+          </HostsWithStatusLink>
         </p>
       }
       <p>
-        {__('For more info, please visit the')}{' '}
-        <a
-          href={foremanUrl('new/hosts')}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {__('hosts page')}
-        </a>
+        {__('You can review this information later by looking at the Inventory status of each host.')}
       </p>
     </span>
   );
@@ -42,6 +54,10 @@ const Toast = ({ syncHosts, disconnectHosts, userOmittedHosts }) => {
 Toast.propTypes = {
   syncHosts: PropTypes.number.isRequired,
   disconnectHosts: PropTypes.number.isRequired,
+  userOmittedHosts: PropTypes.number,
+};
+Toast.defaultProps = {
+  userOmittedHosts: 0,
 };
 
 export default Toast;

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/__tests__/Toast.test.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/__tests__/Toast.test.js
@@ -12,9 +12,24 @@ describe('Toast', () => {
     expect(links).toHaveLength(3);
 
     // Check the children (numbers) of each link
-    expect(links.at(0).children().text()).toBe('5');
-    expect(links.at(1).children().text()).toBe('3');
-    expect(links.at(2).children().text()).toBe('2');
+    expect(
+      links
+        .at(0)
+        .children()
+        .text()
+    ).toBe('5');
+    expect(
+      links
+        .at(1)
+        .children()
+        .text()
+    ).toBe('3');
+    expect(
+      links
+        .at(2)
+        .children()
+        .text()
+    ).toBe('2');
   });
 
   it('does not render user_omitted section when count is 0', () => {
@@ -27,21 +42,31 @@ describe('Toast', () => {
     expect(links).toHaveLength(2);
 
     // Should not contain the user_omitted explanation text
-    expect(wrapper.text()).not.toContain('host_registration_insights_inventory parameter value is false');
+    expect(wrapper.text()).not.toContain(
+      'host_registration_insights_inventory parameter value is false'
+    );
   });
 
   it('renders without crashing when userOmittedHosts is not provided (default)', () => {
-    const wrapper = shallow(
-      <Toast syncHosts={5} disconnectHosts={3} />
-    );
+    const wrapper = shallow(<Toast syncHosts={5} disconnectHosts={3} />);
 
     // Should use default value of 0, so only 2 links
     const links = wrapper.find('HostsWithStatusLink');
     expect(links).toHaveLength(2);
 
     // Verify the count values
-    expect(links.at(0).children().text()).toBe('5');
-    expect(links.at(1).children().text()).toBe('3');
+    expect(
+      links
+        .at(0)
+        .children()
+        .text()
+    ).toBe('5');
+    expect(
+      links
+        .at(1)
+        .children()
+        .text()
+    ).toBe('3');
   });
 
   it('renders correct status links for each category', () => {

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/__tests__/Toast.test.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/components/SyncButton/components/__tests__/Toast.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { shallow } from '@theforeman/test';
+import Toast from '../Toast';
+
+describe('Toast', () => {
+  it('renders with all three status counts including user_omitted', () => {
+    const wrapper = shallow(
+      <Toast syncHosts={5} disconnectHosts={3} userOmittedHosts={2} />
+    );
+
+    const links = wrapper.find('HostsWithStatusLink');
+    expect(links).toHaveLength(3);
+
+    // Check the children (numbers) of each link
+    expect(links.at(0).children().text()).toBe('5');
+    expect(links.at(1).children().text()).toBe('3');
+    expect(links.at(2).children().text()).toBe('2');
+  });
+
+  it('does not render user_omitted section when count is 0', () => {
+    const wrapper = shallow(
+      <Toast syncHosts={5} disconnectHosts={3} userOmittedHosts={0} />
+    );
+
+    // Should have only 2 HostsWithStatusLink components (sync and disconnect)
+    const links = wrapper.find('HostsWithStatusLink');
+    expect(links).toHaveLength(2);
+
+    // Should not contain the user_omitted explanation text
+    expect(wrapper.text()).not.toContain('host_registration_insights_inventory parameter value is false');
+  });
+
+  it('renders without crashing when userOmittedHosts is not provided (default)', () => {
+    const wrapper = shallow(
+      <Toast syncHosts={5} disconnectHosts={3} />
+    );
+
+    // Should use default value of 0, so only 2 links
+    const links = wrapper.find('HostsWithStatusLink');
+    expect(links).toHaveLength(2);
+
+    // Verify the count values
+    expect(links.at(0).children().text()).toBe('5');
+    expect(links.at(1).children().text()).toBe('3');
+  });
+
+  it('renders correct status links for each category', () => {
+    const wrapper = shallow(
+      <Toast syncHosts={5} disconnectHosts={3} userOmittedHosts={2} />
+    );
+
+    const links = wrapper.find('HostsWithStatusLink');
+    expect(links.at(0).prop('statusName')).toBe('sync');
+    expect(links.at(1).prop('statusName')).toBe('disconnect');
+    expect(links.at(2).prop('statusName')).toBe('user_omitted');
+  });
+});


### PR DESCRIPTION
### What are the changes introduced in this pull request?
First, some background.

Insights hosts have host statuses:
* `InsightsClientReportStatus` - Tracks whether `insights-client` is regularly reporting for this host.
* `InventoryStatus`- Tracks whether this host has a record in the hosted Inventory service. (These records come from inventory upload reports sent from rh_cloud. They will also be created if insights-client sends a report.)

And host parameters:
* `host_registration_insights` - Decides two things:
  * whether insights-client is installed on this host as part of the generated global registration script
  * whether requests from insights-client get forwarded to the cloud or blocked for this host
* `host_registration_insights_inventory` - Decides whether the host's information is included in inventory upload reports.

Users can set these params individually. On the Inventory Upload page, if you click "Sync all inventory status," you get a toast notification with a tally of
* all registered hosts
* Hosts uploaded to the hosted inventory ("synced")
* "disconnected" hosts (those that are not present in the hosted inventory)

There were a few problems with this -
* Hosts that were excluded on purpose, via the host parameter, were not accounted for in this tally. ("Total registered hosts" was just "disconnected + synced".)
* Once the toast was gone, you could review the same information by looking at the Inventory status. But that was not highlighted.

So, the improvements here are

* Introduce a third category in the notification, USER_OMITTED, to account for the "user-omitted" hosts.
* Also introduce a USER_OMITTED __status value__ for both `InventoryStatus` AND `InsightsClientReportStatus`.
* Update and improve the wording of both the notification and the host status descriptions.
* Side bonus improvement: Mark `InventoryStatus` as not relevant for IoP setups. In IoP, this status is ignored because we use single-host reports and data is never sent to the cloud.
* Also added scoped_search support.

### Considerations taken when implementing this change?
It took quite a while to get this framework in my head. Also, the code that updates host status is a bit complicated, so I hope I didn't do anything wrong. But I tried to stay within the existing frameworks.

### What are the testing steps for this pull request?
Setup: NON-IoP (hosted). Get 3 registered hosts.

It helped me to have 3 host groups, one host in each. This way you can add the "Host group" column on the All Hosts page, and immediately know which host you're dealing with.

'Yes' hostgroup - both host params set to true
'Mixed' hostgroup - `host_registration_insights` set to false, `host_registration_insights_inventory` set to true (this one will show 'Disconnected' status for ~24h or until hosted HBI gives it a uuid)
'No' hostgroup - both host params set to false (this one should show the new USER_OMITTED status)



Now -
Insights > Inventory upload > Sync all inventory status

1. New toast notification should have correct tallies
2. Look! I added links! Click them. isn't that cool? 😄
3. Inspect each host status and make sure it's as expected. user_omitted status will show as OK / green.
4. Try searching hosts for `insights_client_report_status = user_omitted` or `insights_inventory_sync_status = user_omitted` - these should work.