### PR TITLE
SAT-42760 - Hide the Connectivity test option in IoP Mode

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/PageTitle.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/PageTitle.js
@@ -18,9 +18,11 @@ import {
   getInventoryDocsUrl,
 } from '../../ForemanInventoryHelpers';
 import CloudPingModal from './components/CloudPingModal';
+import { useIopConfig } from '../../../common/Hooks/ConfigHooks';
 
 const PageTitle = () => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const isIop = useIopConfig();
   const [showPingModal, setPingModal] = useState(false);
   const togglePingModal = () => setPingModal(v => !v);
   const dropdownItems = [
@@ -42,13 +44,17 @@ const PageTitle = () => {
     >
       {DOCS_BUTTON_TEXT}
     </DropdownItem>,
-    <DropdownItem
-      key="cloud-ping"
-      ouiaId="dropdownItem-cloud-ping"
-      onClick={togglePingModal}
-    >
-      {CLOUD_PING_TITLE}
-    </DropdownItem>,
+    ...(!isIop
+      ? [
+          <DropdownItem
+            key="cloud-ping"
+            ouiaId="dropdownItem-cloud-ping"
+            onClick={togglePingModal}
+          >
+            {CLOUD_PING_TITLE}
+          </DropdownItem>,
+        ]
+      : []),
   ];
   return (
     <Grid className="inventory-upload-header-title">

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/__tests__/PageTitle.test.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/__tests__/PageTitle.test.js
@@ -1,12 +1,29 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import PageTitle from '../PageTitle';
+
+let mockIopMode = false;
+
+jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
+  useForemanContext: () => ({
+    metadata: {
+      foreman_rh_cloud: {
+        iop: mockIopMode,
+      },
+    },
+    UI: {},
+  }),
+}));
 
 jest.mock('../components/CloudPingModal', () => () => (
   <div data-testid="cloud-ping-modal">CloudPingModal</div>
 ));
 
 describe('PageTitle', () => {
+  afterEach(() => {
+    mockIopMode = false;
+  });
+
   it('renders the page title', () => {
     render(<PageTitle />);
     expect(screen.getByText('Red Hat Inventory')).toBeTruthy();
@@ -15,5 +32,20 @@ describe('PageTitle', () => {
   it('renders the kebab dropdown', () => {
     const { container } = render(<PageTitle />);
     expect(container.querySelector('.title-dropdown')).toBeTruthy();
+  });
+
+  it('renders cloud-ping dropdown item when not in IoP mode', () => {
+    mockIopMode = false;
+    render(<PageTitle />);
+    fireEvent.click(screen.getByLabelText('Actions'));
+    expect(screen.getByText('Connectivity test')).toBeTruthy();
+  });
+
+  it('does not render cloud-ping dropdown item when in IoP mode', () => {
+    mockIopMode = true;
+    render(<PageTitle />);
+    fireEvent.click(screen.getByLabelText('Actions'));
+    expect(screen.queryByText('Connectivity test')).toBeNull();
+    mockIopMode = false;
   });
 });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Previously, the `Connectivity test` on the `Inventory Upload` page resulted in an HTTP 400 response when the server was running in IoP mode. Since connectivity to hosted Insights is not relevant in IoP mode, this PR hides the `Connectivity test` option from the dropdown menu if the server is in IoP mode.

#### What are the testing steps for this pull request?
1. Deploy a Foreman server in IoP mode.
2. In the webUI, navigate to Administer > Inventory Upload.
3. Open the dropdown menu on the top right corner of the page. The `Connectivity test` option should not be present.