### PR TITLE
feat(Compliance): onboarding compliance frontend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -51,6 +51,7 @@
           "rhc",
           "rulename",
           "scalprum",
+          "scappolicies",
           "theforeman",
           "tooltip",
           "unmount",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,16 @@ Rails.application.routes.draw do
     get 'insights_cloud', to: '/react#index' # Uses foreman's react controller
     get 'insights_vulnerability', to: '/react#index'
     get 'insights_vulnerability/:cve_id', to: '/react#index'
+    scope 'insights_compliance' do
+      get 'reports', to: '/react#index'
+      get 'reports/:report_id', to: '/react#index'
+      get 'reports/:report_id/delete', to: '/react#index'
+      get 'scappolicies', to: '/react#index'
+      get 'scappolicies/new', to: '/react#index'
+      get 'scappolicies/:policy_id', to: '/react#index'
+      get 'scappolicies/:policy_id/edit', to: '/react#index'
+      get 'scappolicies/:policy_id/delete', to: '/react#index'
+    end
   end
 
   scope :module => :'insights_cloud/api', :path => :redhat_access do

--- a/lib/foreman_rh_cloud/plugin.rb
+++ b/lib/foreman_rh_cloud/plugin.rb
@@ -144,6 +144,20 @@ module ForemanRhCloud
             url_hash: { controller: :react, action: :index },
             parent: :insights_menu,
             if: -> { ForemanRhCloud.with_iop_smart_proxy? }
+          menu :top_menu,
+            :insights_compliance_reports,
+            caption: N_('Compliance Reports'),
+            url: '/foreman_rh_cloud/insights_compliance/reports',
+            url_hash: { controller: :react, action: :index },
+            parent: :insights_menu,
+            if: -> { ForemanRhCloud.with_iop_smart_proxy? }
+          menu :top_menu,
+            :insights_compliance_scappolicies,
+            caption: N_('SCAP Policies'),
+            url: '/foreman_rh_cloud/insights_compliance/scappolicies',
+            url_hash: { controller: :react, action: :index },
+            parent: :insights_menu,
+            if: -> { ForemanRhCloud.with_iop_smart_proxy? }
         end
 
         # In IoP case we want the page to be in the admin menu

--- a/webpack/ForemanRhCloudPages.js
+++ b/webpack/ForemanRhCloudPages.js
@@ -7,6 +7,8 @@ import InsightsCloudSync from './InsightsCloudSync';
 import IopRecommendationDetails from './IopRecommendationDetails/IopRecommendationDetails';
 import InsightsHostDetailsTab from './InsightsHostDetailsTab';
 import CveDetailsPage from './CveDetailsPage';
+import InsightsComplianceReportsPage from './InsightsCompliance/InsightsComplianceReportsPage';
+import InsightsComplianceSCAPPoliciesPage from './InsightsCompliance/InsightsComplianceSCAPPoliciesPage';
 import './common/styles.scss';
 
 const pages = [
@@ -19,6 +21,14 @@ const pages = [
     type: InsightsVulnerabilityListPage,
   },
   { name: 'CveDetailsPage', type: CveDetailsPage },
+  {
+    name: 'InsightsComplianceReportsPage',
+    type: InsightsComplianceReportsPage,
+  },
+  {
+    name: 'InsightsComplianceSCAPPoliciesPage',
+    type: InsightsComplianceSCAPPoliciesPage,
+  },
 ];
 
 export const registerPages = () => {
@@ -50,6 +60,16 @@ export const routes = [
     path: '/foreman_rh_cloud/insights_vulnerability/:cveId',
     exact: true,
     render: props => <CveDetailsPage {...props} />,
+  },
+  {
+    path: '/foreman_rh_cloud/insights_compliance/reports',
+    exact: false,
+    render: props => <InsightsComplianceReportsPage {...props} />,
+  },
+  {
+    path: '/foreman_rh_cloud/insights_compliance/scappolicies',
+    exact: false,
+    render: props => <InsightsComplianceSCAPPoliciesPage {...props} />,
   },
 ];
 

--- a/webpack/InsightsCompliance/InsightsCompliancePlaceholder.js
+++ b/webpack/InsightsCompliance/InsightsCompliancePlaceholder.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const InsightsCompliancePlaceholder = () => (
+  <div className="insights-compliance">
+    <p>This page is under development. Please check back soon for updates.</p>
+  </div>
+);
+
+export default InsightsCompliancePlaceholder;

--- a/webpack/InsightsCompliance/InsightsComplianceReportsPage.js
+++ b/webpack/InsightsCompliance/InsightsComplianceReportsPage.js
@@ -1,0 +1,1 @@
+export { default } from './InsightsCompliancePlaceholder';

--- a/webpack/InsightsCompliance/InsightsComplianceSCAPPoliciesPage.js
+++ b/webpack/InsightsCompliance/InsightsComplianceSCAPPoliciesPage.js
@@ -1,0 +1,1 @@
+export { default } from './InsightsCompliancePlaceholder';

--- a/webpack/common/Hooks/PermissionsHooks.js
+++ b/webpack/common/Hooks/PermissionsHooks.js
@@ -25,6 +25,16 @@ const PERMISSION_MAPPING = {
   ],
   view_advisor: ['advisor:recommendation-results:read', 'advisor:exports:read'],
   edit_advisor: ['advisor:disable-recommendations:write'],
+  view_compliance: [
+    'inventory:hosts:read',
+    'compliance:report:read',
+    'compliance:policy:read',
+  ],
+  edit_compliance: [
+    'compliance:policy:write',
+    'compliance:policy:create',
+    'compliance:policy:delete',
+  ],
 };
 
 /**


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Initial compliance-frontend onboarding by adding routes, placeholder page and permissions required. 
inspired by the way how other apps have been onboarded step by step https://github.com/theforeman/foreman_rh_cloud/pull/999.


I also have [this PR](https://github.com/theforeman/foreman_rh_cloud/pull/1209) but it adds some tweaks that I'm not sure about yet (since we are still looking into the best way to integrate compliance into IoP)

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Run foreman with foreman_rh_cloud, navigate to Insights, open nav menu and see that `Compliance Reports` and `SCAP Policies` entries are in place. If you select one of these - you will see `This page is under development. Please check back soon for updates.`


<img width="1470" height="906" alt="Screenshot 2026-06-22 at 16 37 42" src="https://github.com/user-attachments/assets/3ff744d1-ed8f-4c73-9b82-60a3dbe4f839" />
