### PR TITLE
Fix inventory upload job hang on non-retryable errors

### DIFF
--- a/lib/foreman_inventory_upload/async/upload_report_direct_job.rb
+++ b/lib/foreman_inventory_upload/async/upload_report_direct_job.rb
@@ -78,6 +78,18 @@ module ForemanInventoryUpload
 
         move_to_done_folder
         done!
+      rescue RestClient::ExceptionWithResponse => e
+        if non_retryable_upload_error?(e)
+          logger.warn(
+            "Upload skipped for organization '#{organization}' " \
+            "due to non-retryable response (#{e.http_code}): #{sanitized_http_body(e)}"
+          )
+          output[:status] = 'upload_skipped_non_retryable'
+          done!
+          return
+        end
+
+        raise
       end
 
       def upload_file(cer_path)
@@ -159,6 +171,24 @@ module ForemanInventoryUpload
       def content_disconnected?
         return false if ForemanRhCloud.with_iop_smart_proxy?
         !Setting[:subscription_connection_enabled]
+      end
+
+      def non_retryable_upload_error?(exception)
+        code = exception.http_code.to_i
+        code >= 400 && code < 500 && ![408, 429].include?(code)
+      end
+
+      def sanitized_http_body(exception)
+        body = exception.http_body.to_s
+        max_length = 500
+
+        if body.length > max_length
+          "#{body[0, max_length]}... [truncated]"
+        else
+          body
+        end
+      rescue StandardError
+        exception.message.to_s
       end
 
       def logger

--- a/test/jobs/upload_report_direct_job_test.rb
+++ b/test/jobs/upload_report_direct_job_test.rb
@@ -241,6 +241,46 @@ class UploadReportDirectJobTest < ActiveSupport::TestCase
     end
   end
 
+  test 'marks action done on non-retryable client upload errors' do
+    response = mock('response')
+    response.stubs(:code).returns(422)
+    response.stubs(:body).returns('No eligible hosts in report')
+
+    ForemanInventoryUpload::Async::UploadReportDirectJob.any_instance.stubs(:upload_file)
+                                                        .raises(RestClient::UnprocessableEntity.new(response))
+
+    action = create_action(ForemanInventoryUpload::Async::UploadReportDirectJob)
+    action.expects(:action_subject).with(@organization)
+    plan_action(action, @filename, @organization.id)
+    runtime_output = {}
+    action.stubs(:output).returns(runtime_output)
+
+    # Non-retryable 4xx responses should not raise and should end polling.
+    action.send(:try_execute)
+    assert action.done?
+    assert_equal 'upload_skipped_non_retryable', runtime_output[:status]
+  end
+
+  test 'keeps retry behavior for retryable client upload errors' do
+    response = mock('response')
+    response.stubs(:code).returns(429)
+    response.stubs(:body).returns('Too Many Requests')
+
+    ForemanInventoryUpload::Async::UploadReportDirectJob.any_instance.stubs(:upload_file)
+                                                        .raises(RestClient::TooManyRequests.new(response))
+
+    action = create_action(ForemanInventoryUpload::Async::UploadReportDirectJob)
+    action.expects(:action_subject).with(@organization)
+    plan_action(action, @filename, @organization.id)
+    runtime_output = {}
+    action.stubs(:output).returns(runtime_output)
+
+    assert_raises(RestClient::TooManyRequests) do
+      action.send(:try_execute)
+    end
+    assert_nil runtime_output[:status]
+  end
+
   test 'uses proxy configuration from ForemanRhCloud' do
     proxy_url = 'http://proxy.example.com:8080'
     ForemanRhCloud.stubs(:transformed_http_proxy_string).returns(proxy_url)


### PR DESCRIPTION
When report upload returns non-retryable client errors (4xx except 408/429), mark UploadReportDirectJob as done instead of re-raising and polling forever. This prevents HostInventoryReportJob from staying stuck around 83% and keeps the inventory upload UI from remaining in a perpetual loading/disabled state. Also adds tests for non-retryable vs retryable client error behavior.

#### What are the changes introduced in this pull request?
- Updated UploadReportDirectJob to treat non-retryable upload client errors as terminal.
- On HTTP 4xx (except 408 and 429), the job now logs, sets `output[:status] = 'upload_skipped_non_retryable'`, and finishes with `done!` instead of retrying.
- Added tests covering

#### Considerations taken when implementing this change?
- Preserved retry behavior for transient conditions (408 timeout and 429 rate limit).
- Scoped the change to upload error handling only; no changes to report generation flow.
- Added explicit task output status for observability.

#### What are the testing steps for this pull request?

- Run unit tests for upload job
- Verify new cases:
  - 422 => action completes with upload_skipped_non_retryable
  - 429 => action raises/retries as before.