### PR TITLE
Pass through cloud error responses as-is

### DIFF
--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -32,14 +32,10 @@ module InsightsCloud::Api
       rescue RestClient::ExceptionWithResponse => e
         response_obj = e.response.presence || e.exception
         code = response_obj.try(:code) || response_obj.try(:http_code) || 500
-        message = 'Cloud request failed'
+        upstream_content_type = response_obj.try(:headers)&.[](:content_type)
+        content_type = upstream_content_type&.match?(/json/) ? upstream_content_type : 'application/json'
 
-        return render json: {
-          :message => message,
-          :error => response_obj.to_s,
-          :headers => {},
-          :response => response_obj,
-        }, status: code
+        return render body: response_obj.to_s, status: code, content_type: content_type
       rescue StandardError => e
         # Catch any other exceptions here, such as Errno::ECONNREFUSED
         logger.warn("Cloud request failed with exception: #{e}")

--- a/app/controllers/insights_cloud/ui_requests_controller.rb
+++ b/app/controllers/insights_cloud/ui_requests_controller.rb
@@ -36,14 +36,10 @@ module InsightsCloud
       rescue RestClient::ExceptionWithResponse => e
         response_obj = e.response.presence || e.exception
         code = response_obj.try(:code) || response_obj.try(:http_code) || 500
-        message = 'Cloud request failed'
+        upstream_content_type = response_obj.try(:headers)&.[](:content_type)
+        content_type = upstream_content_type&.match?(/json/) ? upstream_content_type : 'application/json'
 
-        return render json: {
-          :message => message,
-          :error => response_obj.to_s,
-          :headers => {},
-          :response => response_obj,
-        }, status: code
+        return render body: response_obj.to_s, status: code, content_type: content_type
       rescue StandardError => e
         # Catch any other exceptions here, such as Errno::ECONNREFUSED
         logger.warn("Cloud request failed with exception: #{e}")

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -154,8 +154,22 @@ module InsightsCloud::Api
 
         get :forward_request, params: { "path" => "platform/module-update-router/v1/channel" }
         assert_equal 500, @response.status
-        assert_equal 'Cloud request failed', JSON.parse(@response.body)['message']
-        assert_match /#{@body}/, JSON.parse(@response.body)['response']
+        assert_equal @body, @response.body
+      end
+
+      test "should forward JSON error responses without double-escaping" do
+        json_error = { errors: [{ detail: 'inventory_id must exist', status: '404' }] }.to_json
+        net_http_resp = Net::HTTPResponse.new(1.0, 404, "Not Found")
+        net_http_resp['content-type'] = 'application/json'
+        res = RestClient::Response.create(json_error, net_http_resp, @http_req)
+        ::ForemanRhCloud::CloudRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::NotFound.new(res))
+
+        get :forward_request, params: { "path" => "api/vulnerability/v1/systems/00000000-0000-0000-0000-000000000000" }
+        assert_equal 404, @response.status
+        assert_includes @response.content_type, 'application/json'
+        assert_equal json_error, @response.body
+        parsed = JSON.parse(@response.body)
+        assert_equal 'inventory_id must exist', parsed['errors'][0]['detail']
       end
 
       test "should create insights facet" do

--- a/test/controllers/insights_cloud/ui_requests_controller_test.rb
+++ b/test/controllers/insights_cloud/ui_requests_controller_test.rb
@@ -177,8 +177,22 @@ module InsightsCloud
 
         get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
         assert_equal 500, @response.status
-        assert_equal 'Cloud request failed', JSON.parse(@response.body)['message']
-        assert_match(/#{@body}/, JSON.parse(@response.body)['response'])
+        assert_equal @body, @response.body
+      end
+
+      test "should forward JSON error responses without double-escaping" do
+        json_error = { errors: [{ detail: 'inventory_id must exist', status: '404' }] }.to_json
+        net_http_resp = Net::HTTPResponse.new(1.0, 404, "Not Found")
+        net_http_resp['content-type'] = 'application/json'
+        res = RestClient::Response.create(json_error, net_http_resp, @http_req)
+        ::ForemanRhCloud::InsightsApiForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::NotFound.new(res))
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/systems/00000000-0000-0000-0000-000000000000" }, session: set_session
+        assert_equal 404, @response.status
+        assert_includes @response.content_type, 'application/json'
+        assert_equal json_error, @response.body
+        parsed = JSON.parse(@response.body)
+        assert_equal 'inventory_id must exist', parsed['errors'][0]['detail']
       end
 
       test "should allow forward_request with nil location (Any location)" do


### PR DESCRIPTION
The cloud request forwarder was re-formatting error responses (non-200 HTTP responses) by wrapping them in a custom JSON structure with message, error, headers, and response fields. This caused double-escaping when the upstream service returned JSON errors, making it difficult for the frontend to properly parse and display error messages.

Changed both MachineTelemetriesController and UIRequestsController to pass through error response bodies directly with their original status code and content-type, matching the behavior of successful responses.

#### What are the changes introduced in this pull request?
The cloud request forwarder was re-formatting error responses (non-200 HTTP responses) by wrapping them in a custom JSON structure:
```
{
  "message": "Cloud request failed",
  "error": "{\"errors\": [...]}",
  "headers": {},
  "response": "{\"errors\": [...]}"
}
```
This caused double-escaping when the upstream service returned JSON errors, making it difficult for the frontend to properly parse and display error messages.

This PR changes both MachineTelemetriesController and UIRequestsController to pass through error response bodies directly with their original status code and content-type, matching the behavior of successful responses.

#### Considerations taken when implementing this change?

- Backward compatibility: This is a breaking change for any code that expects the wrapped error format. However, the wrapped format was problematic and inconsistent with successful responses, so this change aligns error handling with the existing success path.
- Special error cases preserved: The specific handlers for RestClient::Unauthorized (401) and RestClient::NotModified (304) are preserved with their custom messages, as these provide meaningful context (e.g., "Authentication to the Insights Service failed") rather than exposing internal authentication details.
- Content-type preservation: The fix extracts and forwards the original Content-Type header from the error response, defaulting to application/json if not present.
- Both controllers updated: The same forwarding logic exists in both MachineTelemetriesController (for insights-client requests) and UIRequestsController (for UI requests), so both were updated consistently.

#### What are the testing steps for this pull request?
Manual testing via UI:

1. Log into Foreman and select a specific organization
2. Navigate to a URL that triggers a cloud error, e.g.: `https://<foreman-host>/insights_cloud/api/vulnerability/v1/systems/00000000-0000-0000-0000-000000000000`
3. Verify the response is the raw cloud error (not wrapped in a message/error/response structure)
4. Verify the response format:
**Before**: `{"message":"Cloud request failed","error":"{\"errors\":[...]}","headers":{},"response":"{\"errors\":[...]}"}`
<img width="1715" height="239" alt="image" src="https://github.com/user-attachments/assets/55648a94-7dfa-4644-a972-8d74762c950c" />

**After**: `{"errors":[{"detail":"inventory_id must exist...","status":"404"}]}`
<img width="863" height="221" alt="Screenshot From 2026-04-13 15-23-15" src="https://github.com/user-attachments/assets/fab1efa9-9293-47ed-b49f-2ff5d303a922" />
