### PR TITLE
Cherry-pick: SAT-42831 - Fix stale recommendations/CVEs data when switching hosts …

### DIFF
--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '13.2.6'.freeze
+  VERSION = '13.2.7'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "13.2.6",
+  "version": "13.2.7",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {

--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -10,7 +10,12 @@ const CVEsHostDetailsTab = ({ systemId }) => {
   const module = './SystemDetailTable';
   return (
     <div className="rh-cloud-insights-vulnerability-host-details-component vulnerability">
-      <ScalprumComponent scope={scope} module={module} systemId={systemId} />
+      <ScalprumComponent
+        key={systemId}
+        scope={scope}
+        module={module}
+        systemId={systemId}
+      />
     </div>
   );
 };

--- a/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
+++ b/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
@@ -11,14 +11,25 @@ jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
   useForemanPermissions: () => new Set(['view_vulnerability']),
 }));
 
-jest.mock('@scalprum/react-core', () => ({
-  ScalprumComponent: jest.fn(props => (
-    <div data-testid="mock-scalprum-component">{JSON.stringify(props)}</div>
-  )),
-  ScalprumProvider: jest.fn(({ children }) => <div>{children}</div>),
-}));
+const mockUnmountTracker = jest.fn();
+jest.mock('@scalprum/react-core', () => {
+  const ReactMock = require('react');
+  return {
+    ScalprumComponent: jest.fn(props => {
+      ReactMock.useEffect(() => mockUnmountTracker, []);
+      return (
+        <div data-testid="mock-scalprum-component">{JSON.stringify(props)}</div>
+      );
+    }),
+    ScalprumProvider: jest.fn(({ children }) => <div>{children}</div>),
+  };
+});
 
 describe('CVEsHostDetailsTabWrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders without crashing', () => {
     const { container } = render(
       <CVEsHostDetailsTabWrapper
@@ -30,5 +41,33 @@ describe('CVEsHostDetailsTabWrapper', () => {
         '.rh-cloud-insights-vulnerability-host-details-component'
       )
     ).toBeTruthy();
+  });
+
+  it('remounts ScalprumComponent when systemId changes', () => {
+    const { ScalprumComponent } = require('@scalprum/react-core');
+
+    const { rerender } = render(
+      <CVEsHostDetailsTabWrapper
+        response={{ subscription_facet_attributes: { uuid: 'uuid-host-A' } }}
+      />
+    );
+
+    expect(mockUnmountTracker).not.toHaveBeenCalled();
+    expect(ScalprumComponent).toHaveBeenLastCalledWith(
+      expect.objectContaining({ systemId: 'uuid-host-A' }),
+      expect.anything()
+    );
+
+    rerender(
+      <CVEsHostDetailsTabWrapper
+        response={{ subscription_facet_attributes: { uuid: 'uuid-host-B' } }}
+      />
+    );
+
+    expect(mockUnmountTracker).toHaveBeenCalledTimes(1);
+    expect(ScalprumComponent).toHaveBeenLastCalledWith(
+      expect.objectContaining({ systemId: 'uuid-host-B' }),
+      expect.anything()
+    );
   });
 });

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -128,17 +128,32 @@ NewHostDetailsTab.defaultProps = {
 const scope = 'advisor';
 const module = './SystemDetailWrapped';
 
-const IopInsightsTab = props => (
-  <div className="advisor">
-    <ScalprumComponent
-      scope={scope}
-      module={module}
-      IopRemediationModal={RemediationModal}
-      generateRuleUrl={generateRuleUrl}
-      {...props}
-    />
-  </div>
-);
+const IopInsightsTab = props => {
+  // eslint-disable-next-line camelcase
+  const systemId = props.response?.subscription_facet_attributes?.uuid;
+  return (
+    <div className="advisor">
+      <ScalprumComponent
+        key={systemId || props.hostName}
+        scope={scope}
+        module={module}
+        IopRemediationModal={RemediationModal}
+        generateRuleUrl={generateRuleUrl}
+        {...props}
+      />
+    </div>
+  );
+};
+
+IopInsightsTab.propTypes = {
+  hostName: PropTypes.string,
+  response: PropTypes.object,
+};
+
+IopInsightsTab.defaultProps = {
+  hostName: '',
+  response: {},
+};
 
 const IopInsightsTabWrapped = props => {
   const permissions = useInsightsPermissions();


### PR DESCRIPTION
## Summary by Sourcery

Ensure host details tabs remount embedded Scalprum applications when the underlying host/system identifier changes to avoid stale vulnerability and recommendations data.

Bug Fixes:
- Force remount of the CVEs host details Scalprum component when systemId changes to prevent displaying stale vulnerability data.
- Force remount of the Insights host details Scalprum component when host identity changes to prevent stale recommendations data.

Tests:
- Extend CVEs host details tab tests to verify the Scalprum component unmounts and remounts when the systemId changes.