### PR TITLE
Fix VmaasReposcanSync errors preventing parent task success (#1180)

### DIFF
--- a/lib/insights_cloud/async/vmaas_reposcan_sync.rb
+++ b/lib/insights_cloud/async/vmaas_reposcan_sync.rb
@@ -6,6 +6,8 @@ module InsightsCloud
     class VmaasReposcanSync < ::Actions::EntryAction
       include ::ForemanRhCloud::CertAuth
 
+      HTTP_TOO_MANY_REQUESTS = 429
+
       # Subscribe to Katello repository sync hook action, if available
       def self.subscribe
         'Actions::Katello::Repository::SyncHook'.constantize
@@ -49,15 +51,9 @@ module InsightsCloud
 
         response
       rescue RestClient::ExceptionWithResponse => e
-        message = "VMaaS reposcan sync failed: #{e.response&.code} - #{e.response&.body}"
-        logger.error(message)
-        output[:message] = message
-        raise
+        handle_rest_client_error(e)
       rescue StandardError => e
-        message = "Error triggering VMaaS reposcan sync: #{e.message}, response: #{e.respond_to?(:response) ? e.response : nil}"
-        logger.error(message)
-        output[:message] = message
-        raise
+        handle_standard_error(e)
       end
 
       def rescue_strategy_for_self
@@ -69,6 +65,25 @@ module InsightsCloud
       end
 
       private
+
+      def handle_rest_client_error(exception)
+        if exception.response&.code == HTTP_TOO_MANY_REQUESTS
+          message = "VMaaS reposcan sync skipped: another sync already in progress (#{HTTP_TOO_MANY_REQUESTS})"
+          logger.warn(message)
+        else
+          message = "VMaaS reposcan sync failed: #{exception.response&.code} - #{exception.response&.body}"
+          logger.error(message)
+        end
+        output[:message] = message
+        # Do NOT raise - let rescue_strategy_for_self Skip handle this
+      end
+
+      def handle_standard_error(exception)
+        message = "Error triggering VMaaS reposcan sync: #{exception.message}"
+        logger.error(message)
+        output[:message] = message
+        # Do NOT raise - let rescue_strategy_for_self Skip handle this
+      end
 
       def logger
         action_logger

--- a/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
+++ b/test/unit/lib/insights_cloud/async/vmaas_reposcan_sync_test.rb
@@ -5,19 +5,17 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
   include ForemanTasks::TestHelpers::WithInThreadExecutor
 
   setup do
-    @root = FactoryBot.build(:katello_root_repository, :fedora_17_x86_64_dev_root)
-    @root.save(validate: false)
-    @repo = FactoryBot.create(
-      :katello_repository,
-      :with_product,
-      distribution_family: 'Red Hat',
-      distribution_version: '7.5',
-      root: @root
-    )
+    @organization = FactoryBot.create(:organization)
+    # Create a simple repository - we only need id and organization_id for the action
+    @repo = ::Katello::Repository.new(id: 1)
+    @repo.stubs(:organization_id).returns(@organization.id)
+    ::Katello::Repository.stubs(:find).with(1).returns(@repo)
+
     @repo_payload = { id: @repo.id }
     @expected_url = 'https://example.com/api/v1/vmaas/reposcan/sync'
     InsightsCloud.stubs(:vmaas_reposcan_sync_url).returns(@expected_url)
     ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+    Organization.stubs(:find).with(@organization.id).returns(@organization)
   end
 
   teardown do
@@ -83,7 +81,7 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
         params[:url] == @expected_url &&
         params[:headers].is_a?(Hash) &&
         params[:headers]['Content-Type'] == 'application/json' &&
-        params[:organization] == @repo.organization
+        params[:organization] == @organization
     end
                                            .returns(mock_response)
 
@@ -116,37 +114,94 @@ class VmaasReposcanSyncTest < ActiveSupport::TestCase
                                            .stubs(:execute_cloud_request)
                                            .raises(exception)
 
-    error = assert_raises(ForemanTasks::TaskError) do
-      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
-    end
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
 
-    assert_equal 'VMaaS reposcan sync failed: 500 - Server Error', error.task.output[:message]
+    assert_equal 'VMaaS reposcan sync failed: 500 - Server Error', task.output[:message]
   end
 
   test 'run sets error message in task output for StandardError exception' do
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with('Error triggering VMaaS reposcan sync: Network timeout')
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+
     InsightsCloud::Async::VmaasReposcanSync.any_instance
                                            .stubs(:execute_cloud_request)
                                            .raises(StandardError.new('Network timeout'))
 
-    error = assert_raises(ForemanTasks::TaskError) do
-      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
-    end
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
 
-    # The task is available via main_action
-    assert_match(/Error triggering VMaaS reposcan sync: Network timeout, response: /,
-      error.task.main_action.output[:message])
+    assert_equal 'Error triggering VMaaS reposcan sync: Network timeout', task.output[:message]
   end
 
-  test 'run logs and re-raises when cloud request returns error response' do
-    error_response = mock('error_response', code: 500, body: 'error')
+  test 'run logs and handles error response without raising' do
+    error_response = mock('error_response')
+    error_response.stubs(:code).returns(500)
+    error_response.stubs(:body).returns('error')
     exception = RestClient::ExceptionWithResponse.new(error_response)
 
     InsightsCloud::Async::VmaasReposcanSync.any_instance
                                            .stubs(:execute_cloud_request)
                                            .raises(exception)
 
-    assert_raises(ForemanTasks::TaskError) do
-      ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
-    end
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync failed: 500 - error', task.output[:message]
+  end
+
+  test 'run handles 429 error with warning log level' do
+    error_response = mock('error_response')
+    error_response.stubs(:code).returns(429)
+    error_response.stubs(:body).returns('{"msg": "Another task already in progress"}')
+    exception = RestClient::ExceptionWithResponse.new(error_response)
+
+    mock_logger = mock('logger')
+    mock_logger.expects(:warn).with('VMaaS reposcan sync skipped: another sync already in progress (429)')
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync skipped: another sync already in progress (429)',
+      task.output[:message]
+  end
+
+  test 'run handles non-429 errors with error log level' do
+    error_response = mock('error_response')
+    error_response.stubs(:code).returns(500)
+    error_response.stubs(:body).returns('Internal Server Error')
+    exception = RestClient::ExceptionWithResponse.new(error_response)
+
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with('VMaaS reposcan sync failed: 500 - Internal Server Error')
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    assert_equal 'VMaaS reposcan sync failed: 500 - Internal Server Error',
+      task.output[:message]
+  end
+
+  test 'run handles RestClient::ExceptionWithResponse with nil response' do
+    exception = RestClient::ExceptionWithResponse.new(nil)
+
+    mock_logger = mock('logger')
+    mock_logger.expects(:error).with('VMaaS reposcan sync failed:  - ')
+    InsightsCloud::Async::VmaasReposcanSync.any_instance.stubs(:logger).returns(mock_logger)
+
+    InsightsCloud::Async::VmaasReposcanSync.any_instance
+                                           .stubs(:execute_cloud_request)
+                                           .raises(exception)
+
+    task = ForemanTasks.sync_task(InsightsCloud::Async::VmaasReposcanSync, @repo_payload)
+
+    refute_nil task.output[:message]
+    assert_equal 'VMaaS reposcan sync failed:  - ', task.output[:message]
   end
 end


### PR DESCRIPTION
* Fix VmaasReposcanSync errors preventing parent task success

When VmaasReposcanSync receives an error from the IoP service (especially 429 during concurrent syncs), the action was re-raising exceptions which caused parent Katello repository sync tasks to fail. This fix removes the raise statements and allows the rescue_strategy_for_self Skip to work correctly, ensuring repository syncs succeed even when reposcan requests fail.


(cherry picked from commit 38bc0e24a610c0b5f839cffcdb2785d7119091fc)

#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Ensure VMaaS reposcan sync errors no longer cause parent Katello repository sync tasks to fail by handling them gracefully and relying on the action's skip rescue strategy.

Bug Fixes:
- Prevent VMaaS reposcan sync HTTP and network errors from propagating as task failures, allowing repository syncs to succeed even when reposcan requests fail.

Enhancements:
- Add structured error handling for VMaaS reposcan sync, including special treatment for HTTP 429 to log a warning and mark the sync as skipped.
- Simplify test setup for VMaaS reposcan sync by using a minimal repository and organization stub rather than full database-backed objects.

Tests:
- Extend and update VMaaS reposcan sync unit tests to cover new error-handling paths, logging behavior, and task output messages for various failure scenarios.