### PR TITLE
RHINENG-26829,RHINENG-26830 - Add pathway detail route and Scalprum module routing for IoP Pathways

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
   namespace :foreman_rh_cloud do
     get 'inventory_upload', to: 'foreman_rh_cloud#inventory_upload'
     get 'recommendations', to: 'foreman_rh_cloud#recommendations'
+    get 'recommendations/pathways/:slug', to: 'foreman_rh_cloud#recommendations'
     get 'recommendations/:rule_id', to: 'foreman_rh_cloud#recommendations'
     get 'insights_cloud', to: '/react#index' # Uses foreman's react controller
     get 'insights_vulnerability', to: '/react#index'

--- a/webpack/IopRecommendationDetails/IopRecommendationDetails.js
+++ b/webpack/IopRecommendationDetails/IopRecommendationDetails.js
@@ -8,11 +8,29 @@ import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 
 const scope = 'advisor';
 const module = './RecommendationDetailsWrapped';
+const pathwayModule = './PathwayDetailsWrapped';
 
 const IopRecommendationDetails = props => {
+  const pathwayMatch = useRouteMatch(
+    '/foreman_rh_cloud/recommendations/pathways/:slug'
+  );
   const urlParams = useRouteMatch('/foreman_rh_cloud/recommendations/:rule_id');
   // eslint-disable-next-line camelcase
   const ruleId = urlParams?.params?.rule_id;
+
+  if (pathwayMatch) {
+    return (
+      <div className="iop-pathway-details-scalprum advisor">
+        <ScalprumComponent
+          scope={scope}
+          module={pathwayModule}
+          pathwayId={pathwayMatch.params.slug}
+          {...props}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="iop-recommendation-details-scalprum advisor">
       <ScalprumComponent


### PR DESCRIPTION
## Summary

  Adds foreman_rh_cloud support for Advisor Pathways detail pages in IoP mode.
  This is the Foreman plugin side of the Pathways feature — the advisor frontend
  changes are in a separate PR against insights-advisor-frontend.

  Two changes are needed so that pathway detail URLs resolve and render the
  correct advisor Scalprum module:

  - **Rails route** (`config/routes.rb`): Register
    `recommendations/pathways/:slug` before the existing `recommendations/:rule_id`
    route so the more specific pattern matches first. Without this, pathway URLs
    404 at the Rails level before any frontend code loads.
  - **Scalprum module routing** (`webpack/IopRecommendationDetails/IopRecommendationDetails.js`):
    Add a `useRouteMatch` for the pathway pattern, checked before the existing
    `:rule_id` match. When matched, renders `./PathwayDetailsWrapped` from the
    advisor scope with the `pathwayId` prop. Regular recommendation detail pages
    are unaffected.

  No backend logic changes are needed — the existing `/insights_cloud/` catch-all
  proxy already forwards pathway API requests to the advisor backend.

  ## Test plan

  - [ ] Navigate to `/foreman_rh_cloud/recommendations/pathways/:slug` — loads pathway detail view (requires advisor frontend with Pathways enabled)
  - [ ] Navigate to `/foreman_rh_cloud/recommendations/:rule_id` — still loads recommendation detail view (no regression)
  - [ ] Pathway API requests (`/insights_cloud/api/insights/v1/pathway/`) return data through existing proxy
  - [ ] No JavaScript errors during pathway navigation
  - [ ] Empty pathway list renders gracefully (no spinner or crash)