### PR TITLE
SAT-46475 - fix inventory page padding

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/PageHeader/PageHeader.scss
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/PageHeader.scss
@@ -1,6 +1,6 @@
 .rh-cloud-inventory-page {
   .inventory-upload-header {
-    margin-top: 35px;
+    padding: var(--pf-v5-global--spacer--md) var(--pf-v5-global--spacer--lg) var(--pf-v5-global--spacer--lg) var(--pf-v5-global--spacer--lg);
 
     h1 {
       font-family: 'RedHatDisplay';
@@ -33,7 +33,6 @@
     }
 
     .inventory-upload-header-title {
-      margin-top: -15px;
       margin-bottom: 8px;
     }
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixed CSS padding for Inventory Page

Before:
<img width="1617" height="1019" alt="image" src="https://github.com/user-attachments/assets/5038fd67-58a1-4c35-af7d-3048b85b8929" />
After:
<img width="1639" height="1028" alt="image" src="https://github.com/user-attachments/assets/36bdd817-30bc-4352-942e-3437e50d5d51" />
