### PR TITLE
Release 13.2.6

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '13.2.5'.freeze
+  VERSION = '13.2.6'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "13.2.5",
+  "version": "13.2.6",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary by Sourcery

Bump the foreman_rh_cloud plugin version to 13.2.6 in both the Ruby gem and npm package metadata.

Build:
- Update Ruby gem version constant to 13.2.6.
- Update npm package.json version to 13.2.6 to match the new release.