### PR TITLE
Release 12.2.17

### DIFF
--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -21,7 +21,8 @@ module RhCloudHost
     scoped_search :relation => :inventory_sync_status_object, :on => :status, :rename => :insights_inventory_sync_status,
       :complete_value => { :disconnect => ::InventorySync::InventoryStatus::DISCONNECT,
                            :sync => ::InventorySync::InventoryStatus::SYNC }
-    scoped_search :relation => :insights, :on => :uuid, :only_explicit => true, :rename => :insights_uuid
+    scoped_search :on => :id, :rename => :insights_uuid, :only_explicit => true,
+      :ext_method => :search_by_insights_uuid, :complete_value => false
 
     def insights_facet
       insights
@@ -39,6 +40,35 @@ module RhCloudHost
     def ensure_iop_insights_uuid
       return unless insights_facet.present? && subscription_facet.present? && insights_facet.uuid != subscription_facet.uuid
       insights_facet.update!(uuid: subscription_facet.uuid)
+    end
+  end
+
+  module ClassMethods
+    def search_by_insights_uuid(_key, operator, value)
+      # Determine which facet table to search based on IoP mode
+      facet_table = ForemanRhCloud.with_iop_smart_proxy? ? Katello::Host::SubscriptionFacet.table_name : InsightsFacet.table_name
+
+      # Build SQL condition
+      if ['IN', 'NOT IN'].include?(operator)
+        # For IN/NOT IN, value may be an array or comma-separated string
+        # Convert to array and build placeholders for each value
+        values = value.is_a?(Array) ? value : value.to_s.split(',').map(&:strip)
+        placeholders = (['?'] * values.size).join(',')
+        condition = sanitize_sql_for_conditions(
+          ["#{facet_table}.uuid #{operator} (#{placeholders})", *values]
+        )
+      else
+        # For other operators (=, !=, LIKE, etc.), use value_to_sql for proper SQL formatting
+        condition = sanitize_sql_for_conditions(
+          ["#{facet_table}.uuid #{operator} ?", value_to_sql(operator, value)]
+        )
+      end
+
+      # Return search parameters with LEFT JOIN to include hosts without facets
+      {
+        joins: "LEFT JOIN #{facet_table} ON #{facet_table}.host_id = #{Host::Managed.table_name}.id",
+        conditions: condition,
+      }
     end
   end
 end

--- a/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
+++ b/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
@@ -7,9 +7,15 @@ module ForemanInventoryUpload
 
       def run
         organization = ::Organization.find(input[:organization_id])
-        hosts_without_facets = ::ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: 'null? insights_uuid')
+        # Find hosts with subscription facets but without insights facets
+        # Note: We can't use scoped_search 'null? insights_uuid' because the null? operator
+        # doesn't work with ext_methods - it would check hosts.id IS NULL instead of the facet
+        hosts_without_facets = ::ForemanInventoryUpload::Generators::Queries.for_org(organization, use_batches: false)
+                                                                            .left_outer_joins(:insights)
+                                                                            .where(insights_facets: { id: nil })
+
         facet_count = 0
-        hosts_without_facets.each do |batch|
+        hosts_without_facets.in_batches(of: ForemanInventoryUpload.slice_size) do |batch|
           facets = batch.pluck(:id, 'katello_subscription_facets.uuid').map do |host_id, uuid|
             {
               host_id: host_id,

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '12.2.16'.freeze
+  VERSION = '12.2.17'.freeze
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "12.2.16",
+  "version": "12.2.17",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {

--- a/test/unit/rh_cloud_host_test.rb
+++ b/test/unit/rh_cloud_host_test.rb
@@ -188,4 +188,158 @@ class RhCloudHostTest < ActiveSupport::TestCase
       assert_equal local_uuid, @host.insights_uuid
     end
   end
+
+  context 'scoped search on insights_uuid' do
+    setup do
+      @org = FactoryBot.create(:organization)
+    end
+
+    teardown do
+      ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+    end
+
+    test 'searches insights_facet.uuid in non-IoP mode with = operator' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host1 = FactoryBot.create(:host, :managed, organization: @org)
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'insights-uuid-123')
+      host2 = FactoryBot.create(:host, :managed, organization: @org)
+      host2.insights = FactoryBot.create(:insights_facet, host_id: host2.id, uuid: 'insights-uuid-456')
+
+      results = Host::Managed.search_for('insights_uuid = insights-uuid-123')
+
+      assert_includes results, host1
+      assert_not_includes results, host2
+    end
+
+    test 'searches subscription_facet.uuid in IoP mode with = operator' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      host1 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host2 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      # Even if insights_facet has different UUID, should use subscription_facet UUID
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'stale-123')
+
+      results = Host::Managed.search_for("insights_uuid = #{host1.subscription_facet.uuid}")
+
+      assert_includes results, host1
+      assert_not_includes results, host2
+    end
+
+    test 'searches with ^ operator (IN) in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host1 = FactoryBot.create(:host, :managed, organization: @org)
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'uuid-1')
+      host2 = FactoryBot.create(:host, :managed, organization: @org)
+      host2.insights = FactoryBot.create(:insights_facet, host_id: host2.id, uuid: 'uuid-2')
+      host3 = FactoryBot.create(:host, :managed, organization: @org)
+      host3.insights = FactoryBot.create(:insights_facet, host_id: host3.id, uuid: 'uuid-3')
+
+      results = Host::Managed.search_for('insights_uuid ^ (uuid-1,uuid-2)')
+
+      assert_includes results, host1
+      assert_includes results, host2
+      assert_not_includes results, host3
+    end
+
+    test 'searches with ^ operator (IN) in IoP mode - THE BUG FIX' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      host1 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host2 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host3 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      # Create insights facets with stale UUIDs to verify we're using subscription_facet
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'stale-1')
+      host2.insights = FactoryBot.create(:insights_facet, host_id: host2.id, uuid: 'stale-2')
+      host3.insights = FactoryBot.create(:insights_facet, host_id: host3.id, uuid: 'stale-3')
+
+      uuid1 = host1.subscription_facet.uuid
+      uuid2 = host2.subscription_facet.uuid
+
+      # This is the search query that remediation modal creates
+      results = Host::Managed.search_for("insights_uuid ^ (#{uuid1},#{uuid2})")
+
+      # Should find hosts by subscription_facet UUID, not insights_facet UUID
+      assert_includes results, host1
+      assert_includes results, host2
+      assert_not_includes results, host3
+    end
+
+    test 'searches with !^ operator (NOT IN) in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host1 = FactoryBot.create(:host, :managed, organization: @org)
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'uuid-1')
+      host2 = FactoryBot.create(:host, :managed, organization: @org)
+      host2.insights = FactoryBot.create(:insights_facet, host_id: host2.id, uuid: 'uuid-2')
+      host3 = FactoryBot.create(:host, :managed, organization: @org)
+      host3.insights = FactoryBot.create(:insights_facet, host_id: host3.id, uuid: 'uuid-3')
+
+      results = Host::Managed.search_for('insights_uuid !^ (uuid-1,uuid-2)')
+
+      assert_not_includes results, host1
+      assert_not_includes results, host2
+      assert_includes results, host3
+    end
+
+    test 'searches with !^ operator (NOT IN) in IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      host1 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host2 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host3 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      uuid1 = host1.subscription_facet.uuid
+      uuid2 = host2.subscription_facet.uuid
+
+      results = Host::Managed.search_for("insights_uuid !^ (#{uuid1},#{uuid2})")
+
+      assert_not_includes results, host1
+      assert_not_includes results, host2
+      assert_includes results, host3
+    end
+
+    test 'handles hosts without facets in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host_without_facet = FactoryBot.create(:host, :managed, organization: @org)
+      host_with_facet = FactoryBot.create(:host, :managed, organization: @org)
+      host_with_facet.insights = FactoryBot.create(:insights_facet, host_id: host_with_facet.id, uuid: 'uuid-1')
+
+      results = Host::Managed.search_for('insights_uuid = uuid-1')
+
+      assert_includes results, host_with_facet
+      assert_not_includes results, host_without_facet
+    end
+
+    test 'handles hosts without subscription_facet in IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      host_without_sub = FactoryBot.create(:host, :managed, organization: @org)
+      host_with_sub = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      uuid = host_with_sub.subscription_facet.uuid
+
+      results = Host::Managed.search_for("insights_uuid = #{uuid}")
+
+      assert_includes results, host_with_sub
+      assert_not_includes results, host_without_sub
+    end
+
+    test 'mode changes are reflected in searches' do
+      host1 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'insights-uuid-abc')
+      insights_uuid = 'insights-uuid-abc'
+      subscription_uuid = host1.subscription_facet.uuid
+
+      # Non-IoP mode: should find by insights_facet UUID
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      results = Host::Managed.search_for("insights_uuid = #{insights_uuid}")
+      assert_includes results, host1
+
+      # IoP mode: should find by subscription_facet UUID
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      results = Host::Managed.search_for("insights_uuid = #{subscription_uuid}")
+      assert_includes results, host1
+
+      # Should NOT find by old insights_facet UUID in IoP mode
+      results = Host::Managed.search_for("insights_uuid = #{insights_uuid}")
+      assert_not_includes results, host1
+    end
+  end
 end

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -32,13 +32,28 @@ const NewHostDetailsTab = ({ hostName, router }) => {
   const hits = useSelector(selectHits);
   const isIop = useIopConfig();
 
-  useEffect(() => () => router.replace({ search: null }), [router]);
+  useEffect(
+    () => () => {
+      // Preserve hash when clearing search params to prevent tab navigation bugs
+      if (router && typeof router.replace === 'function') {
+        const replaceOptions = { search: null };
+        if (router.location && router.location.hash) {
+          replaceOptions.hash = router.location.hash;
+        }
+        router.replace(replaceOptions);
+      }
+    },
+    [router]
+  );
 
   const onSearch = q => dispatch(fetchInsights({ query: q, page: 1 }));
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const onSatInsightsClick = () =>
-    router.push({ pathname: '/foreman_rh_cloud/insights_cloud' });
+  const onSatInsightsClick = () => {
+    if (router && typeof router.push === 'function') {
+      router.push({ pathname: '/foreman_rh_cloud/insights_cloud' });
+    }
+  };
 
   const dropdownItems = [
     <DropdownItem key="insights-link" ouiaId="insights-link">

--- a/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import NewHostDetailsTab from '../NewHostDetailsTab';
+
+jest.mock('../../common/Hooks/ConfigHooks', () => ({
+  useIopConfig: jest.fn(() => false),
+}));
+
+jest.mock('foremanReact/common/I18n', () => ({
+  translate: jest.fn(str => str),
+}));
+
+const mockStore = configureMockStore([thunk]);
+
+describe('NewHostDetailsTab', () => {
+  let store;
+  let mockRouter;
+
+  beforeEach(() => {
+    mockRouter = {
+      push: jest.fn(),
+      replace: jest.fn(),
+      location: {
+        pathname: '/new/hosts/test-host.example.com',
+        search: '?page=1&per_page=20',
+        hash: '#/Insights',
+        query: { page: '1', per_page: '20' },
+      },
+    };
+
+    store = mockStore({
+      API: {},
+      ForemanRhCloud: {
+        InsightsCloudSync: {
+          table: {
+            selectedIds: {},
+            isAllSelected: false,
+            showSelectAllAlert: false,
+          },
+        },
+      },
+      insightsHostDetailsTab: {
+        query: '',
+        hits: [],
+        selectedIds: {},
+        error: null,
+      },
+      router: {
+        location: {
+          pathname: '/new/hosts/test-host.example.com',
+          search: '?page=1&per_page=20',
+          hash: '#/Insights',
+          query: { page: '1', per_page: '20' },
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('cleanup effect', () => {
+    it('should preserve hash when clearing search params on unmount', () => {
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={mockRouter}
+          />
+        </Provider>
+      );
+
+      // Unmount the component to trigger cleanup
+      unmount();
+
+      // Verify router.replace was called with both search: null AND the existing hash
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+        search: null,
+        hash: '#/Insights',
+      });
+    });
+
+    it('should only clear search params when no hash exists', () => {
+      mockRouter.location.hash = '';
+
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={mockRouter}
+          />
+        </Provider>
+      );
+
+      unmount();
+
+      // When there's no hash, should only pass search: null
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+        search: null,
+      });
+    });
+
+    it('should handle router.location being undefined gracefully', () => {
+      const routerWithoutLocation = {
+        push: jest.fn(),
+        replace: jest.fn(),
+        location: undefined,
+      };
+
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={routerWithoutLocation}
+          />
+        </Provider>
+      );
+
+      unmount();
+
+      // Should still call replace with search: null even if location is undefined
+      expect(routerWithoutLocation.replace).toHaveBeenCalledWith({
+        search: null,
+      });
+    });
+
+    it('should use the latest hash value at unmount time, not a stale captured value', () => {
+      const { unmount } = render(
+        <Provider store={store}>
+          <NewHostDetailsTab
+            hostName="test-host.example.com"
+            router={mockRouter}
+          />
+        </Provider>
+      );
+
+      // Change the hash after mount, before unmount
+      mockRouter.location.hash = '#/Overview';
+
+      unmount();
+
+      // Verify router.replace was called with the UPDATED hash, not the initial '#/Insights'
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+        search: null,
+        hash: '#/Overview',
+      });
+    });
+  });
+});


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Fix insights UUID-based host searching and related cleanup for both backend and UI while preparing the 12.2.17 release.

Bug Fixes:
- Ensure scoped search on insights_uuid correctly queries the appropriate facet table in both IoP and non-IoP modes, including support for IN and NOT IN operators.
- Correct the inventory upload job to identify hosts missing insights facets without relying on scoped_search null? semantics.
- Prevent tab navigation issues in the Insights host details view by preserving the URL hash when clearing search query parameters and by safely guarding router interactions.

Enhancements:
- Add a custom scoped_search handler for insights_uuid to route queries through a dedicated search method and support additional operators.

Build:
- Bump plugin and package.json version numbers to 12.2.17.

Tests:
- Add comprehensive unit tests for insights_uuid scoped search behavior across IoP modes, operators, and edge cases such as missing facets or mode changes.
- Add Jest tests for NewHostDetailsTab to validate URL cleanup behavior and hash preservation on unmount.