### PR TITLE
Use ref parameter for katello dependency to support Ruby 3.3

### DIFF
--- a/gemfile.d/katello.rb
+++ b/gemfile.d/katello.rb
@@ -1,1 +1,1 @@
-gem 'katello', github: 'Katello/katello', branch: ENV.fetch('KATELLO_BRANCH', 'master')
+gem 'katello', github: 'Katello/katello', ref: ENV.fetch('KATELLO_REF', 'master')


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
use git ref instead of branch to bundle ruby. This ref should work with both master branch and PR merge refs which Katello CI workflow relies on to trigger rh_cloud tests.
#### Considerations taken when implementing this change?
AI has me convinced that: 
```
Bundler 2.5+ (shipped with Ruby 3.3) validates branch: parameter
  more strictly and rejects non-branch refs like SHAs or PR merge refs.
  The ref: parameter accepts any git reference including branches,
  making it compatible with both normal use and CI environments.
```
#### What are the testing steps for this pull request?
Green CIs here against master branch..And green CI on https://github.com/Katello/katello/pull/11778 after this is merged and the github action there is rerun with https://github.com/Katello/katello/pull/11778/changes#diff-7aa10e7d6cc9e32f26a92b7d4be84100a3247fa948f51cedff811996309b048eL26 .