### PR TITLE
SAT-25889 - Handle missing Foreman base host records gracefully

### DIFF
--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -96,7 +96,14 @@ module ForemanInventoryUpload
   end
 
   def self.inventory_self_url
-    inventory_base_url + "?hostname_or_id=#{ForemanRhCloud.foreman_host.fqdn}"
+    host = ForemanRhCloud.foreman_host
+    hostname = host ? host.fqdn : ForemanRhCloud.foreman_host_name
+    if hostname.nil?
+      Rails.logger.warn("Cannot determine Foreman hostname for inventory sync. " \
+                        "Please configure Setting[:foreman_url]. " \
+                        "Containerized setups must explicitly set this.")
+    end
+    inventory_base_url + "?hostname_or_id=#{hostname}"
   end
 
   def self.host_by_id_url(host_uuid)

--- a/lib/foreman_inventory_upload/generators/fact_helpers.rb
+++ b/lib/foreman_inventory_upload/generators/fact_helpers.rb
@@ -106,6 +106,7 @@ module ForemanInventoryUpload
 
       def host_ips(host)
         # Determines and returns the IP addresses associated with a host, applying obfuscation if enabled.
+        return {} if host.nil?
 
         # If IP obfuscation is enabled for the host return a representation of obfuscated IP addresses.
         return obfuscated_ips(host) if obfuscate_ips?(host)
@@ -155,10 +156,29 @@ module ForemanInventoryUpload
 
       def hostname_match
         bash_hostname = `uname -n`.chomp
-        foreman_hostname = ForemanRhCloud.foreman_host&.name
-        if bash_hostname == foreman_hostname
-          fqdn(ForemanRhCloud.foreman_host)
-        elsif Setting[:obfuscate_inventory_hostnames]
+        foreman_host = ForemanRhCloud.foreman_host
+
+        # If bash hostname matches foreman_host, use fqdn
+        if foreman_host && bash_hostname == foreman_host.name
+          return fqdn(foreman_host)
+        end
+
+        # If no foreman_host, try foreman_host_name from Setting[:foreman_url]
+        unless foreman_host
+          foreman_hostname_from_setting = ForemanRhCloud.foreman_host_name
+          if foreman_hostname_from_setting
+            # Apply obfuscation if enabled
+            return obfuscate_fqdn(foreman_hostname_from_setting) if Setting[:obfuscate_inventory_hostnames]
+
+            return foreman_hostname_from_setting
+          end
+          # Otherwise fall through to bash_hostname below
+          # NOTE: Containerized foremanctl setups must configure Setting[:foreman_url]
+          # as bash hostname may not be available or meaningful in containers
+        end
+
+        # Fallback to bash hostname (with obfuscation if enabled)
+        if Setting[:obfuscate_inventory_hostnames]
           obfuscate_fqdn(bash_hostname)
         else
           bash_hostname
@@ -166,6 +186,8 @@ module ForemanInventoryUpload
       end
 
       def bios_uuid(host)
+        return nil if host.nil?
+
         value = fact_value(host, 'dmi::system::uuid') || ''
         uuid_value(value)
       end

--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -84,23 +84,50 @@ module ForemanRhCloud
 
   # For testing purposes we can override the default hostname with an environment variable SATELLITE_RH_CLOUD_FOREMAN_HOST
   def self.foreman_host
-    @foreman_host ||= begin
-      fullname = foreman_host_name
-      ::Host.unscoped.friendly.find(fullname)
-    rescue ActiveRecord::RecordNotFound
-      # fullname didn't work. Let's try shortname
+    return @foreman_host if defined?(@foreman_host)
+
+    fullname = foreman_host_name
+    return @foreman_host = nil unless fullname
+
+    # Try fullname first
+    host = ::Host.unscoped.friendly.where(name: fullname).first
+
+    # If not found, try shortname
+    if host.nil?
       shortname = /(?<shortname>[^\.]*)\.?.*/.match(fullname)[:shortname]
-      ::Host.unscoped.friendly.find(shortname)
+      host = ::Host.unscoped.friendly.where(name: shortname).first
     end
+
+    @foreman_host = host
   end
 
   def self.foreman_host_name
-    ENV['SATELLITE_RH_CLOUD_FOREMAN_HOST'] || marked_foreman_host&.name || ::SmartProxy.default_capsule.name
+    ENV['SATELLITE_RH_CLOUD_FOREMAN_HOST'] || marked_foreman_host&.name || foreman_url_hostname
+  end
+
+  def self.foreman_url_hostname
+    return nil unless Setting[:foreman_url]
+
+    begin
+      # Ensure setting is a string to avoid TypeError from URI.parse
+      url = Setting[:foreman_url].to_s
+      URI.parse(url).host
+    rescue URI::InvalidURIError, ArgumentError, TypeError => e
+      Rails.logger.warn("Invalid foreman_url setting: #{e.message}")
+      nil
+    end
   end
 
   def self.marked_foreman_host
-    ::Host.unscoped.search_for('infrastructure_facet.foreman = true').first
-  rescue ScopedSearch::QueryNotSupported
+    # Find host with infrastructure_facet.foreman_instance = true
+    # Facets use a special mechanism in Foreman, so we query the facet table directly
+    return nil unless defined?(HostFacets::InfrastructureFacet)
+
+    facet = HostFacets::InfrastructureFacet.find_by(foreman_instance: true)
+    facet&.host
+  rescue ActiveRecord::StatementInvalid => e
+    # Table might not exist yet during migrations
+    Rails.logger.debug("Could not query marked foreman host: #{e.message}")
     nil
   end
 

--- a/lib/insights_cloud/async/insights_generate_notifications.rb
+++ b/lib/insights_cloud/async/insights_generate_notifications.rb
@@ -13,7 +13,16 @@ module InsightsCloud
       end
 
       def add_satellite_notifications
-        hits_count = InsightsHit.where(host_id: foreman_host.id).count
+        host = foreman_host
+
+        # Skip if no Foreman host record exists
+        unless host
+          logger.debug("Skipping Insights notifications: no Foreman host record found")
+          blueprint&.notifications&.destroy_all
+          return
+        end
+
+        hits_count = InsightsHit.where(host_id: host.id).count
 
         # Remove stale notifications
         blueprint.notifications.destroy_all

--- a/lib/inventory_sync/async/inventory_self_host_sync.rb
+++ b/lib/inventory_sync/async/inventory_self_host_sync.rb
@@ -4,7 +4,14 @@ module InventorySync
       set_callback :step, :around, :create_facets
 
       def plan
-        super(ForemanRhCloud.foreman_host.organization)
+        host = ForemanRhCloud.foreman_host
+
+        if host.nil?
+          logger.warn("Skipping self-host inventory sync: no Foreman host record found.")
+          return
+        end
+
+        super(host.organization)
       end
 
       def create_facets
@@ -22,7 +29,10 @@ module InventorySync
       private
 
       def add_missing_insights_facet(uuids_hash)
-        facet = InsightsFacet.find_or_create_by(host_id: ForemanRhCloud.foreman_host.id) do |facet|
+        host = ForemanRhCloud.foreman_host
+        return unless host # Guard against nil
+
+        facet = InsightsFacet.find_or_create_by(host_id: host.id) do |facet|
           facet.uuid = uuids_hash.values.first
         end
 

--- a/test/jobs/insights_generate_notifications_test.rb
+++ b/test/jobs/insights_generate_notifications_test.rb
@@ -1,0 +1,26 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class InsightsGenerateNotificationsTest < ActiveSupport::TestCase
+  include Dynflow::Testing::Factories
+
+  setup do
+    User.current = User.find_by(login: 'secret_admin')
+  end
+
+  test 'skips notifications when foreman_host is nil' do
+    ForemanRhCloud.stubs(:foreman_host).returns(nil)
+
+    # Ensure blueprint exists or create it
+    NotificationBlueprint.find_or_create_by(name: 'insights_satellite_hits') do |bp|
+      bp.message = 'Test message'
+      bp.level = 'info'
+      bp.expires_in = 7.days
+    end
+
+    plan = ForemanTasks.sync_task(InsightsCloud::Async::InsightsGenerateNotifications)
+
+    # Should not raise an error, task completes successfully
+    assert_includes ['success', 'stopped'], plan.state, "Task should complete without error"
+  end
+end

--- a/test/jobs/inventory_self_host_sync_test.rb
+++ b/test/jobs/inventory_self_host_sync_test.rb
@@ -106,4 +106,13 @@ class InventorySelfHostSyncTest < ActiveSupport::TestCase
 
     assert_equal @host1_inventory_id, @host1.insights.uuid
   end
+
+  test 'skips sync when foreman_host is nil' do
+    ForemanRhCloud.stubs(:foreman_host).returns(nil)
+
+    plan = ForemanTasks.sync_task(InventorySync::Async::InventorySelfHostSync)
+
+    # Task should be stopped (not executed) when host is nil, not failed
+    assert_equal 'stopped', plan.state
+  end
 end

--- a/test/unit/foreman_rh_cloud_self_host_test.rb
+++ b/test/unit/foreman_rh_cloud_self_host_test.rb
@@ -4,6 +4,7 @@ class ForemanRhCloudSelfHostTest < ActiveSupport::TestCase
   setup do
     # reset cached value - must remove the variable entirely, not just set to nil
     ForemanRhCloud.remove_instance_variable(:@foreman_host) if ForemanRhCloud.instance_variable_defined?(:@foreman_host)
+    ENV.delete('SATELLITE_RH_CLOUD_FOREMAN_HOST')
   end
 
   test 'finds host by fullname' do
@@ -27,7 +28,6 @@ class ForemanRhCloudSelfHostTest < ActiveSupport::TestCase
   end
 
   test 'finds host by infrastructure facet' do
-    ENV.delete('SATELLITE_RH_CLOUD_FOREMAN_HOST')
     @host = FactoryBot.create(:host, :managed, :with_infrastructure_facet)
     actual = ForemanRhCloud.foreman_host
 
@@ -52,9 +52,7 @@ class ForemanRhCloudSelfHostTest < ActiveSupport::TestCase
   test 'caches nil value to avoid repeated lookups' do
     ForemanRhCloud.expects(:foreman_host_name).once.returns('nonexistent.example.com')
 
-    # Call twice, should only query once
-    ForemanRhCloud.foreman_host
-    ForemanRhCloud.foreman_host
+    2.times { ForemanRhCloud.foreman_host }
   end
 
   test 'extracts hostname from foreman_url setting' do
@@ -74,9 +72,7 @@ class ForemanRhCloudSelfHostTest < ActiveSupport::TestCase
     assert_nil actual
   end
 
-  test 'foreman_host_name uses foreman_url when SmartProxy not available' do
-    # Clear ENV variable that might interfere
-    ENV.delete('SATELLITE_RH_CLOUD_FOREMAN_HOST')
+  test 'foreman_host_name uses foreman_url when marked_foreman_host is nil' do
     ForemanRhCloud.expects(:marked_foreman_host).returns(nil)
     ForemanRhCloud.expects(:foreman_url_hostname).returns('satellite.example.com')
 

--- a/test/unit/foreman_rh_cloud_self_host_test.rb
+++ b/test/unit/foreman_rh_cloud_self_host_test.rb
@@ -2,8 +2,8 @@ require 'test_plugin_helper'
 
 class ForemanRhCloudSelfHostTest < ActiveSupport::TestCase
   setup do
-    # reset cached value
-    ForemanRhCloud.instance_variable_set(:@foreman_host, nil)
+    # reset cached value - must remove the variable entirely, not just set to nil
+    ForemanRhCloud.remove_instance_variable(:@foreman_host) if ForemanRhCloud.instance_variable_defined?(:@foreman_host)
   end
 
   test 'finds host by fullname' do
@@ -27,9 +27,61 @@ class ForemanRhCloudSelfHostTest < ActiveSupport::TestCase
   end
 
   test 'finds host by infrastructure facet' do
+    ENV.delete('SATELLITE_RH_CLOUD_FOREMAN_HOST')
     @host = FactoryBot.create(:host, :managed, :with_infrastructure_facet)
     actual = ForemanRhCloud.foreman_host
 
     assert_equal @host, actual
+  end
+
+  test 'returns nil when host does not exist' do
+    ForemanRhCloud.expects(:foreman_host_name).returns('nonexistent.example.com')
+
+    actual = ForemanRhCloud.foreman_host
+
+    assert_nil actual
+  end
+
+  test 'returns nil and does not query Host when foreman_host_name is nil' do
+    ForemanRhCloud.stubs(:foreman_host_name).returns(nil)
+    ::Host.unscoped.friendly.expects(:where).never
+
+    assert_nil ForemanRhCloud.foreman_host
+  end
+
+  test 'caches nil value to avoid repeated lookups' do
+    ForemanRhCloud.expects(:foreman_host_name).once.returns('nonexistent.example.com')
+
+    # Call twice, should only query once
+    ForemanRhCloud.foreman_host
+    ForemanRhCloud.foreman_host
+  end
+
+  test 'extracts hostname from foreman_url setting' do
+    Setting[:foreman_url] = 'https://satellite.example.com'
+
+    actual = ForemanRhCloud.foreman_url_hostname
+
+    assert_equal 'satellite.example.com', actual
+  end
+
+  test 'handles invalid foreman_url gracefully' do
+    # Stub Setting to return invalid URL without validation
+    Setting.stubs(:[]).with(:foreman_url).returns('not a valid url')
+
+    actual = ForemanRhCloud.foreman_url_hostname
+
+    assert_nil actual
+  end
+
+  test 'foreman_host_name uses foreman_url when SmartProxy not available' do
+    # Clear ENV variable that might interfere
+    ENV.delete('SATELLITE_RH_CLOUD_FOREMAN_HOST')
+    ForemanRhCloud.expects(:marked_foreman_host).returns(nil)
+    ForemanRhCloud.expects(:foreman_url_hostname).returns('satellite.example.com')
+
+    actual = ForemanRhCloud.foreman_host_name
+
+    assert_equal 'satellite.example.com', actual
   end
 end

--- a/test/unit/metadata_generator_test.rb
+++ b/test/unit/metadata_generator_test.rb
@@ -2,7 +2,8 @@ require 'test_plugin_helper'
 
 class MetadataGeneratorTest < ActiveSupport::TestCase
   setup do
-    ForemanRhCloud.instance_variable_set(:@foreman_host, nil)
+    # reset cached value - must remove the variable entirely, not just set to nil
+    ForemanRhCloud.remove_instance_variable(:@foreman_host) if ForemanRhCloud.instance_variable_defined?(:@foreman_host)
   end
 
   test 'generates an empty report' do
@@ -63,5 +64,27 @@ class MetadataGeneratorTest < ActiveSupport::TestCase
     assert_equal 2, slice['number_hosts']
     assert_not_nil(slice = slices['test_12345'])
     assert_equal 3, slice['number_hosts']
+  end
+
+  test 'generates metadata when foreman_host is nil' do
+    ForemanRhCloud.stubs(:foreman_host).returns(nil)
+    ForemanRhCloud.stubs(:foreman_host_name).returns('satellite.example.com')
+
+    generator = ForemanInventoryUpload::Generators::Metadata.new
+
+    # Should not raise an error
+    json_str = nil
+    assert_nothing_raised do
+      json_str = generator.render do
+      end
+    end
+
+    # Verify hostname is from foreman_host_name
+    actual = JSON.parse(json_str.join("\n"))
+    assert_equal 'satellite.example.com', actual['reporting_host_name']
+    # Verify IP and BIOS UUID fields are nil when host is nil
+    # This is acceptable per SAT-25889 - cloud services don't rely on these fields
+    assert_nil actual['reporting_host_ips']
+    assert_nil actual['reporting_host_bios_uuid']
   end
 end


### PR DESCRIPTION
## Summary
- Handle cases where the Foreman/Satellite host itself doesn't have a host record in the database
- Add fallback to extract hostname from `Setting[:foreman_url]` when host record is missing
- Add nil guards throughout codebase to prevent crashes when foreman_host is nil
- Skip sync tasks gracefully when foreman_host is unavailable

## Changes
- Modified `ForemanRhCloud.foreman_host` to return nil instead of raising when host not found
- Added `ForemanRhCloud.foreman_url_hostname` to extract hostname from foreman_url setting as fallback
- Updated `marked_foreman_host` to use facet lookup instead of scoped search
- Added nil guards in:
  - `ForemanInventoryUpload::Generators::FactHelpers` (bios_uuid, host_ips, hostname_match)
  - `InsightsCloud::Async::InsightsGenerateNotifications` (skips when host missing)
  - `InventorySync::Async::InventorySelfHostSync` (skips when host missing)
- Added comprehensive tests for nil host scenarios

## Test plan
- [x] All existing tests pass
- [x] New tests verify behavior when foreman_host is nil
- [x] Metadata generation works without host record
- [x] Sync tasks skip gracefully instead of crashing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)