### PR TITLE
Fix ensure unfinishable Upload job is marked done

### DIFF
--- a/lib/foreman_inventory_upload/async/upload_report_direct_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_direct_job.rb
@@ -59,11 +59,13 @@ module ForemanInventoryUpload
       def try_execute
         if content_disconnected?
           logger.info("Upload canceled: connection to Insights is not enabled. Report location: #{filename}")
+          done!
           return
         end
 
         unless organization.owner_details&.dig('upstreamConsumer', 'idCert')
           logger.info("Skipping organization '#{organization}', no candlepin certificate defined.")
+          done!
           return
         end
 

--- a/test/jobs/upload_report_direct_job_test.rb
+++ b/test/jobs/upload_report_direct_job_test.rb
@@ -401,4 +401,33 @@ class UploadReportDirectJobTest < ActiveSupport::TestCase
       file.close
     end
   end
+
+  test 'mark as done when upload aborted due to missing certificate' do
+    # Remove certificate from organization
+    Organization.any_instance.stubs(:owner_details).returns({})
+
+    action = create_action(ForemanInventoryUpload::Async::UploadReportDirectJob)
+    action.expects(:action_subject).with(@organization)
+    plan_action(action, nil, @organization.id)
+
+    # Execute the action
+    action.send(:try_execute)
+
+    # Verify it is marked as done
+    assert action.done?
+  end
+
+  test 'mark as done when upload aborted due to disconnected mode' do
+    Setting.stubs(:[]).with(:subscription_connection_enabled).returns(false)
+
+    action = create_action(ForemanInventoryUpload::Async::UploadReportDirectJob)
+    action.expects(:action_subject).with(@organization)
+    plan_action(action, nil, @organization.id)
+
+    # Execute the action
+    action.send(:try_execute)
+
+    # Verify it is marked as done
+    assert action.done?
+  end
 end


### PR DESCRIPTION
Fixes #1227

#### What are the changes introduced in this pull request?

Add code to mark aborted Jobs as `done` (broke with #1127).

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

Created unit-tests (might need some refinement).

Have a system not registered to Insights (no consumer certs) and start Upload-Job.
_Expected Result:_ Upload aborted, but Task finishes.
