### PR TITLE
Fix report path not returned when subscription connection is disabled

### DIFF
--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -32,7 +32,11 @@ module ForemanInventoryUpload
 
   def self.report_file_paths(organization_id)
     filename = facts_archive_name(organization_id)
-    Dir[ForemanInventoryUpload.uploads_file_path(filename), ForemanInventoryUpload.done_file_path(filename)]
+    Dir[
+      ForemanInventoryUpload.generated_reports_file_path(filename),
+      ForemanInventoryUpload.uploads_file_path(filename),
+      ForemanInventoryUpload.done_file_path(filename)
+    ]
   end
 
   def self.generated_reports_folder
@@ -42,6 +46,10 @@ module ForemanInventoryUpload
         'generated_reports/'
       )
     )
+  end
+
+  def self.generated_reports_file_path(filename)
+    File.join(ForemanInventoryUpload.generated_reports_folder, filename)
   end
 
   def self.outputs_folder

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -32,6 +32,13 @@ module ForemanInventoryUpload
 
   def self.report_file_paths(organization_id)
     filename = facts_archive_name(organization_id)
+    # Report files start in generated
+    # They are then MOVED (not copied) to uploads, then done.
+    # When they are moved to the new folder, they overwrite any file with the same name.
+    # If it's a generate-only, it will be in generated
+    # Failed or incomplete uploads will be in uploads
+    # Completed uploads will be in done
+    # The ordering here ensures we get the correct file path every time.
     Dir[
       ForemanInventoryUpload.generated_reports_file_path(filename),
       ForemanInventoryUpload.uploads_file_path(filename),

--- a/lib/foreman_inventory_upload/async/upload_report_direct_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_direct_job.rb
@@ -95,8 +95,8 @@ module ForemanInventoryUpload
           begin
             upload_file(cer_path)
             progress_output.write_line("Upload completed successfully")
-            move_to_done_folder
-            progress_output.write_line("Uploaded file moved to done/ folder")
+            done_path = move_to_done_folder
+            progress_output.write_line("Uploaded report moved to #{done_path}")
             progress_output.status = "pid #{Process.pid} exit 0"
           rescue StandardError => e
             progress_output.write_line("Upload failed: #{e.message}")
@@ -139,6 +139,7 @@ module ForemanInventoryUpload
         done_file = ForemanInventoryUpload.done_file_path(File.basename(filename))
         FileUtils.mv(filename, done_file)
         logger.debug("Moved #{filename} to #{done_file}")
+        done_file
       end
 
       def certificate

--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -46,6 +46,10 @@ namespace :rh_cloud_inventory do
             filter,
             false # don't upload; the user ran report:generate and not report:generate_upload
           )
+          unless Setting[:subscription_connection_enabled]
+            report_path = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization_id, filter))
+            puts "Generated report at #{report_path}" if File.exist?(report_path)
+          end
         end
         puts "Check the Uploading tab for report uploading status." if Setting[:subscription_connection_enabled]
       end

--- a/lib/tasks/rh_cloud_inventory.rake
+++ b/lib/tasks/rh_cloud_inventory.rake
@@ -47,8 +47,8 @@ namespace :rh_cloud_inventory do
             false # don't upload; the user ran report:generate and not report:generate_upload
           )
           unless Setting[:subscription_connection_enabled]
-            report_path = File.join(base_folder, ForemanInventoryUpload.facts_archive_name(organization_id, filter))
-            puts "Generated report at #{report_path}" if File.exist?(report_path)
+            report_paths = ForemanInventoryUpload.report_file_paths(organization_id)
+            puts "Report saved to #{report_paths.first}" if report_paths.any?
           end
         end
         puts "Check the Uploading tab for report uploading status." if Setting[:subscription_connection_enabled]

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -5,6 +5,49 @@ class AccountsControllerTest < ActionController::TestCase
 
   include FolderIsolation
 
+  test 'report_file_paths finds report in generated_reports folder' do
+    test_org = FactoryBot.create(:organization)
+    filename = ForemanInventoryUpload.facts_archive_name(test_org.id)
+
+    generated_path = ForemanInventoryUpload.generated_reports_file_path(filename)
+    FileUtils.mkdir_p(File.dirname(generated_path))
+    FileUtils.touch(generated_path)
+
+    paths = ForemanInventoryUpload.report_file_paths(test_org.id)
+    assert_includes paths, generated_path
+  end
+
+  test 'report_file_paths finds report in uploads folder' do
+    test_org = FactoryBot.create(:organization)
+    filename = ForemanInventoryUpload.facts_archive_name(test_org.id)
+
+    uploads_path = ForemanInventoryUpload.uploads_file_path(filename)
+    FileUtils.mkdir_p(File.dirname(uploads_path))
+    FileUtils.touch(uploads_path)
+
+    paths = ForemanInventoryUpload.report_file_paths(test_org.id)
+    assert_includes paths, uploads_path
+  end
+
+  test 'report_file_paths finds report in done folder' do
+    test_org = FactoryBot.create(:organization)
+    filename = ForemanInventoryUpload.facts_archive_name(test_org.id)
+
+    done_path = ForemanInventoryUpload.done_file_path(filename)
+    FileUtils.mkdir_p(File.dirname(done_path))
+    FileUtils.touch(done_path)
+
+    paths = ForemanInventoryUpload.report_file_paths(test_org.id)
+    assert_includes paths, done_path
+  end
+
+  test 'report_file_paths returns empty when no report exists' do
+    test_org = FactoryBot.create(:organization)
+
+    paths = ForemanInventoryUpload.report_file_paths(test_org.id)
+    assert_empty paths
+  end
+
   test 'Returns statuses for each process type' do
     test_org = FactoryBot.create(:organization)
 

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -31,6 +31,7 @@ module FolderIsolation
       ForemanInventoryUpload.stubs(:base_folder).returns(@tmpdir)
       ForemanInventoryUpload.instance_variable_set(:@outputs_folder, nil)
       ForemanInventoryUpload.instance_variable_set(:@uploads_folders, nil)
+      ForemanInventoryUpload.instance_variable_set(:@generated_reports_folder, nil)
     end
 
     teardown do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* When subscription_connection_enabled is FALSE, the generated report stays in generated_reports/ folder since QueueForUploadJob is skipped. The report_file_paths method only searched uploads/ and done/ folders, so the UI received an empty array and couldn't show the download path.
* Add generated_reports/ to the search locations in report_file_paths and add tests covering all three folder locations.
* Fixed wording on the upload section

#### Root cause

* (lib/foreman_inventory_upload.rb:33-36):

* When subscription_connection_enabled is FALSE:
  1. The report generates successfully into generated_reports/ folder
  2. QueueForUploadJob is skipped (line 17 of generate_report_job.rb), so the file never moves to uploads/
  3. report_file_paths (line 33-36) only searches in uploads/ and done/ — not in generated_reports/
  4. The UI gets an empty array and can't show the report path

#### What are the testing steps for this pull request?
* Spin up a non iop Satellite 6.18.4 latest snap
* Turn the `subscription_connection_enabled` to false in Settings
* Try to do an inventory upload and see nothing shows up
![Screenshot_26-3-2026_11217_ip-10-0-198-98 rhos-01 prod psi rdu2 redhat com](https://github.com/user-attachments/assets/a87993bf-e738-4366-aaa6-60b5d93ee33b)
* `cd /usr/share/gems/gems/foreman_rh_cloud-12.2.17/`
* `wget https://patch-diff.githubusercontent.com/raw/theforeman/foreman_rh_cloud/pull/1189.patch
* `patch -p1 < 1189.patch`
* Ignore the errors about the test files and hit y it should have patched the main files
* Restart services with `foreman-maintain service restart`
* Try to do an inventory upload and see it shows the report location and text now:
![Screenshot_26-3-2026_113646_ip-10-0-198-98 rhos-01 prod psi rdu2 redhat com](https://github.com/user-attachments/assets/570b80ec-61cf-43b9-88af-67989a11ef06)
