### PR TITLE
Use POST for remediations playbook endpoint instead of GET

### DIFF
--- a/app/services/foreman_rh_cloud/url_remediations_retriever.rb
+++ b/app/services/foreman_rh_cloud/url_remediations_retriever.rb
@@ -1,11 +1,23 @@
 module ForemanRhCloud
   class URLRemediationsRetriever < RemediationsRetriever
-    attr_reader :url, :payload, :headers
+    attr_reader :url, :headers
 
     def initialize(url:, organization_id:, payload: '', headers: {}, logger: Logger.new(IO::NULL))
       super(logger: logger)
 
-      @url = url
+      parsed_url = URI.parse(url)
+      query_params = parsed_url.query ? CGI.parse(parsed_url.query) : {}
+      hosts_param = query_params.delete('hosts')
+
+      if hosts_param.present?
+        @host_uuids = hosts_param.flat_map { |v| v.split(',') }
+        parsed_url.query = query_params.any? ? URI.encode_www_form(query_params) : nil
+        @url = parsed_url.to_s
+      else
+        @host_uuids = nil
+        @url = url
+      end
+
       @payload = payload
       @headers = headers
       @organization_id = organization_id
@@ -14,7 +26,7 @@ module ForemanRhCloud
     private
 
     def query_playbook
-      logger.debug("Querying playbook at: #{url} with payload: #{payload} and headers: #{headers}")
+      logger.debug("Querying playbook via #{method.to_s.upcase} at: #{url} with payload: #{payload} and headers: #{headers}")
 
       super
     end
@@ -28,11 +40,12 @@ module ForemanRhCloud
     end
 
     def payload
-      @payload.present? ? @payload.to_json : @payload # don't run .to_json if @payload is ''
+      return @host_uuids.to_json if @host_uuids.present?
+      @payload.present? ? @payload.to_json : @payload
     end
 
     def method
-      :get
+      @host_uuids.present? ? :post : :get
     end
 
     def organization

--- a/app/services/foreman_rh_cloud/url_remediations_retriever.rb
+++ b/app/services/foreman_rh_cloud/url_remediations_retriever.rb
@@ -10,7 +10,8 @@ module ForemanRhCloud
       hosts_param = query_params.delete('hosts')
 
       if hosts_param.present?
-        @host_uuids = hosts_param.flat_map { |v| v.split(',') }
+        @host_uuids = hosts_param.flat_map { |v| v.split(',') }.map(&:strip).reject(&:blank?)
+        @host_uuids = nil if @host_uuids.empty?
         parsed_url.query = query_params.any? ? URI.encode_www_form(query_params) : nil
         @url = parsed_url.to_s
       else

--- a/test/unit/services/foreman_rh_cloud/url_remediations_retriever_test.rb
+++ b/test/unit/services/foreman_rh_cloud/url_remediations_retriever_test.rb
@@ -1,8 +1,8 @@
 require 'test_plugin_helper'
 
 class URLRemediationsRetrieverTest < ActiveSupport::TestCase
-  test 'Calls the given url' do
-    retreiver = ForemanRhCloud::URLRemediationsRetriever.new(
+  test 'Calls the given url with GET when no hosts in URL' do
+    retriever = ForemanRhCloud::URLRemediationsRetriever.new(
       organization_id: FactoryBot.create(:organization).id,
       url: 'http://test.example.com',
       payload: 'TEST_PAYLOAD',
@@ -11,19 +11,60 @@ class URLRemediationsRetrieverTest < ActiveSupport::TestCase
       }
     )
 
-    retreiver.stubs(:cert_auth_available?).returns(true)
+    retriever.stubs(:cert_auth_available?).returns(true)
 
     response = mock('response')
     response.stubs(:body).returns('TEST_RESPONSE')
-    retreiver.expects(:execute_cloud_request).with do |params|
+    retriever.expects(:execute_cloud_request).with do |params|
       params[:method] == :get &&
       params[:url] == 'http://test.example.com' &&
       params[:headers][:custom1] == 'TEST_HEADER' &&
       params[:payload] == "\"TEST_PAYLOAD\""
     end.returns(response)
 
-    actual = retreiver.create_playbook
+    actual = retriever.create_playbook
 
     assert_equal 'TEST_RESPONSE', actual
+  end
+
+  test 'Uses POST with hosts in body when URL contains hosts query param' do
+    retriever = ForemanRhCloud::URLRemediationsRetriever.new(
+      organization_id: FactoryBot.create(:organization).id,
+      url: 'http://test.example.com/api/remediations/1234/playbook?hosts=uuid-1,uuid-2,uuid-3'
+    )
+
+    retriever.stubs(:cert_auth_available?).returns(true)
+
+    response = mock('response')
+    response.stubs(:body).returns('TEST_PLAYBOOK')
+    retriever.expects(:execute_cloud_request).with do |params|
+      params[:method] == :post &&
+      params[:url] == 'http://test.example.com/api/remediations/1234/playbook' &&
+      JSON.parse(params[:payload]) == ['uuid-1', 'uuid-2', 'uuid-3']
+    end.returns(response)
+
+    actual = retriever.create_playbook
+
+    assert_equal 'TEST_PLAYBOOK', actual
+  end
+
+  test 'Preserves other query params when extracting hosts' do
+    retriever = ForemanRhCloud::URLRemediationsRetriever.new(
+      organization_id: FactoryBot.create(:organization).id,
+      url: 'http://test.example.com/api/remediations/1234/playbook?hosts=uuid-1,uuid-2&localhost=false'
+    )
+
+    retriever.stubs(:cert_auth_available?).returns(true)
+
+    response = mock('response')
+    response.stubs(:body).returns('TEST_PLAYBOOK')
+    retriever.expects(:execute_cloud_request).with do |params|
+      params[:method] == :post &&
+      params[:url].include?('localhost=false') &&
+      !params[:url].include?('hosts=') &&
+      JSON.parse(params[:payload]) == ['uuid-1', 'uuid-2']
+    end.returns(response)
+
+    retriever.create_playbook
   end
 end

--- a/test/unit/services/foreman_rh_cloud/url_remediations_retriever_test.rb
+++ b/test/unit/services/foreman_rh_cloud/url_remediations_retriever_test.rb
@@ -67,4 +67,40 @@ class URLRemediationsRetrieverTest < ActiveSupport::TestCase
 
     retriever.create_playbook
   end
+
+  test 'Merges multiple hosts query params into a single array' do
+    retriever = ForemanRhCloud::URLRemediationsRetriever.new(
+      organization_id: FactoryBot.create(:organization).id,
+      url: 'http://test.example.com/api/remediations/1234/playbook?hosts=uuid-1&hosts=uuid-2'
+    )
+
+    retriever.stubs(:cert_auth_available?).returns(true)
+
+    response = mock('response')
+    response.stubs(:body).returns('TEST_PLAYBOOK')
+    retriever.expects(:execute_cloud_request).with do |params|
+      params[:method] == :post &&
+      params[:url] == 'http://test.example.com/api/remediations/1234/playbook' &&
+      JSON.parse(params[:payload]) == ['uuid-1', 'uuid-2']
+    end.returns(response)
+
+    retriever.create_playbook
+  end
+
+  test 'Falls back to GET when hosts query param is empty' do
+    retriever = ForemanRhCloud::URLRemediationsRetriever.new(
+      organization_id: FactoryBot.create(:organization).id,
+      url: 'http://test.example.com/api/remediations/1234/playbook?hosts='
+    )
+
+    retriever.stubs(:cert_auth_available?).returns(true)
+
+    response = mock('response')
+    response.stubs(:body).returns('TEST_PLAYBOOK')
+    retriever.expects(:execute_cloud_request).with do |params|
+      params[:method] == :get
+    end.returns(response)
+
+    retriever.create_playbook
+  end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* When the remediations playbook URL contains host UUIDs as query parameters (GET /remediations/:id/playbook?hosts=uuid1,uuid2,...), the URLRemediationsRetriever now extracts the hosts from the URL and sends them as a JSON array in the body of a POST request instead. This prevents HTTP 400 errors caused by URL length limits when many hosts (e.g. 321+) are included. URLs without a hosts query parameter continue to use GET with the original behavior unchanged.

#### Considerations taken when implementing this change?

- Backward compatibility: Only switches to POST when hosts are present in the URL. URLs without hosts still use GET, so existing callers (e.g. download_rh_playbook without host params) are unaffected.
- Other query parameters: Any non-hosts query parameters on the URL are preserved when stripping hosts.
- Minimal scope: The change is contained to URLRemediationsRetriever — no changes needed to the job template, controller, or cloud connector flow.

#### What are the testing steps for this pull request?
* Setup a non iop devel box or production install
* Import a manifest and sync some repos
* Register a host and configure some vulnerabilities
* Configure `cloud connector`
* Login to `console.redhat.com` and try to remediate a recommendation and watch the playbook connect to your Foreman server and run then send back up a request as a `POST` instead of `GET`

Screenshot of rh_cloud recommendations before:
<img width="1376" height="348" alt="Screenshot_20-4-2026_143140_ip-10-0-167-106 rhos-01 prod psi rdu2 redhat com" src="https://github.com/user-attachments/assets/9e2e92d3-dcc6-48b8-acba-4d4c3cf5e60e" />

Screenshot of rh_cloud recommendations after:
<img width="1409" height="393" alt="Screenshot_20-4-2026_143156_ip-10-0-167-106 rhos-01 prod psi rdu2 redhat com" src="https://github.com/user-attachments/assets/d9ea9877-0c89-44fd-b352-a08b01efecb9" />

Screenshot of job:
<img width="1380" height="221" alt="Screenshot_20-4-2026_143128_ip-10-0-167-106 rhos-01 prod psi rdu2 redhat com" src="https://github.com/user-attachments/assets/c575774d-7215-4d6f-b3e7-a418c0efa1d7" />

Screenshots of success on console.redhat.com and playbook run
<img width="1099" height="771" alt="Screenshot_20-4-2026_143216_console redhat com" src="https://github.com/user-attachments/assets/31372afe-df46-4298-b08c-928bdfac7281" />
<img width="1348" height="594" alt="Screenshot_20-4-2026_14314_console redhat com" src="https://github.com/user-attachments/assets/119ede3c-a673-4173-bad3-011067f9b1bf" />

#### Output of `POST` request:

```ruby
22:45:18 rails.1   | 2026-04-20T22:45:18 [D|tem|aaae8aac] Querying playbook via POST at: https://cert.cloud.redhat.com/api/remediations/v1/remediations/71feeb38-1a82-4132-9b36-ad8379556772/playbook with payload: ["61b8abb6-dcc6-43f8-b52a-990464c87341"] and headers: {:content_type=>:json}
22:45:18 rails.1   | 2026-04-20T22:45:18 [D|tem|aaae8aac] Response headers for request url https://cert.cloud.redhat.com/api/remediations/v1/remediations/71feeb38-1a82-4132-9b36-ad8379556772/playbook are: {:server=>"openresty", :content_type=>"text/vnd.yaml; charset=utf-8", :content_length=>"4853", :x_rh_insights_request_id=>"0c27275796b44a3db507d9e1ad7e4d07", :x_powered_by=>"Express", :etag=>"W/\"1284-TQie8Wa9G1TPQMaPKYkYs/ZXGWI\"", :content_disposition=>"attachment;filename=\"test4-1776739525501.yml\"", :x_content_type_options=>"nosniff", :date=>"Tue, 21 Apr 2026 02:45:25 GMT", :connection=>"keep-alive", :set_cookie=>["3ba1432eca9ab72ebcff858daecadbf5=de6d939ec411a941178f66fe946f4d8e; path=/; HttpOnly; Secure; SameSite=None"], :x_rh_edge_request_id=>"a1d6419f", :x_rh_edge_reference_id=>"0.9b6bdc17.1776739525.a1d6419f", :x_rh_edge_cache_status=>"NotCacheable from child", :x_frame_options=>"SAMEORIGIN", :strict_transport_security=>"max-age=31536000; includeSubDomains"}
22:45:18 rails.1   | 2026-04-20T22:45:18 [D|tem|aaae8aac] Got playbook response: ---
22:45:18 rails.1   |  aaae8aac | # Red Hat Insights has recommended one or more actions for you, a system administrator, to review and if you
22:45:18 rails.1   |  aaae8aac | # deem appropriate, deploy on your systems running Red Hat software. Based on the analysis, we have automatically
22:45:18 rails.1   |  aaae8aac | # generated an Ansible Playbook for you. Please review and test the recommended actions and the Playbook as
22:45:18 rails.1   |  aaae8aac | # they may contain configuration changes, updates, reboots and/or other changes to your systems. Red Hat is not
22:45:18 rails.1   |  aaae8aac | # responsible for any adverse outcomes related to these recommendations or Playbooks.
```