### PR TITLE
Backport: Fix insights_uuid scoped search for IoP mode

### DIFF
--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -21,7 +21,8 @@ module RhCloudHost
     scoped_search :relation => :inventory_sync_status_object, :on => :status, :rename => :insights_inventory_sync_status,
       :complete_value => { :disconnect => ::InventorySync::InventoryStatus::DISCONNECT,
                            :sync => ::InventorySync::InventoryStatus::SYNC }
-    scoped_search :relation => :insights, :on => :uuid, :only_explicit => true, :rename => :insights_uuid
+    scoped_search :on => :id, :rename => :insights_uuid, :only_explicit => true,
+      :ext_method => :search_by_insights_uuid, :complete_value => false
 
     def insights_facet
       insights
@@ -39,6 +40,35 @@ module RhCloudHost
     def ensure_iop_insights_uuid
       return unless insights_facet.present? && subscription_facet.present? && insights_facet.uuid != subscription_facet.uuid
       insights_facet.update!(uuid: subscription_facet.uuid)
+    end
+  end
+
+  module ClassMethods
+    def search_by_insights_uuid(_key, operator, value)
+      # Determine which facet table to search based on IoP mode
+      facet_table = ForemanRhCloud.with_iop_smart_proxy? ? Katello::Host::SubscriptionFacet.table_name : InsightsFacet.table_name
+
+      # Build SQL condition
+      if ['IN', 'NOT IN'].include?(operator)
+        # For IN/NOT IN, value may be an array or comma-separated string
+        # Convert to array and build placeholders for each value
+        values = value.is_a?(Array) ? value : value.to_s.split(',').map(&:strip)
+        placeholders = (['?'] * values.size).join(',')
+        condition = sanitize_sql_for_conditions(
+          ["#{facet_table}.uuid #{operator} (#{placeholders})", *values]
+        )
+      else
+        # For other operators (=, !=, LIKE, etc.), use value_to_sql for proper SQL formatting
+        condition = sanitize_sql_for_conditions(
+          ["#{facet_table}.uuid #{operator} ?", value_to_sql(operator, value)]
+        )
+      end
+
+      # Return search parameters with LEFT JOIN to include hosts without facets
+      {
+        joins: "LEFT JOIN #{facet_table} ON #{facet_table}.host_id = #{Host::Managed.table_name}.id",
+        conditions: condition,
+      }
     end
   end
 end

--- a/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
+++ b/lib/foreman_inventory_upload/async/create_missing_insights_facets.rb
@@ -7,9 +7,15 @@ module ForemanInventoryUpload
 
       def run
         organization = ::Organization.find(input[:organization_id])
-        hosts_without_facets = ::ForemanInventoryUpload::Generators::Queries.for_org(organization, hosts_query: 'null? insights_uuid')
+        # Find hosts with subscription facets but without insights facets
+        # Note: We can't use scoped_search 'null? insights_uuid' because the null? operator
+        # doesn't work with ext_methods - it would check hosts.id IS NULL instead of the facet
+        hosts_without_facets = ::ForemanInventoryUpload::Generators::Queries.for_org(organization, use_batches: false)
+                                                                            .left_outer_joins(:insights)
+                                                                            .where(insights_facets: { id: nil })
+
         facet_count = 0
-        hosts_without_facets.each do |batch|
+        hosts_without_facets.in_batches(of: ForemanInventoryUpload.slice_size) do |batch|
           facets = batch.pluck(:id, 'katello_subscription_facets.uuid').map do |host_id, uuid|
             {
               host_id: host_id,

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '13.2.7'.freeze
+  VERSION = '13.2.8'.freeze
 end

--- a/test/unit/rh_cloud_host_test.rb
+++ b/test/unit/rh_cloud_host_test.rb
@@ -188,4 +188,158 @@ class RhCloudHostTest < ActiveSupport::TestCase
       assert_equal local_uuid, @host.insights_uuid
     end
   end
+
+  context 'scoped search on insights_uuid' do
+    setup do
+      @org = FactoryBot.create(:organization)
+    end
+
+    teardown do
+      ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+    end
+
+    test 'searches insights_facet.uuid in non-IoP mode with = operator' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host1 = FactoryBot.create(:host, :managed, organization: @org)
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'insights-uuid-123')
+      host2 = FactoryBot.create(:host, :managed, organization: @org)
+      host2.insights = FactoryBot.create(:insights_facet, host_id: host2.id, uuid: 'insights-uuid-456')
+
+      results = Host::Managed.search_for('insights_uuid = insights-uuid-123')
+
+      assert_includes results, host1
+      assert_not_includes results, host2
+    end
+
+    test 'searches subscription_facet.uuid in IoP mode with = operator' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      host1 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host2 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      # Even if insights_facet has different UUID, should use subscription_facet UUID
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'stale-123')
+
+      results = Host::Managed.search_for("insights_uuid = #{host1.subscription_facet.uuid}")
+
+      assert_includes results, host1
+      assert_not_includes results, host2
+    end
+
+    test 'searches with ^ operator (IN) in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host1 = FactoryBot.create(:host, :managed, organization: @org)
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'uuid-1')
+      host2 = FactoryBot.create(:host, :managed, organization: @org)
+      host2.insights = FactoryBot.create(:insights_facet, host_id: host2.id, uuid: 'uuid-2')
+      host3 = FactoryBot.create(:host, :managed, organization: @org)
+      host3.insights = FactoryBot.create(:insights_facet, host_id: host3.id, uuid: 'uuid-3')
+
+      results = Host::Managed.search_for('insights_uuid ^ (uuid-1,uuid-2)')
+
+      assert_includes results, host1
+      assert_includes results, host2
+      assert_not_includes results, host3
+    end
+
+    test 'searches with ^ operator (IN) in IoP mode - THE BUG FIX' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      host1 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host2 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host3 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      # Create insights facets with stale UUIDs to verify we're using subscription_facet
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'stale-1')
+      host2.insights = FactoryBot.create(:insights_facet, host_id: host2.id, uuid: 'stale-2')
+      host3.insights = FactoryBot.create(:insights_facet, host_id: host3.id, uuid: 'stale-3')
+
+      uuid1 = host1.subscription_facet.uuid
+      uuid2 = host2.subscription_facet.uuid
+
+      # This is the search query that remediation modal creates
+      results = Host::Managed.search_for("insights_uuid ^ (#{uuid1},#{uuid2})")
+
+      # Should find hosts by subscription_facet UUID, not insights_facet UUID
+      assert_includes results, host1
+      assert_includes results, host2
+      assert_not_includes results, host3
+    end
+
+    test 'searches with !^ operator (NOT IN) in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host1 = FactoryBot.create(:host, :managed, organization: @org)
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'uuid-1')
+      host2 = FactoryBot.create(:host, :managed, organization: @org)
+      host2.insights = FactoryBot.create(:insights_facet, host_id: host2.id, uuid: 'uuid-2')
+      host3 = FactoryBot.create(:host, :managed, organization: @org)
+      host3.insights = FactoryBot.create(:insights_facet, host_id: host3.id, uuid: 'uuid-3')
+
+      results = Host::Managed.search_for('insights_uuid !^ (uuid-1,uuid-2)')
+
+      assert_not_includes results, host1
+      assert_not_includes results, host2
+      assert_includes results, host3
+    end
+
+    test 'searches with !^ operator (NOT IN) in IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      host1 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host2 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host3 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      uuid1 = host1.subscription_facet.uuid
+      uuid2 = host2.subscription_facet.uuid
+
+      results = Host::Managed.search_for("insights_uuid !^ (#{uuid1},#{uuid2})")
+
+      assert_not_includes results, host1
+      assert_not_includes results, host2
+      assert_includes results, host3
+    end
+
+    test 'handles hosts without facets in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host_without_facet = FactoryBot.create(:host, :managed, organization: @org)
+      host_with_facet = FactoryBot.create(:host, :managed, organization: @org)
+      host_with_facet.insights = FactoryBot.create(:insights_facet, host_id: host_with_facet.id, uuid: 'uuid-1')
+
+      results = Host::Managed.search_for('insights_uuid = uuid-1')
+
+      assert_includes results, host_with_facet
+      assert_not_includes results, host_without_facet
+    end
+
+    test 'handles hosts without subscription_facet in IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      host_without_sub = FactoryBot.create(:host, :managed, organization: @org)
+      host_with_sub = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+
+      uuid = host_with_sub.subscription_facet.uuid
+
+      results = Host::Managed.search_for("insights_uuid = #{uuid}")
+
+      assert_includes results, host_with_sub
+      assert_not_includes results, host_without_sub
+    end
+
+    test 'mode changes are reflected in searches' do
+      host1 = FactoryBot.create(:host, :managed, :with_subscription, organization: @org)
+      host1.insights = FactoryBot.create(:insights_facet, host_id: host1.id, uuid: 'insights-uuid-abc')
+      insights_uuid = 'insights-uuid-abc'
+      subscription_uuid = host1.subscription_facet.uuid
+
+      # Non-IoP mode: should find by insights_facet UUID
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      results = Host::Managed.search_for("insights_uuid = #{insights_uuid}")
+      assert_includes results, host1
+
+      # IoP mode: should find by subscription_facet UUID
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+      results = Host::Managed.search_for("insights_uuid = #{subscription_uuid}")
+      assert_includes results, host1
+
+      # Should NOT find by old insights_facet UUID in IoP mode
+      results = Host::Managed.search_for("insights_uuid = #{insights_uuid}")
+      assert_not_includes results, host1
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Cherry-pick of #1173 to `foreman_3_18`
- Fixes remediation failing for hosts re-registered to Insights after enabling IoP
- The scoped search was using subscription facet UUIDs instead of insights facet UUIDs

## References
- Original PR: #1173
- Jira: SAT-43307