### PR TITLE
Cherry-pick Fix host details tab navigation when switching from Recommendations

### DIFF
--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -33,13 +33,28 @@ const NewHostDetailsTab = ({ hostName, router }) => {
   const hits = useSelector(selectHits);
   const isIop = useIopConfig();
 
-  useEffect(() => () => router.replace({ search: null }), [router]);
+  useEffect(
+    () => () => {
+      // Preserve hash when clearing search params to prevent tab navigation bugs
+      if (router && typeof router.replace === 'function') {
+        const replaceOptions = { search: null };
+        if (router.location && router.location.hash) {
+          replaceOptions.hash = router.location.hash;
+        }
+        router.replace(replaceOptions);
+      }
+    },
+    [router]
+  );
 
   const onSearch = q => dispatch(fetchInsights({ query: q, page: 1 }));
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const onSatInsightsClick = () =>
-    router.push({ pathname: '/foreman_rh_cloud/insights_cloud' });
+  const onSatInsightsClick = () => {
+    if (router && typeof router.push === 'function') {
+      router.push({ pathname: '/foreman_rh_cloud/insights_cloud' });
+    }
+  };
 
   const dropdownItems = [
     <DropdownItem key="insights-link" ouiaId="insights-link">

--- a/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import NewHostDetailsTab from '../NewHostDetailsTab';
+
+jest.mock('../../common/Hooks/ConfigHooks', () => ({
+  useIopConfig: jest.fn(() => false),
+}));
+
+jest.mock('foremanReact/common/I18n', () => ({
+  translate: jest.fn(str => str),
+}));
+
+const mockStore = configureMockStore([thunk]);
+
+describe('NewHostDetailsTab', () => {
+  let store;
+  let mockRouter;
+
+  beforeEach(() => {
+    mockRouter = {
+      push: jest.fn(),
+      replace: jest.fn(),
+      location: {
+        pathname: '/new/hosts/test-host.example.com',
+        search: '?page=1&per_page=20',
+        hash: '#/Insights',
+        query: { page: '1', per_page: '20' },
+      },
+    };
+
+    store = mockStore({
+      API: {},
+      ForemanRhCloud: {
+        InsightsCloudSync: {
+          table: {
+            selectedIds: {},
+            isAllSelected: false,
+            showSelectAllAlert: false,
+          },
+        },
+      },
+      insightsHostDetailsTab: {
+        query: '',
+        hits: [],
+        selectedIds: {},
+        error: null,
+      },
+      router: {
+        location: {
+          pathname: '/new/hosts/test-host.example.com',
+          search: '?page=1&per_page=20',
+          hash: '#/Insights',
+          query: { page: '1', per_page: '20' },
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('cleanup effect', () => {
+    it('should preserve hash when clearing search params on unmount', () => {
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={mockRouter}
+          />
+        </Provider>
+      );
+
+      // Unmount the component to trigger cleanup
+      unmount();
+
+      // Verify router.replace was called with both search: null AND the existing hash
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+        search: null,
+        hash: '#/Insights',
+      });
+    });
+
+    it('should only clear search params when no hash exists', () => {
+      mockRouter.location.hash = '';
+
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={mockRouter}
+          />
+        </Provider>
+      );
+
+      unmount();
+
+      // When there's no hash, should only pass search: null
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+        search: null,
+      });
+    });
+
+    it('should handle router.location being undefined gracefully', () => {
+      const routerWithoutLocation = {
+        push: jest.fn(),
+        replace: jest.fn(),
+        location: undefined,
+      };
+
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={routerWithoutLocation}
+          />
+        </Provider>
+      );
+
+      unmount();
+
+      // Should still call replace with search: null even if location is undefined
+      expect(routerWithoutLocation.replace).toHaveBeenCalledWith({
+        search: null,
+      });
+    });
+
+    it('should use the latest hash value at unmount time, not a stale captured value', () => {
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={mockRouter}
+          />
+        </Provider>
+      );
+
+      // Change the hash after mount, before unmount
+      mockRouter.location.hash = '#/Overview';
+
+      unmount();
+
+      // Verify router.replace was called with the UPDATED hash, not the initial '#/Insights'
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+        search: null,
+        hash: '#/Overview',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary by Sourcery

Preserve host details tab navigation state when cleaning up router search parameters and add coverage for the behavior.

Bug Fixes:
- Ensure router hash is preserved when clearing search parameters on host details tab unmount to avoid tab navigation issues.
- Guard router navigation calls to avoid errors when router or its methods are undefined.

Tests:
- Add unit tests for NewHostDetailsTab cleanup behavior to verify hash preservation, behavior when no hash exists, handling of undefined router location, and use of the latest hash value at unmount.