### PR TITLE
Fix blank screen when switching to host without Insights tabs

### DIFF
--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
 import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
 import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
+import { vulnerabilityDisabled } from '../ForemanRhCloudHelpers';
 import './CVEsHostDetailsTab.scss';
 
 const CVEsHostDetailsTab = ({ systemId }) => {
@@ -25,7 +27,22 @@ CVEsHostDetailsTab.propTypes = {
 };
 
 const CVEsHostDetailsTabWrapper = ({ response }) => {
+  const history = useHistory();
   const permissions = useInsightsPermissions();
+  const isHostDataLoaded = Boolean(response?.id);
+  const shouldHideTab =
+    isHostDataLoaded && vulnerabilityDisabled({ hostDetails: response });
+
+  useEffect(() => {
+    if (shouldHideTab && history) {
+      history.replace('/Overview');
+    }
+  }, [shouldHideTab, history]);
+
+  if (shouldHideTab) {
+    return null;
+  }
+
   return (
     <ScalprumProvider {...createProviderOptions(permissions)}>
       <CVEsHostDetailsTab
@@ -38,10 +55,15 @@ const CVEsHostDetailsTabWrapper = ({ response }) => {
 
 CVEsHostDetailsTabWrapper.propTypes = {
   response: PropTypes.shape({
+    id: PropTypes.number,
     subscription_facet_attributes: PropTypes.shape({
-      uuid: PropTypes.string.isRequired,
+      uuid: PropTypes.string,
     }),
-  }).isRequired,
+  }),
+};
+
+CVEsHostDetailsTabWrapper.defaultProps = {
+  response: {},
 };
 
 export default CVEsHostDetailsTabWrapper;

--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -1,12 +1,11 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
 import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
 import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 import {
   vulnerabilityDisabled,
-  OVERVIEW_TAB_PATH,
+  useTabRedirect,
 } from '../ForemanRhCloudHelpers';
 import './CVEsHostDetailsTab.scss';
 
@@ -30,17 +29,11 @@ CVEsHostDetailsTab.propTypes = {
 };
 
 const CVEsHostDetailsTabWrapper = ({ response }) => {
-  const history = useHistory();
   const permissions = useInsightsPermissions();
   const isHostDataLoaded = Boolean(response?.id);
-  const shouldHideTab =
-    isHostDataLoaded && vulnerabilityDisabled({ hostDetails: response });
-
-  useEffect(() => {
-    if (shouldHideTab && history) {
-      history.replace(OVERVIEW_TAB_PATH);
-    }
-  }, [shouldHideTab, history]);
+  const shouldHideTab = useTabRedirect(
+    isHostDataLoaded && vulnerabilityDisabled({ hostDetails: response })
+  );
 
   if (shouldHideTab) {
     return null;

--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -4,7 +4,10 @@ import { useHistory } from 'react-router-dom';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
 import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
 import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
-import { vulnerabilityDisabled } from '../ForemanRhCloudHelpers';
+import {
+  vulnerabilityDisabled,
+  OVERVIEW_TAB_PATH,
+} from '../ForemanRhCloudHelpers';
 import './CVEsHostDetailsTab.scss';
 
 const CVEsHostDetailsTab = ({ systemId }) => {
@@ -35,7 +38,7 @@ const CVEsHostDetailsTabWrapper = ({ response }) => {
 
   useEffect(() => {
     if (shouldHideTab && history) {
-      history.replace('/Overview');
+      history.replace(OVERVIEW_TAB_PATH);
     }
   }, [shouldHideTab, history]);
 
@@ -56,6 +59,10 @@ const CVEsHostDetailsTabWrapper = ({ response }) => {
 CVEsHostDetailsTabWrapper.propTypes = {
   response: PropTypes.shape({
     id: PropTypes.number,
+    operatingsystem_name: PropTypes.string,
+    vulnerability: PropTypes.shape({
+      enabled: PropTypes.bool,
+    }),
     subscription_facet_attributes: PropTypes.shape({
       uuid: PropTypes.string,
     }),

--- a/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
+++ b/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import CVEsHostDetailsTabWrapper from '../CVEsHostDetailsTab';
+import { OVERVIEW_TAB_PATH } from '../../ForemanRhCloudHelpers';
 
 const mockHistoryReplace = jest.fn();
 
@@ -47,7 +48,7 @@ describe('CVEsHostDetailsTabWrapper', () => {
     jest.clearAllMocks();
   });
 
-  it('renders without crashing', () => {
+  it('renders without crashing and does not redirect for valid host', () => {
     const { container } = render(
       <MemoryRouter>
         <CVEsHostDetailsTabWrapper response={defaultResponse} />
@@ -58,6 +59,7 @@ describe('CVEsHostDetailsTabWrapper', () => {
         '.rh-cloud-insights-vulnerability-host-details-component'
       )
     ).toBeTruthy();
+    expect(mockHistoryReplace).not.toHaveBeenCalled();
   });
 
   it('remounts ScalprumComponent when systemId changes', () => {
@@ -112,7 +114,7 @@ describe('CVEsHostDetailsTabWrapper', () => {
       </MemoryRouter>
     );
 
-    expect(mockHistoryReplace).toHaveBeenCalledWith('/Overview');
+    expect(mockHistoryReplace).toHaveBeenCalledWith(OVERVIEW_TAB_PATH);
     expect(
       container.querySelector(
         '.rh-cloud-insights-vulnerability-host-details-component'
@@ -129,6 +131,6 @@ describe('CVEsHostDetailsTabWrapper', () => {
       </MemoryRouter>
     );
 
-    expect(mockHistoryReplace).not.toHaveBeenCalledWith('/Overview');
+    expect(mockHistoryReplace).not.toHaveBeenCalled();
   });
 });

--- a/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
+++ b/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
@@ -1,6 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import CVEsHostDetailsTabWrapper from '../CVEsHostDetailsTab';
+
+const mockHistoryReplace = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    replace: mockHistoryReplace,
+  }),
+}));
 
 jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
   useForemanContext: () => ({
@@ -25,6 +35,13 @@ jest.mock('@scalprum/react-core', () => {
   };
 });
 
+const defaultResponse = {
+  id: 1,
+  operatingsystem_name: 'Red Hat Enterprise Linux 8',
+  vulnerability: { enabled: true },
+  subscription_facet_attributes: { uuid: '1-2-3' },
+};
+
 describe('CVEsHostDetailsTabWrapper', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -32,9 +49,9 @@ describe('CVEsHostDetailsTabWrapper', () => {
 
   it('renders without crashing', () => {
     const { container } = render(
-      <CVEsHostDetailsTabWrapper
-        response={{ subscription_facet_attributes: { uuid: '1-2-3' } }}
-      />
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={defaultResponse} />
+      </MemoryRouter>
     );
     expect(
       container.querySelector(
@@ -46,10 +63,15 @@ describe('CVEsHostDetailsTabWrapper', () => {
   it('remounts ScalprumComponent when systemId changes', () => {
     const { ScalprumComponent } = require('@scalprum/react-core');
 
+    const responseHostA = {
+      ...defaultResponse,
+      subscription_facet_attributes: { uuid: 'uuid-host-A' },
+    };
+
     const { rerender } = render(
-      <CVEsHostDetailsTabWrapper
-        response={{ subscription_facet_attributes: { uuid: 'uuid-host-A' } }}
-      />
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={responseHostA} />
+      </MemoryRouter>
     );
 
     expect(mockUnmountTracker).not.toHaveBeenCalled();
@@ -58,10 +80,15 @@ describe('CVEsHostDetailsTabWrapper', () => {
       expect.anything()
     );
 
+    const responseHostB = {
+      ...defaultResponse,
+      subscription_facet_attributes: { uuid: 'uuid-host-B' },
+    };
+
     rerender(
-      <CVEsHostDetailsTabWrapper
-        response={{ subscription_facet_attributes: { uuid: 'uuid-host-B' } }}
-      />
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={responseHostB} />
+      </MemoryRouter>
     );
 
     expect(mockUnmountTracker).toHaveBeenCalledTimes(1);
@@ -69,5 +96,39 @@ describe('CVEsHostDetailsTabWrapper', () => {
       expect.objectContaining({ systemId: 'uuid-host-B' }),
       expect.anything()
     );
+  });
+
+  it('redirects to Overview when tab should be hidden', () => {
+    const nonRhelResponse = {
+      id: 2,
+      operatingsystem_name: 'Ubuntu 20.04',
+      vulnerability: { enabled: false },
+      subscription_facet_attributes: { uuid: '1-2-3' },
+    };
+
+    const { container } = render(
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={nonRhelResponse} />
+      </MemoryRouter>
+    );
+
+    expect(mockHistoryReplace).toHaveBeenCalledWith('/Overview');
+    expect(
+      container.querySelector(
+        '.rh-cloud-insights-vulnerability-host-details-component'
+      )
+    ).toBeNull();
+  });
+
+  it('does not redirect when host data is not yet loaded', () => {
+    const emptyResponse = { subscription_facet_attributes: { uuid: '1-2-3' } };
+
+    render(
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={emptyResponse} />
+      </MemoryRouter>
+    );
+
+    expect(mockHistoryReplace).not.toHaveBeenCalledWith('/Overview');
   });
 });

--- a/webpack/ForemanRhCloudHelpers.js
+++ b/webpack/ForemanRhCloudHelpers.js
@@ -5,6 +5,8 @@
  */
 export const foremanUrl = path => `${window.URL_PREFIX}${path}`;
 
+export const OVERVIEW_TAB_PATH = '/Overview';
+
 export const isNotRhelHost = ({ hostDetails }) =>
   // This regex tries matches sane variations of "RedHat", "RHEL" and "RHCOS"
   !new RegExp('red[\\s\\-]?hat|rh[\\s\\-]?el|rhc[\\s\\-]?os', 'i').test(

--- a/webpack/ForemanRhCloudHelpers.js
+++ b/webpack/ForemanRhCloudHelpers.js
@@ -1,3 +1,6 @@
+import { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+
 /**
  * copied from core, since it's not in the ReactApp folder,
  * it's complicated to import it and mock it in tests.
@@ -6,6 +9,23 @@
 export const foremanUrl = path => `${window.URL_PREFIX}${path}`;
 
 export const OVERVIEW_TAB_PATH = '/Overview';
+
+/**
+ * Redirects to Overview tab when the current tab should be hidden
+ * @param {boolean} shouldRedirect - Whether to redirect (e.g., host loaded AND tab should hide)
+ * @returns {boolean} - Returns shouldRedirect for convenience
+ */
+export const useTabRedirect = shouldRedirect => {
+  const history = useHistory();
+
+  useEffect(() => {
+    if (shouldRedirect && history) {
+      history.replace(OVERVIEW_TAB_PATH);
+    }
+  }, [shouldRedirect, history]);
+
+  return shouldRedirect;
+};
 
 export const isNotRhelHost = ({ hostDetails }) =>
   // This regex tries matches sane variations of "RedHat", "RHEL" and "RHCOS"

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import SearchBar from 'foremanReact/components/SearchBar';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
@@ -25,6 +26,7 @@ import { useIopConfig } from '../common/Hooks/ConfigHooks';
 import { generateRuleUrl } from '../InsightsCloudSync/InsightsCloudSync';
 import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
 import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
+import { isNotRhelHost, hasNoInsightsFacet } from '../ForemanRhCloudHelpers';
 
 // Hosted Insights advisor
 const NewHostDetailsTab = ({ hostName, router }) => {
@@ -165,7 +167,24 @@ const IopInsightsTabWrapped = props => {
 };
 
 const InsightsTab = props => {
+  const { response } = props;
+  const history = useHistory();
   const isIop = useIopConfig();
+  const isHostDataLoaded = Boolean(response?.id);
+  const shouldHideTab =
+    isHostDataLoaded &&
+    (isNotRhelHost({ hostDetails: response }) ||
+      hasNoInsightsFacet({ response, hostDetails: response }));
+
+  useEffect(() => {
+    if (shouldHideTab && history) {
+      history.replace('/Overview');
+    }
+  }, [shouldHideTab, history]);
+
+  if (shouldHideTab) {
+    return null;
+  }
 
   return isIop ? (
     <IopInsightsTabWrapped {...props} />
@@ -174,6 +193,12 @@ const InsightsTab = props => {
   );
 };
 
-InsightsTab.defaultProps = {};
+InsightsTab.propTypes = {
+  response: PropTypes.object,
+};
+
+InsightsTab.defaultProps = {
+  response: {},
+};
 
 export default InsightsTab;

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -26,7 +26,11 @@ import { useIopConfig } from '../common/Hooks/ConfigHooks';
 import { generateRuleUrl } from '../InsightsCloudSync/InsightsCloudSync';
 import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
 import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
-import { isNotRhelHost, hasNoInsightsFacet } from '../ForemanRhCloudHelpers';
+import {
+  isNotRhelHost,
+  hasNoInsightsFacet,
+  OVERVIEW_TAB_PATH,
+} from '../ForemanRhCloudHelpers';
 
 // Hosted Insights advisor
 const NewHostDetailsTab = ({ hostName, router }) => {
@@ -178,7 +182,7 @@ const InsightsTab = props => {
 
   useEffect(() => {
     if (shouldHideTab && history) {
-      history.replace('/Overview');
+      history.replace(OVERVIEW_TAB_PATH);
     }
   }, [shouldHideTab, history]);
 
@@ -194,7 +198,11 @@ const InsightsTab = props => {
 };
 
 InsightsTab.propTypes = {
-  response: PropTypes.object,
+  response: PropTypes.shape({
+    id: PropTypes.number,
+    operatingsystem_name: PropTypes.string,
+    insights_attributes: PropTypes.object,
+  }),
 };
 
 InsightsTab.defaultProps = {

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
 import SearchBar from 'foremanReact/components/SearchBar';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
@@ -29,7 +28,7 @@ import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 import {
   isNotRhelHost,
   hasNoInsightsFacet,
-  OVERVIEW_TAB_PATH,
+  useTabRedirect,
 } from '../ForemanRhCloudHelpers';
 
 // Hosted Insights advisor
@@ -172,19 +171,13 @@ const IopInsightsTabWrapped = props => {
 
 const InsightsTab = props => {
   const { response } = props;
-  const history = useHistory();
   const isIop = useIopConfig();
   const isHostDataLoaded = Boolean(response?.id);
-  const shouldHideTab =
+  const shouldHideTab = useTabRedirect(
     isHostDataLoaded &&
-    (isNotRhelHost({ hostDetails: response }) ||
-      hasNoInsightsFacet({ response, hostDetails: response }));
-
-  useEffect(() => {
-    if (shouldHideTab && history) {
-      history.replace(OVERVIEW_TAB_PATH);
-    }
-  }, [shouldHideTab, history]);
+      (isNotRhelHost({ hostDetails: response }) ||
+        hasNoInsightsFacet({ response, hostDetails: response }))
+  );
 
   if (shouldHideTab) {
     return null;

--- a/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import NewHostDetailsTab from '../NewHostDetailsTab';
+import { OVERVIEW_TAB_PATH } from '../../ForemanRhCloudHelpers';
 
 const mockHistoryReplace = jest.fn();
 
@@ -212,7 +213,7 @@ describe('NewHostDetailsTab', () => {
         </Provider>
       );
 
-      expect(mockHistoryReplace).toHaveBeenCalledWith('/Overview');
+      expect(mockHistoryReplace).toHaveBeenCalledWith(OVERVIEW_TAB_PATH);
     });
 
     it('should redirect to Overview when insights facet is missing', () => {
@@ -232,7 +233,7 @@ describe('NewHostDetailsTab', () => {
         </Provider>
       );
 
-      expect(mockHistoryReplace).toHaveBeenCalledWith('/Overview');
+      expect(mockHistoryReplace).toHaveBeenCalledWith(OVERVIEW_TAB_PATH);
     });
 
     it('should not redirect when host is valid RHEL with insights facet', () => {
@@ -247,7 +248,7 @@ describe('NewHostDetailsTab', () => {
         </Provider>
       );
 
-      expect(mockHistoryReplace).not.toHaveBeenCalledWith('/Overview');
+      expect(mockHistoryReplace).not.toHaveBeenCalled();
     });
 
     it('should not redirect when host data is not yet loaded', () => {
@@ -259,7 +260,7 @@ describe('NewHostDetailsTab', () => {
         </Provider>
       );
 
-      expect(mockHistoryReplace).not.toHaveBeenCalledWith('/Overview');
+      expect(mockHistoryReplace).not.toHaveBeenCalled();
     });
   });
 });

--- a/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
@@ -2,9 +2,19 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import NewHostDetailsTab from '../NewHostDetailsTab';
+
+const mockHistoryReplace = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    replace: mockHistoryReplace,
+  }),
+}));
 
 jest.mock('../../common/Hooks/ConfigHooks', () => ({
   useIopConfig: jest.fn(() => false),
@@ -14,7 +24,32 @@ jest.mock('foremanReact/common/I18n', () => ({
   translate: jest.fn(str => str),
 }));
 
+jest.mock(
+  'foremanReact/components/SearchBar',
+  () => () => <div>SearchBar</div>,
+  { virtual: true }
+);
+
+jest.mock('../../InsightsCloudSync/Components/InsightsTable', () => () => (
+  <div>InsightsTable</div>
+));
+
+jest.mock('../../InsightsCloudSync/Components/RemediationModal', () => () => (
+  <div>RemediationModal</div>
+));
+
+jest.mock(
+  '../../InsightsCloudSync/Components/InsightsTable/Pagination',
+  () => () => <div>Pagination</div>
+);
+
 const mockStore = configureMockStore([thunk]);
+
+const defaultResponse = {
+  id: 1,
+  operatingsystem_name: 'Red Hat Enterprise Linux 8',
+  insights_attributes: { uuid: 'test-uuid' },
+};
 
 describe('NewHostDetailsTab', () => {
   let store;
@@ -68,17 +103,18 @@ describe('NewHostDetailsTab', () => {
     it('should preserve hash when clearing search params on unmount', () => {
       const { unmount } = render(
         <Provider store={store}>
-          <NewHostDetailsTab
-            hostName="test-host.example.com"
-            router={mockRouter}
-          />
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              router={mockRouter}
+              response={defaultResponse}
+            />
+          </MemoryRouter>
         </Provider>
       );
 
-      // Unmount the component to trigger cleanup
       unmount();
 
-      // Verify router.replace was called with both search: null AND the existing hash
       expect(mockRouter.replace).toHaveBeenCalledWith({
         search: null,
         hash: '#/Insights',
@@ -90,16 +126,18 @@ describe('NewHostDetailsTab', () => {
 
       const { unmount } = render(
         <Provider store={store}>
-          <NewHostDetailsTab
-            hostName="test-host.example.com"
-            router={mockRouter}
-          />
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              router={mockRouter}
+              response={defaultResponse}
+            />
+          </MemoryRouter>
         </Provider>
       );
 
       unmount();
 
-      // When there's no hash, should only pass search: null
       expect(mockRouter.replace).toHaveBeenCalledWith({
         search: null,
       });
@@ -114,16 +152,18 @@ describe('NewHostDetailsTab', () => {
 
       const { unmount } = render(
         <Provider store={store}>
-          <NewHostDetailsTab
-            hostName="test-host.example.com"
-            router={routerWithoutLocation}
-          />
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              router={routerWithoutLocation}
+              response={defaultResponse}
+            />
+          </MemoryRouter>
         </Provider>
       );
 
       unmount();
 
-      // Should still call replace with search: null even if location is undefined
       expect(routerWithoutLocation.replace).toHaveBeenCalledWith({
         search: null,
       });
@@ -132,23 +172,94 @@ describe('NewHostDetailsTab', () => {
     it('should use the latest hash value at unmount time, not a stale captured value', () => {
       const { unmount } = render(
         <Provider store={store}>
-          <NewHostDetailsTab
-            hostName="test-host.example.com"
-            router={mockRouter}
-          />
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              router={mockRouter}
+              response={defaultResponse}
+            />
+          </MemoryRouter>
         </Provider>
       );
 
-      // Change the hash after mount, before unmount
       mockRouter.location.hash = '#/Overview';
 
       unmount();
 
-      // Verify router.replace was called with the UPDATED hash, not the initial '#/Insights'
       expect(mockRouter.replace).toHaveBeenCalledWith({
         search: null,
         hash: '#/Overview',
       });
+    });
+  });
+
+  describe('tab visibility', () => {
+    it('should redirect to Overview when host is not RHEL', () => {
+      const nonRhelResponse = {
+        id: 2,
+        operatingsystem_name: 'Ubuntu 20.04',
+        insights_attributes: { uuid: 'test-uuid' },
+      };
+
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              response={nonRhelResponse}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(mockHistoryReplace).toHaveBeenCalledWith('/Overview');
+    });
+
+    it('should redirect to Overview when insights facet is missing', () => {
+      const responseWithoutInsights = {
+        id: 3,
+        operatingsystem_name: 'Red Hat Enterprise Linux 8',
+      };
+
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              response={responseWithoutInsights}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(mockHistoryReplace).toHaveBeenCalledWith('/Overview');
+    });
+
+    it('should not redirect when host is valid RHEL with insights facet', () => {
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              response={defaultResponse}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(mockHistoryReplace).not.toHaveBeenCalledWith('/Overview');
+    });
+
+    it('should not redirect when host data is not yet loaded', () => {
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <NewHostDetailsTab hostName="test-host.example.com" response={{}} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(mockHistoryReplace).not.toHaveBeenCalledWith('/Overview');
     });
   });
 });


### PR DESCRIPTION
When using breadcrumb switcher to navigate from a registered host (with Recommendations/Vulnerabilities tabs) to an unregistered host, redirect to Overview tab instead of showing a loading spinner.

#### What are the changes introduced in this pull request?
This PR fixes a navigation bug when using the breadcrumb host switcher to navigate from a registered host (with Recommendations/Vulnerabilities tabs) to an unregistered host (without those tabs). Previously, users would see a blank screen with a loading spinner. Now, they are automatically redirected to the Overview tab.

Changes:

- Added redirect logic to `CVEsHostDetailsTabWrapper` and `InsightsTab` components that detects when the current host doesn't support the tab and redirects to `/Overview`
- Uses the same visibility helper functions (`vulnerabilityDisabled`, `isNotRhelHost`, `hasNoInsightsFacet`) already used in the `hideTab` metadata
- Added corresponding test cases

#### Considerations taken when implementing this change?
Consistency: Reused the existing helper functions from `ForemanRhCloudHelpers.js` that are already used for the `hideTab` metadata, ensuring the redirect logic matches the tab visibility logic exactly

#### What are the testing steps for this pull request?

1. Setup: Have two types of hosts available:

-   Type 1: Unregistered host without Recommendations/Vulnerabilities tabs (e.g., the Satellite base host)
-   Type 2: Registered RHEL host with Recommendations & Vulnerabilities tabs (IoP environment)

2. Test the fix:

- Navigate to a Type 2 host and select the Recommendations tab
-  Use the breadcrumb switcher to switch to a Type 1 host
-   Expected: You are redirected to the Overview tab
-   Repeat for the Vulnerabilities tab

3. Regression test:

- Navigate to a Type 2 host, Recommendations or Vulnerabilities tab
- Use breadcrumb switcher to switch to another Type 2 host
- Expected: You remain on the same tab with the new host's data

## Summary by Sourcery

Ensure host details Insights and Vulnerabilities tabs redirect to Overview when unsupported for the selected host.

Bug Fixes:
- Fix blank screen by redirecting from unsupported Insights and Vulnerabilities tabs to the Overview tab when switching to hosts without the necessary capabilities.

Tests:
- Add tests validating redirect behavior for Insights and Vulnerabilities tabs based on host OS, Insights facet presence, and vulnerability enablement.