### PR TITLE
SAT-44713 - Move dev dependencies to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'rdoc'
+gem 'theforeman-rubocop', '~> 0.1.2', require: false, groups: [:development, :rubocop]

--- a/foreman_rh_cloud.gemspec
+++ b/foreman_rh_cloud.gemspec
@@ -23,7 +23,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'foreman_ansible', '>= 15.0.0'
   s.add_dependency 'foreman-tasks', '>= 10.0.0'
   s.add_runtime_dependency 'katello', '>= 4.18'
-
-  s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Move theforeman-rubocop and rdoc dependencies to Gemfile instead of specifying them in gemspec.

#### Considerations taken when implementing this change?

With newer bundler and the way we setup the Foreman with plugins, there are resolution failures due to duplicated dependencies.

#### What are the testing steps for this pull request?

Run bundle install with any other plugin that has the same dependency with a different version.

Before: fails to resolve (or there are warning on older bundler version)
After: passes without any issue, rubocop still works locally and in CI