### PR TITLE
Hide checkbox on Recommendations table when no rows are selectable

### DIFF
--- a/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTable.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTable.js
@@ -58,6 +58,8 @@ const InsightsTable = ({
     if (hideHost) setColumns(getColumnsWithoutHostname());
   }, [hits, selectedIds, hideHost]);
 
+  const hasSelectableRows = rows.some(row => !row.disableCheckbox);
+
   return (
     <React.Fragment>
       <SelectAllAlert
@@ -71,10 +73,11 @@ const InsightsTable = ({
         className="rh-cloud-recommendations-table"
         ouiaId="rh-cloud-recommendations-table"
         aria-label="Recommendations Table"
-        onSelect={(_event, isSelected, rowId) =>
-          onTableSelect(isSelected, rowId, rows, selectedIds)
-        }
-        canSelectAll={rows.length > 0}
+        {...(hasSelectableRows && {
+          onSelect: (_event, isSelected, rowId) =>
+            onTableSelect(isSelected, rowId, rows, selectedIds),
+        })}
+        canSelectAll={hasSelectableRows}
         sortBy={{
           index: getSortColumnIndex(columns, sortBy),
           direction: sortOrder,

--- a/webpack/InsightsCloudSync/Components/InsightsTable/table.scss
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/table.scss
@@ -5,6 +5,15 @@
     }
   }
 
+  tbody .pf-v5-c-table__check {
+    vertical-align: middle;
+  }
+
+  thead .pf-v5-c-table__check label {
+    position: relative;
+    top: 2px;
+  }
+
   .td-insights-remediate-playbook {
     svg {
       margin-right: 5px;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* When all rows are manual-only (no playbook), the select-all checkbox was appearing in the header next to Hostname with no corresponding row checkboxes, looking out of place. Now the checkbox column is only rendered when at least one row has a playbook available.

#### What are the testing steps for this pull request?
* Have a non-iop devel box
* Register a host to it fresh from broker and register it with insights-client
* Sync recommendations
* See screenshot:
<img width="1667" height="930" alt="before" src="https://github.com/user-attachments/assets/4a4de634-4db6-45c4-9320-988802689a59" />
* Apply pr and restart dev box
* Check and see if it looks like this:
<img width="1667" height="930" alt="manual-remediation" src="https://github.com/user-attachments/assets/16537cd5-f797-4f40-bf71-f876a5be5419" />
* Now do some changes to have non manual remediations show up:

```bash
chmod 777 /etc/ssh/sshd_config
chmod 0600 /etc/ssh/sshd_config
insights-client
```

* Sync recommendations
* See that the checkbox only shows up for non-manual ones:
<img width="1667" height="930" alt="multi-remediations" src="https://github.com/user-attachments/assets/2af6058a-8015-4723-95f6-4b43aafbc5b7" />
