### PR TITLE
SAT-46497 - Disable insights_recommendations_count search in IoP mode

### DIFF
--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -46,8 +46,6 @@ module RhCloudHost
     end
   end
 
-  NUMERIC_OPERATORS = ['=', '!=', '>', '>=', '<', '<='].freeze
-
   module ClassMethods
     def search_by_insights_recommendations_count(_key, operator, value)
       if ForemanRhCloud.with_iop_smart_proxy?
@@ -56,7 +54,7 @@ module RhCloudHost
         )
       end
 
-      unless RhCloudHost::NUMERIC_OPERATORS.include?(operator)
+      unless ScopedSearch::QueryBuilder::SQL_OPERATORS.value?(operator)
         raise ScopedSearch::QueryNotSupported.new(
           _('Unsupported operator for recommendations count search: %s') % operator
         )

--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -61,9 +61,19 @@ module RhCloudHost
       end
 
       facet_table = InsightsFacet.table_name
-      condition = sanitize_sql_for_conditions(
-        ["COALESCE(#{facet_table}.hits_count, 0) #{operator} ?", value_to_sql(operator, value)]
-      )
+      hits_count_col = "COALESCE(#{facet_table}.hits_count, 0)"
+
+      if ['IN', 'NOT IN'].include?(operator)
+        values = value.is_a?(Array) ? value : value.to_s.split(',').map(&:strip)
+        placeholders = (['?'] * values.size).join(',')
+        condition = sanitize_sql_for_conditions(
+          ["#{hits_count_col} #{operator} (#{placeholders})", *values]
+        )
+      else
+        condition = sanitize_sql_for_conditions(
+          ["#{hits_count_col} #{operator} ?", value_to_sql(operator, value)]
+        )
+      end
 
       {
         joins: "LEFT JOIN #{facet_table} ON #{facet_table}.host_id = #{Host::Managed.table_name}.id",

--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -49,8 +49,9 @@ module RhCloudHost
   module ClassMethods
     def search_by_insights_recommendations_count(_key, operator, value)
       if ForemanRhCloud.with_iop_smart_proxy?
-        raise ScopedSearch::QueryNotSupported,
+        raise ScopedSearch::QueryNotSupported.new(
           _('Searching by recommendations count is not supported in IoP mode. Recommendation counts are fetched live from the IoP Smart Proxy and are not stored locally.')
+        )
       end
 
       facet_table = InsightsFacet.table_name

--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -46,17 +46,25 @@ module RhCloudHost
     end
   end
 
+  NUMERIC_OPERATORS = ['=', '!=', '>', '>=', '<', '<='].freeze
+
   module ClassMethods
     def search_by_insights_recommendations_count(_key, operator, value)
       if ForemanRhCloud.with_iop_smart_proxy?
         raise ScopedSearch::QueryNotSupported.new(
-          _('Searching by recommendations count is not supported in IoP mode. Recommendation counts are fetched live from the IoP Smart Proxy and are not stored locally.')
+          _('Searching by recommendations count is not available in IoP mode.')
+        )
+      end
+
+      unless RhCloudHost::NUMERIC_OPERATORS.include?(operator)
+        raise ScopedSearch::QueryNotSupported.new(
+          _('Unsupported operator for recommendations count search: %s') % operator
         )
       end
 
       facet_table = InsightsFacet.table_name
       condition = sanitize_sql_for_conditions(
-        ["#{facet_table}.hits_count #{operator} ?", value_to_sql(operator, value)]
+        ["COALESCE(#{facet_table}.hits_count, 0) #{operator} ?", value_to_sql(operator, value)]
       )
 
       {

--- a/app/models/concerns/rh_cloud_host.rb
+++ b/app/models/concerns/rh_cloud_host.rb
@@ -10,7 +10,8 @@ module RhCloudHost
     )
 
     has_many :insights_hits, through: :insights, source: :hits
-    scoped_search :relation => :insights, :on => :hits_count, :only_explicit => true, :rename => :insights_recommendations_count
+    scoped_search :on => :id, :rename => :insights_recommendations_count, :only_explicit => true,
+      :ext_method => :search_by_insights_recommendations_count, :complete_value => false
 
     has_one :insights_client_report_status_object, :class_name => '::InsightsClientReportStatus', :foreign_key => 'host_id'
     scoped_search :relation => :insights_client_report_status_object, :on => :status, :rename => :insights_client_report_status,
@@ -46,6 +47,23 @@ module RhCloudHost
   end
 
   module ClassMethods
+    def search_by_insights_recommendations_count(_key, operator, value)
+      if ForemanRhCloud.with_iop_smart_proxy?
+        raise ScopedSearch::QueryNotSupported,
+          _('Searching by recommendations count is not supported in IoP mode. Recommendation counts are fetched live from the IoP Smart Proxy and are not stored locally.')
+      end
+
+      facet_table = InsightsFacet.table_name
+      condition = sanitize_sql_for_conditions(
+        ["#{facet_table}.hits_count #{operator} ?", value_to_sql(operator, value)]
+      )
+
+      {
+        joins: "LEFT JOIN #{facet_table} ON #{facet_table}.host_id = #{Host::Managed.table_name}.id",
+        conditions: condition,
+      }
+    end
+
     def search_by_insights_uuid(_key, operator, value)
       # Determine which facet table to search based on IoP mode
       facet_table = ForemanRhCloud.with_iop_smart_proxy? ? Katello::Host::SubscriptionFacet.table_name : InsightsFacet.table_name

--- a/test/unit/insights_facet_test.rb
+++ b/test/unit/insights_facet_test.rb
@@ -6,6 +6,10 @@ class InsightsFacetTest < ActiveSupport::TestCase
     InsightsFacet.reset_counters(@host.insights.id, :hits_count)
   end
 
+  teardown do
+    ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+  end
+
   test 'host with hits can be deleted' do
     assert_equal 1, @host.insights.hits.count
 
@@ -16,6 +20,7 @@ class InsightsFacetTest < ActiveSupport::TestCase
   end
 
   test 'search host by recommendations_count' do
+    ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
     FactoryBot.create(:host) # create another host with no recommendations
 
     assert_equal 1, Host.search_for('insights_recommendations_count = 1').count

--- a/test/unit/rh_cloud_host_test.rb
+++ b/test/unit/rh_cloud_host_test.rb
@@ -343,6 +343,50 @@ class RhCloudHostTest < ActiveSupport::TestCase
     end
   end
 
+  context 'scoped search on insights_recommendations_count' do
+    setup do
+      @org = FactoryBot.create(:organization)
+    end
+
+    teardown do
+      ForemanRhCloud.unstub(:with_iop_smart_proxy?)
+    end
+
+    test 'searches insights_facets.hits_count in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host_with_hits = FactoryBot.create(:host, :with_insights_hits, organization: @org)
+      InsightsFacet.reset_counters(host_with_hits.insights.id, :hits_count)
+      host_without_hits = FactoryBot.create(:host, :managed, organization: @org)
+
+      results = Host::Managed.search_for('insights_recommendations_count = 1')
+
+      assert_includes results, host_with_hits
+      assert_not_includes results, host_without_hits
+    end
+
+    test 'raises QueryNotSupported in IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
+
+      error = assert_raises(ScopedSearch::QueryNotSupported) do
+        Host::Managed.search_for('insights_recommendations_count = 1')
+      end
+
+      assert_match(/not supported in IoP mode/, error.message)
+    end
+
+    test 'handles hosts without insights facets in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host_without_facet = FactoryBot.create(:host, :managed, organization: @org)
+      host_with_facet = FactoryBot.create(:host, :with_insights_hits, organization: @org)
+      InsightsFacet.reset_counters(host_with_facet.insights.id, :hits_count)
+
+      results = Host::Managed.search_for('insights_recommendations_count = 1')
+
+      assert_includes results, host_with_facet
+      assert_not_includes results, host_without_facet
+    end
+  end
+
   test 'scoped search for user_omitted inventory status works' do
     host1 = FactoryBot.create(:host, :managed)
     host2 = FactoryBot.create(:host, :managed)

--- a/test/unit/rh_cloud_host_test.rb
+++ b/test/unit/rh_cloud_host_test.rb
@@ -364,6 +364,18 @@ class RhCloudHostTest < ActiveSupport::TestCase
       assert_not_includes results, host_without_hits
     end
 
+    test 'supports greater-than operator in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host_with_hits = FactoryBot.create(:host, :with_insights_hits, organization: @org)
+      InsightsFacet.reset_counters(host_with_hits.insights.id, :hits_count)
+      host_without_hits = FactoryBot.create(:host, :managed, organization: @org)
+
+      results = Host::Managed.search_for('insights_recommendations_count > 0')
+
+      assert_includes results, host_with_hits
+      assert_not_includes results, host_without_hits
+    end
+
     test 'raises QueryNotSupported in IoP mode' do
       ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(true)
 
@@ -371,7 +383,7 @@ class RhCloudHostTest < ActiveSupport::TestCase
         Host::Managed.search_for('insights_recommendations_count = 1')
       end
 
-      assert_match(/not supported in IoP mode/, error.message)
+      assert_match(/not available in IoP mode/, error.message)
     end
 
     test 'handles hosts without insights facets in non-IoP mode' do

--- a/test/unit/rh_cloud_host_test.rb
+++ b/test/unit/rh_cloud_host_test.rb
@@ -386,6 +386,18 @@ class RhCloudHostTest < ActiveSupport::TestCase
       assert_match(/not available in IoP mode/, error.message)
     end
 
+    test 'supports IN operator in non-IoP mode' do
+      ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
+      host_with_hits = FactoryBot.create(:host, :with_insights_hits, organization: @org)
+      InsightsFacet.reset_counters(host_with_hits.insights.id, :hits_count)
+      host_without_hits = FactoryBot.create(:host, :managed, organization: @org)
+
+      results = Host::Managed.search_for('insights_recommendations_count ^ (1,2,3)')
+
+      assert_includes results, host_with_hits
+      assert_not_includes results, host_without_hits
+    end
+
     test 'handles hosts without insights facets in non-IoP mode' do
       ForemanRhCloud.stubs(:with_iop_smart_proxy?).returns(false)
       host_without_facet = FactoryBot.create(:host, :managed, organization: @org)


### PR DESCRIPTION
## Summary
- In IoP mode, recommendation counts are fetched live from the IoP Smart Proxy — they are not stored locally in `insights_facets.hits_count`. This made the `insights_recommendations_count` scoped search return incorrect results.
- Changed the scoped search from a simple `:relation` to an `ext_method` that raises `ScopedSearch::QueryNotSupported` with a clear message in IoP mode, following the same pattern as the `insights_uuid` fix.
- Updated existing test in `insights_facet_test.rb` to stub IoP mode, and added new tests for both IoP and non-IoP behavior.

## Test plan
- [ ] Verify `insights_recommendations_count = 1` search works correctly in non-IoP mode
- [ ] Verify `insights_recommendations_count = 1` search raises a clear error message in IoP mode
- [ ] Verify the Recommendations column still renders correctly on the hosts page in both modes
- [ ] Run `bundle exec rake test:foreman_rh_cloud`

🤖 Generated with [Claude Code](https://claude.com/claude-code)