### PR TITLE
Release 13.2.10

### DIFF
--- a/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
+++ b/app/controllers/insights_cloud/api/machine_telemetries_controller.rb
@@ -32,14 +32,10 @@ module InsightsCloud::Api
       rescue RestClient::ExceptionWithResponse => e
         response_obj = e.response.presence || e.exception
         code = response_obj.try(:code) || response_obj.try(:http_code) || 500
-        message = 'Cloud request failed'
+        upstream_content_type = response_obj.try(:headers)&.[](:content_type)
+        content_type = upstream_content_type&.match?(/json/) ? upstream_content_type : 'application/json'
 
-        return render json: {
-          :message => message,
-          :error => response_obj.to_s,
-          :headers => {},
-          :response => response_obj,
-        }, status: code
+        return render body: response_obj.to_s, status: code, content_type: content_type
       rescue StandardError => e
         # Catch any other exceptions here, such as Errno::ECONNREFUSED
         logger.warn("Cloud request failed with exception: #{e}")

--- a/app/controllers/insights_cloud/ui_requests_controller.rb
+++ b/app/controllers/insights_cloud/ui_requests_controller.rb
@@ -36,14 +36,10 @@ module InsightsCloud
       rescue RestClient::ExceptionWithResponse => e
         response_obj = e.response.presence || e.exception
         code = response_obj.try(:code) || response_obj.try(:http_code) || 500
-        message = 'Cloud request failed'
+        upstream_content_type = response_obj.try(:headers)&.[](:content_type)
+        content_type = upstream_content_type&.match?(/json/) ? upstream_content_type : 'application/json'
 
-        return render json: {
-          :message => message,
-          :error => response_obj.to_s,
-          :headers => {},
-          :response => response_obj,
-        }, status: code
+        return render body: response_obj.to_s, status: code, content_type: content_type
       rescue StandardError => e
         # Catch any other exceptions here, such as Errno::ECONNREFUSED
         logger.warn("Cloud request failed with exception: #{e}")

--- a/lib/foreman_inventory_upload.rb
+++ b/lib/foreman_inventory_upload.rb
@@ -96,7 +96,14 @@ module ForemanInventoryUpload
   end
 
   def self.inventory_self_url
-    inventory_base_url + "?hostname_or_id=#{ForemanRhCloud.foreman_host.fqdn}"
+    host = ForemanRhCloud.foreman_host
+    hostname = host ? host.fqdn : ForemanRhCloud.foreman_host_name
+    if hostname.nil?
+      Rails.logger.warn("Cannot determine Foreman hostname for inventory sync. " \
+                        "Please configure Setting[:foreman_url]. " \
+                        "Containerized setups must explicitly set this.")
+    end
+    inventory_base_url + "?hostname_or_id=#{hostname}"
   end
 
   def self.host_by_id_url(host_uuid)

--- a/lib/foreman_inventory_upload/generators/fact_helpers.rb
+++ b/lib/foreman_inventory_upload/generators/fact_helpers.rb
@@ -114,6 +114,7 @@ module ForemanInventoryUpload
 
       def host_ips(host)
         # Determines and returns the IP addresses associated with a host, applying obfuscation if enabled.
+        return {} if host.nil?
 
         # If IP obfuscation is enabled for the host return a representation of obfuscated IP addresses.
         return obfuscated_ips(host) if obfuscate_ips?(host)
@@ -163,10 +164,29 @@ module ForemanInventoryUpload
 
       def hostname_match
         bash_hostname = `uname -n`.chomp
-        foreman_hostname = ForemanRhCloud.foreman_host&.name
-        if bash_hostname == foreman_hostname
-          fqdn(ForemanRhCloud.foreman_host)
-        elsif Setting[:obfuscate_inventory_hostnames]
+        foreman_host = ForemanRhCloud.foreman_host
+
+        # If bash hostname matches foreman_host, use fqdn
+        if foreman_host && bash_hostname == foreman_host.name
+          return fqdn(foreman_host)
+        end
+
+        # If no foreman_host, try foreman_host_name from Setting[:foreman_url]
+        unless foreman_host
+          foreman_hostname_from_setting = ForemanRhCloud.foreman_host_name
+          if foreman_hostname_from_setting
+            # Apply obfuscation if enabled
+            return obfuscate_fqdn(foreman_hostname_from_setting) if Setting[:obfuscate_inventory_hostnames]
+
+            return foreman_hostname_from_setting
+          end
+          # Otherwise fall through to bash_hostname below
+          # NOTE: Containerized foremanctl setups must configure Setting[:foreman_url]
+          # as bash hostname may not be available or meaningful in containers
+        end
+
+        # Fallback to bash hostname (with obfuscation if enabled)
+        if Setting[:obfuscate_inventory_hostnames]
           obfuscate_fqdn(bash_hostname)
         else
           bash_hostname
@@ -174,6 +194,8 @@ module ForemanInventoryUpload
       end
 
       def bios_uuid(host)
+        return nil if host.nil?
+
         value = fact_value(host, 'dmi::system::uuid') || ''
         uuid_value(value)
       end

--- a/lib/foreman_rh_cloud.rb
+++ b/lib/foreman_rh_cloud.rb
@@ -84,23 +84,50 @@ module ForemanRhCloud
 
   # For testing purposes we can override the default hostname with an environment variable SATELLITE_RH_CLOUD_FOREMAN_HOST
   def self.foreman_host
-    @foreman_host ||= begin
-      fullname = foreman_host_name
-      ::Host.unscoped.friendly.find(fullname)
-    rescue ActiveRecord::RecordNotFound
-      # fullname didn't work. Let's try shortname
+    return @foreman_host if defined?(@foreman_host)
+
+    fullname = foreman_host_name
+    return @foreman_host = nil unless fullname
+
+    # Try fullname first
+    host = ::Host.unscoped.friendly.where(name: fullname).first
+
+    # If not found, try shortname
+    if host.nil?
       shortname = /(?<shortname>[^\.]*)\.?.*/.match(fullname)[:shortname]
-      ::Host.unscoped.friendly.find(shortname)
+      host = ::Host.unscoped.friendly.where(name: shortname).first
     end
+
+    @foreman_host = host
   end
 
   def self.foreman_host_name
-    ENV['SATELLITE_RH_CLOUD_FOREMAN_HOST'] || marked_foreman_host&.name || ::SmartProxy.default_capsule.name
+    ENV['SATELLITE_RH_CLOUD_FOREMAN_HOST'] || marked_foreman_host&.name || foreman_url_hostname
+  end
+
+  def self.foreman_url_hostname
+    return nil unless Setting[:foreman_url]
+
+    begin
+      # Ensure setting is a string to avoid TypeError from URI.parse
+      url = Setting[:foreman_url].to_s
+      URI.parse(url).host
+    rescue URI::InvalidURIError, ArgumentError, TypeError => e
+      Rails.logger.warn("Invalid foreman_url setting: #{e.message}")
+      nil
+    end
   end
 
   def self.marked_foreman_host
-    ::Host.unscoped.search_for('infrastructure_facet.foreman = true').first
-  rescue ScopedSearch::QueryNotSupported
+    # Find host with infrastructure_facet.foreman_instance = true
+    # Facets use a special mechanism in Foreman, so we query the facet table directly
+    return nil unless defined?(HostFacets::InfrastructureFacet)
+
+    facet = HostFacets::InfrastructureFacet.find_by(foreman_instance: true)
+    facet&.host
+  rescue ActiveRecord::StatementInvalid => e
+    # Table might not exist yet during migrations
+    Rails.logger.debug("Could not query marked foreman host: #{e.message}")
     nil
   end
 

--- a/lib/foreman_rh_cloud/version.rb
+++ b/lib/foreman_rh_cloud/version.rb
@@ -1,3 +1,3 @@
 module ForemanRhCloud
-  VERSION = '13.2.9'.freeze
+  VERSION = '13.2.10'.freeze
 end

--- a/lib/insights_cloud/async/insights_generate_notifications.rb
+++ b/lib/insights_cloud/async/insights_generate_notifications.rb
@@ -13,7 +13,16 @@ module InsightsCloud
       end
 
       def add_satellite_notifications
-        hits_count = InsightsHit.where(host_id: foreman_host.id).count
+        host = foreman_host
+
+        # Skip if no Foreman host record exists
+        unless host
+          logger.debug("Skipping Insights notifications: no Foreman host record found")
+          blueprint&.notifications&.destroy_all
+          return
+        end
+
+        hits_count = InsightsHit.where(host_id: host.id).count
 
         # Remove stale notifications
         blueprint.notifications.destroy_all

--- a/lib/inventory_sync/async/inventory_self_host_sync.rb
+++ b/lib/inventory_sync/async/inventory_self_host_sync.rb
@@ -4,7 +4,14 @@ module InventorySync
       set_callback :step, :around, :create_facets
 
       def plan
-        super(ForemanRhCloud.foreman_host.organization)
+        host = ForemanRhCloud.foreman_host
+
+        if host.nil?
+          logger.warn("Skipping self-host inventory sync: no Foreman host record found.")
+          return
+        end
+
+        super(host.organization)
       end
 
       def create_facets
@@ -22,7 +29,10 @@ module InventorySync
       private
 
       def add_missing_insights_facet(uuids_hash)
-        facet = InsightsFacet.find_or_create_by(host_id: ForemanRhCloud.foreman_host.id) do |facet|
+        host = ForemanRhCloud.foreman_host
+        return unless host # Guard against nil
+
+        facet = InsightsFacet.find_or_create_by(host_id: host.id) do |facet|
           facet.uuid = uuids_hash.values.first
         end
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman_rh_cloud",
-  "version": "13.2.9",
+  "version": "13.2.10",
   "description": "Inventory Upload =============",
   "main": "index.js",
   "scripts": {

--- a/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
+++ b/test/controllers/insights_cloud/api/machine_telemetries_controller_test.rb
@@ -154,8 +154,22 @@ module InsightsCloud::Api
 
         get :forward_request, params: { "path" => "platform/module-update-router/v1/channel" }
         assert_equal 500, @response.status
-        assert_equal 'Cloud request failed', JSON.parse(@response.body)['message']
-        assert_match /#{@body}/, JSON.parse(@response.body)['response']
+        assert_equal @body, @response.body
+      end
+
+      test "should forward JSON error responses without double-escaping" do
+        json_error = { errors: [{ detail: 'inventory_id must exist', status: '404' }] }.to_json
+        net_http_resp = Net::HTTPResponse.new(1.0, 404, "Not Found")
+        net_http_resp['content-type'] = 'application/json'
+        res = RestClient::Response.create(json_error, net_http_resp, @http_req)
+        ::ForemanRhCloud::CloudRequestForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::NotFound.new(res))
+
+        get :forward_request, params: { "path" => "api/vulnerability/v1/systems/00000000-0000-0000-0000-000000000000" }
+        assert_equal 404, @response.status
+        assert_includes @response.content_type, 'application/json'
+        assert_equal json_error, @response.body
+        parsed = JSON.parse(@response.body)
+        assert_equal 'inventory_id must exist', parsed['errors'][0]['detail']
       end
 
       test "should create insights facet" do

--- a/test/controllers/insights_cloud/ui_requests_controller_test.rb
+++ b/test/controllers/insights_cloud/ui_requests_controller_test.rb
@@ -177,8 +177,22 @@ module InsightsCloud
 
         get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/cves" }, session: set_session
         assert_equal 500, @response.status
-        assert_equal 'Cloud request failed', JSON.parse(@response.body)['message']
-        assert_match(/#{@body}/, JSON.parse(@response.body)['response'])
+        assert_equal @body, @response.body
+      end
+
+      test "should forward JSON error responses without double-escaping" do
+        json_error = { errors: [{ detail: 'inventory_id must exist', status: '404' }] }.to_json
+        net_http_resp = Net::HTTPResponse.new(1.0, 404, "Not Found")
+        net_http_resp['content-type'] = 'application/json'
+        res = RestClient::Response.create(json_error, net_http_resp, @http_req)
+        ::ForemanRhCloud::InsightsApiForwarder.any_instance.stubs(:execute_cloud_request).raises(RestClient::NotFound.new(res))
+
+        get :forward_request, params: { "controller" => "vulnerabilities", "path" => "api/vulnerability/v1/systems/00000000-0000-0000-0000-000000000000" }, session: set_session
+        assert_equal 404, @response.status
+        assert_includes @response.content_type, 'application/json'
+        assert_equal json_error, @response.body
+        parsed = JSON.parse(@response.body)
+        assert_equal 'inventory_id must exist', parsed['errors'][0]['detail']
       end
 
       test "should allow forward_request with nil location (Any location)" do

--- a/test/jobs/insights_generate_notifications_test.rb
+++ b/test/jobs/insights_generate_notifications_test.rb
@@ -1,0 +1,26 @@
+require 'test_plugin_helper'
+require 'foreman_tasks/test_helpers'
+
+class InsightsGenerateNotificationsTest < ActiveSupport::TestCase
+  include Dynflow::Testing::Factories
+
+  setup do
+    User.current = User.find_by(login: 'secret_admin')
+  end
+
+  test 'skips notifications when foreman_host is nil' do
+    ForemanRhCloud.stubs(:foreman_host).returns(nil)
+
+    # Ensure blueprint exists or create it
+    NotificationBlueprint.find_or_create_by(name: 'insights_satellite_hits') do |bp|
+      bp.message = 'Test message'
+      bp.level = 'info'
+      bp.expires_in = 7.days
+    end
+
+    plan = ForemanTasks.sync_task(InsightsCloud::Async::InsightsGenerateNotifications)
+
+    # Should not raise an error, task completes successfully
+    assert_includes ['success', 'stopped'], plan.state, "Task should complete without error"
+  end
+end

--- a/test/jobs/inventory_self_host_sync_test.rb
+++ b/test/jobs/inventory_self_host_sync_test.rb
@@ -106,4 +106,13 @@ class InventorySelfHostSyncTest < ActiveSupport::TestCase
 
     assert_equal @host1_inventory_id, @host1.insights.uuid
   end
+
+  test 'skips sync when foreman_host is nil' do
+    ForemanRhCloud.stubs(:foreman_host).returns(nil)
+
+    plan = ForemanTasks.sync_task(InventorySync::Async::InventorySelfHostSync)
+
+    # Task should be stopped (not executed) when host is nil, not failed
+    assert_equal 'stopped', plan.state
+  end
 end

--- a/test/unit/foreman_rh_cloud_self_host_test.rb
+++ b/test/unit/foreman_rh_cloud_self_host_test.rb
@@ -2,8 +2,9 @@ require 'test_plugin_helper'
 
 class ForemanRhCloudSelfHostTest < ActiveSupport::TestCase
   setup do
-    # reset cached value
-    ForemanRhCloud.instance_variable_set(:@foreman_host, nil)
+    # reset cached value - must remove the variable entirely, not just set to nil
+    ForemanRhCloud.remove_instance_variable(:@foreman_host) if ForemanRhCloud.instance_variable_defined?(:@foreman_host)
+    ENV.delete('SATELLITE_RH_CLOUD_FOREMAN_HOST')
   end
 
   test 'finds host by fullname' do
@@ -31,5 +32,52 @@ class ForemanRhCloudSelfHostTest < ActiveSupport::TestCase
     actual = ForemanRhCloud.foreman_host
 
     assert_equal @host, actual
+  end
+
+  test 'returns nil when host does not exist' do
+    ForemanRhCloud.expects(:foreman_host_name).returns('nonexistent.example.com')
+
+    actual = ForemanRhCloud.foreman_host
+
+    assert_nil actual
+  end
+
+  test 'returns nil and does not query Host when foreman_host_name is nil' do
+    ForemanRhCloud.stubs(:foreman_host_name).returns(nil)
+    ::Host.unscoped.friendly.expects(:where).never
+
+    assert_nil ForemanRhCloud.foreman_host
+  end
+
+  test 'caches nil value to avoid repeated lookups' do
+    ForemanRhCloud.expects(:foreman_host_name).once.returns('nonexistent.example.com')
+
+    2.times { ForemanRhCloud.foreman_host }
+  end
+
+  test 'extracts hostname from foreman_url setting' do
+    Setting[:foreman_url] = 'https://satellite.example.com'
+
+    actual = ForemanRhCloud.foreman_url_hostname
+
+    assert_equal 'satellite.example.com', actual
+  end
+
+  test 'handles invalid foreman_url gracefully' do
+    # Stub Setting to return invalid URL without validation
+    Setting.stubs(:[]).with(:foreman_url).returns('not a valid url')
+
+    actual = ForemanRhCloud.foreman_url_hostname
+
+    assert_nil actual
+  end
+
+  test 'foreman_host_name uses foreman_url when marked_foreman_host is nil' do
+    ForemanRhCloud.expects(:marked_foreman_host).returns(nil)
+    ForemanRhCloud.expects(:foreman_url_hostname).returns('satellite.example.com')
+
+    actual = ForemanRhCloud.foreman_host_name
+
+    assert_equal 'satellite.example.com', actual
   end
 end

--- a/test/unit/metadata_generator_test.rb
+++ b/test/unit/metadata_generator_test.rb
@@ -2,7 +2,8 @@ require 'test_plugin_helper'
 
 class MetadataGeneratorTest < ActiveSupport::TestCase
   setup do
-    ForemanRhCloud.instance_variable_set(:@foreman_host, nil)
+    # reset cached value - must remove the variable entirely, not just set to nil
+    ForemanRhCloud.remove_instance_variable(:@foreman_host) if ForemanRhCloud.instance_variable_defined?(:@foreman_host)
   end
 
   test 'generates an empty report' do
@@ -63,5 +64,27 @@ class MetadataGeneratorTest < ActiveSupport::TestCase
     assert_equal 2, slice['number_hosts']
     assert_not_nil(slice = slices['test_12345'])
     assert_equal 3, slice['number_hosts']
+  end
+
+  test 'generates metadata when foreman_host is nil' do
+    ForemanRhCloud.stubs(:foreman_host).returns(nil)
+    ForemanRhCloud.stubs(:foreman_host_name).returns('satellite.example.com')
+
+    generator = ForemanInventoryUpload::Generators::Metadata.new
+
+    # Should not raise an error
+    json_str = nil
+    assert_nothing_raised do
+      json_str = generator.render do
+      end
+    end
+
+    # Verify hostname is from foreman_host_name
+    actual = JSON.parse(json_str.join("\n"))
+    assert_equal 'satellite.example.com', actual['reporting_host_name']
+    # Verify IP and BIOS UUID fields are nil when host is nil
+    # This is acceptable per SAT-25889 - cloud services don't rely on these fields
+    assert_nil actual['reporting_host_ips']
+    assert_nil actual['reporting_host_bios_uuid']
   end
 end

--- a/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
+++ b/webpack/CVEsHostDetailsTab/CVEsHostDetailsTab.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import { ScalprumComponent, ScalprumProvider } from '@scalprum/react-core';
 import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
 import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
+import {
+  vulnerabilityDisabled,
+  useTabRedirect,
+} from '../ForemanRhCloudHelpers';
 import './CVEsHostDetailsTab.scss';
 
 const CVEsHostDetailsTab = ({ systemId }) => {
@@ -26,6 +30,15 @@ CVEsHostDetailsTab.propTypes = {
 
 const CVEsHostDetailsTabWrapper = ({ response }) => {
   const permissions = useInsightsPermissions();
+  const isHostDataLoaded = Boolean(response?.id);
+  const shouldHideTab = useTabRedirect(
+    isHostDataLoaded && vulnerabilityDisabled({ hostDetails: response })
+  );
+
+  if (shouldHideTab) {
+    return null;
+  }
+
   return (
     <ScalprumProvider {...createProviderOptions(permissions)}>
       <CVEsHostDetailsTab
@@ -38,10 +51,19 @@ const CVEsHostDetailsTabWrapper = ({ response }) => {
 
 CVEsHostDetailsTabWrapper.propTypes = {
   response: PropTypes.shape({
-    subscription_facet_attributes: PropTypes.shape({
-      uuid: PropTypes.string.isRequired,
+    id: PropTypes.number,
+    operatingsystem_name: PropTypes.string,
+    vulnerability: PropTypes.shape({
+      enabled: PropTypes.bool,
     }),
-  }).isRequired,
+    subscription_facet_attributes: PropTypes.shape({
+      uuid: PropTypes.string,
+    }),
+  }),
+};
+
+CVEsHostDetailsTabWrapper.defaultProps = {
+  response: {},
 };
 
 export default CVEsHostDetailsTabWrapper;

--- a/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
+++ b/webpack/CVEsHostDetailsTab/__tests__/CVEsHostDetailsTab.test.js
@@ -1,6 +1,17 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import CVEsHostDetailsTabWrapper from '../CVEsHostDetailsTab';
+import { OVERVIEW_TAB_PATH } from '../../ForemanRhCloudHelpers';
+
+const mockHistoryReplace = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    replace: mockHistoryReplace,
+  }),
+}));
 
 jest.mock('foremanReact/Root/Context/ForemanContext', () => ({
   useForemanContext: () => ({
@@ -25,31 +36,44 @@ jest.mock('@scalprum/react-core', () => {
   };
 });
 
+const defaultResponse = {
+  id: 1,
+  operatingsystem_name: 'Red Hat Enterprise Linux 8',
+  vulnerability: { enabled: true },
+  subscription_facet_attributes: { uuid: '1-2-3' },
+};
+
 describe('CVEsHostDetailsTabWrapper', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders without crashing', () => {
+  it('renders without crashing and does not redirect for valid host', () => {
     const { container } = render(
-      <CVEsHostDetailsTabWrapper
-        response={{ subscription_facet_attributes: { uuid: '1-2-3' } }}
-      />
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={defaultResponse} />
+      </MemoryRouter>
     );
     expect(
       container.querySelector(
         '.rh-cloud-insights-vulnerability-host-details-component'
       )
     ).toBeTruthy();
+    expect(mockHistoryReplace).not.toHaveBeenCalled();
   });
 
   it('remounts ScalprumComponent when systemId changes', () => {
     const { ScalprumComponent } = require('@scalprum/react-core');
 
+    const responseHostA = {
+      ...defaultResponse,
+      subscription_facet_attributes: { uuid: 'uuid-host-A' },
+    };
+
     const { rerender } = render(
-      <CVEsHostDetailsTabWrapper
-        response={{ subscription_facet_attributes: { uuid: 'uuid-host-A' } }}
-      />
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={responseHostA} />
+      </MemoryRouter>
     );
 
     expect(mockUnmountTracker).not.toHaveBeenCalled();
@@ -58,10 +82,15 @@ describe('CVEsHostDetailsTabWrapper', () => {
       expect.anything()
     );
 
+    const responseHostB = {
+      ...defaultResponse,
+      subscription_facet_attributes: { uuid: 'uuid-host-B' },
+    };
+
     rerender(
-      <CVEsHostDetailsTabWrapper
-        response={{ subscription_facet_attributes: { uuid: 'uuid-host-B' } }}
-      />
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={responseHostB} />
+      </MemoryRouter>
     );
 
     expect(mockUnmountTracker).toHaveBeenCalledTimes(1);
@@ -69,5 +98,39 @@ describe('CVEsHostDetailsTabWrapper', () => {
       expect.objectContaining({ systemId: 'uuid-host-B' }),
       expect.anything()
     );
+  });
+
+  it('redirects to Overview when tab should be hidden', () => {
+    const nonRhelResponse = {
+      id: 2,
+      operatingsystem_name: 'Ubuntu 20.04',
+      vulnerability: { enabled: false },
+      subscription_facet_attributes: { uuid: '1-2-3' },
+    };
+
+    const { container } = render(
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={nonRhelResponse} />
+      </MemoryRouter>
+    );
+
+    expect(mockHistoryReplace).toHaveBeenCalledWith(OVERVIEW_TAB_PATH);
+    expect(
+      container.querySelector(
+        '.rh-cloud-insights-vulnerability-host-details-component'
+      )
+    ).toBeNull();
+  });
+
+  it('does not redirect when host data is not yet loaded', () => {
+    const emptyResponse = { subscription_facet_attributes: { uuid: '1-2-3' } };
+
+    render(
+      <MemoryRouter>
+        <CVEsHostDetailsTabWrapper response={emptyResponse} />
+      </MemoryRouter>
+    );
+
+    expect(mockHistoryReplace).not.toHaveBeenCalled();
   });
 });

--- a/webpack/ForemanRhCloudHelpers.js
+++ b/webpack/ForemanRhCloudHelpers.js
@@ -1,9 +1,31 @@
+import { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+
 /**
  * copied from core, since it's not in the ReactApp folder,
  * it's complicated to import it and mock it in tests.
  * should be imported once core moves it to the ReactApp folder.
  */
 export const foremanUrl = path => `${window.URL_PREFIX}${path}`;
+
+export const OVERVIEW_TAB_PATH = '/Overview';
+
+/**
+ * Redirects to Overview tab when the current tab should be hidden
+ * @param {boolean} shouldRedirect - Whether to redirect (e.g., host loaded AND tab should hide)
+ * @returns {boolean} - Returns shouldRedirect for convenience
+ */
+export const useTabRedirect = shouldRedirect => {
+  const history = useHistory();
+
+  useEffect(() => {
+    if (shouldRedirect && history) {
+      history.replace(OVERVIEW_TAB_PATH);
+    }
+  }, [shouldRedirect, history]);
+
+  return shouldRedirect;
+};
 
 export const isNotRhelHost = ({ hostDetails }) =>
   // This regex tries matches sane variations of "RedHat", "RHEL" and "RHCOS"

--- a/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
+++ b/webpack/InsightsHostDetailsTab/NewHostDetailsTab.js
@@ -25,6 +25,11 @@ import { useIopConfig } from '../common/Hooks/ConfigHooks';
 import { generateRuleUrl } from '../InsightsCloudSync/InsightsCloudSync';
 import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext';
 import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
+import {
+  isNotRhelHost,
+  hasNoInsightsFacet,
+  useTabRedirect,
+} from '../ForemanRhCloudHelpers';
 
 // Hosted Insights advisor
 const NewHostDetailsTab = ({ hostName, router }) => {
@@ -165,7 +170,18 @@ const IopInsightsTabWrapped = props => {
 };
 
 const InsightsTab = props => {
+  const { response } = props;
   const isIop = useIopConfig();
+  const isHostDataLoaded = Boolean(response?.id);
+  const shouldHideTab = useTabRedirect(
+    isHostDataLoaded &&
+      (isNotRhelHost({ hostDetails: response }) ||
+        hasNoInsightsFacet({ response, hostDetails: response }))
+  );
+
+  if (shouldHideTab) {
+    return null;
+  }
 
   return isIop ? (
     <IopInsightsTabWrapped {...props} />
@@ -174,6 +190,16 @@ const InsightsTab = props => {
   );
 };
 
-InsightsTab.defaultProps = {};
+InsightsTab.propTypes = {
+  response: PropTypes.shape({
+    id: PropTypes.number,
+    operatingsystem_name: PropTypes.string,
+    insights_attributes: PropTypes.object,
+  }),
+};
+
+InsightsTab.defaultProps = {
+  response: {},
+};
 
 export default InsightsTab;

--- a/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/NewHostDetailsTab.test.js
@@ -2,9 +2,20 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import NewHostDetailsTab from '../NewHostDetailsTab';
+import { OVERVIEW_TAB_PATH } from '../../ForemanRhCloudHelpers';
+
+const mockHistoryReplace = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    replace: mockHistoryReplace,
+  }),
+}));
 
 jest.mock('../../common/Hooks/ConfigHooks', () => ({
   useIopConfig: jest.fn(() => false),
@@ -14,7 +25,32 @@ jest.mock('foremanReact/common/I18n', () => ({
   translate: jest.fn(str => str),
 }));
 
+jest.mock(
+  'foremanReact/components/SearchBar',
+  () => () => <div>SearchBar</div>,
+  { virtual: true }
+);
+
+jest.mock('../../InsightsCloudSync/Components/InsightsTable', () => () => (
+  <div>InsightsTable</div>
+));
+
+jest.mock('../../InsightsCloudSync/Components/RemediationModal', () => () => (
+  <div>RemediationModal</div>
+));
+
+jest.mock(
+  '../../InsightsCloudSync/Components/InsightsTable/Pagination',
+  () => () => <div>Pagination</div>
+);
+
 const mockStore = configureMockStore([thunk]);
+
+const defaultResponse = {
+  id: 1,
+  operatingsystem_name: 'Red Hat Enterprise Linux 8',
+  insights_attributes: { uuid: 'test-uuid' },
+};
 
 describe('NewHostDetailsTab', () => {
   let store;
@@ -68,17 +104,18 @@ describe('NewHostDetailsTab', () => {
     it('should preserve hash when clearing search params on unmount', () => {
       const { unmount } = render(
         <Provider store={store}>
-          <NewHostDetailsTab
-            hostName="test-host.example.com"
-            router={mockRouter}
-          />
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              router={mockRouter}
+              response={defaultResponse}
+            />
+          </MemoryRouter>
         </Provider>
       );
 
-      // Unmount the component to trigger cleanup
       unmount();
 
-      // Verify router.replace was called with both search: null AND the existing hash
       expect(mockRouter.replace).toHaveBeenCalledWith({
         search: null,
         hash: '#/Insights',
@@ -90,16 +127,18 @@ describe('NewHostDetailsTab', () => {
 
       const { unmount } = render(
         <Provider store={store}>
-          <NewHostDetailsTab
-            hostName="test-host.example.com"
-            router={mockRouter}
-          />
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              router={mockRouter}
+              response={defaultResponse}
+            />
+          </MemoryRouter>
         </Provider>
       );
 
       unmount();
 
-      // When there's no hash, should only pass search: null
       expect(mockRouter.replace).toHaveBeenCalledWith({
         search: null,
       });
@@ -114,16 +153,18 @@ describe('NewHostDetailsTab', () => {
 
       const { unmount } = render(
         <Provider store={store}>
-          <NewHostDetailsTab
-            hostName="test-host.example.com"
-            router={routerWithoutLocation}
-          />
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              router={routerWithoutLocation}
+              response={defaultResponse}
+            />
+          </MemoryRouter>
         </Provider>
       );
 
       unmount();
 
-      // Should still call replace with search: null even if location is undefined
       expect(routerWithoutLocation.replace).toHaveBeenCalledWith({
         search: null,
       });
@@ -132,23 +173,94 @@ describe('NewHostDetailsTab', () => {
     it('should use the latest hash value at unmount time, not a stale captured value', () => {
       const { unmount } = render(
         <Provider store={store}>
-          <NewHostDetailsTab
-            hostName="test-host.example.com"
-            router={mockRouter}
-          />
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              router={mockRouter}
+              response={defaultResponse}
+            />
+          </MemoryRouter>
         </Provider>
       );
 
-      // Change the hash after mount, before unmount
       mockRouter.location.hash = '#/Overview';
 
       unmount();
 
-      // Verify router.replace was called with the UPDATED hash, not the initial '#/Insights'
       expect(mockRouter.replace).toHaveBeenCalledWith({
         search: null,
         hash: '#/Overview',
       });
+    });
+  });
+
+  describe('tab visibility', () => {
+    it('should redirect to Overview when host is not RHEL', () => {
+      const nonRhelResponse = {
+        id: 2,
+        operatingsystem_name: 'Ubuntu 20.04',
+        insights_attributes: { uuid: 'test-uuid' },
+      };
+
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              response={nonRhelResponse}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(mockHistoryReplace).toHaveBeenCalledWith(OVERVIEW_TAB_PATH);
+    });
+
+    it('should redirect to Overview when insights facet is missing', () => {
+      const responseWithoutInsights = {
+        id: 3,
+        operatingsystem_name: 'Red Hat Enterprise Linux 8',
+      };
+
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              response={responseWithoutInsights}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(mockHistoryReplace).toHaveBeenCalledWith(OVERVIEW_TAB_PATH);
+    });
+
+    it('should not redirect when host is valid RHEL with insights facet', () => {
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <NewHostDetailsTab
+              hostName="test-host.example.com"
+              response={defaultResponse}
+            />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(mockHistoryReplace).not.toHaveBeenCalled();
+    });
+
+    it('should not redirect when host data is not yet loaded', () => {
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <NewHostDetailsTab hostName="test-host.example.com" response={{}} />
+          </MemoryRouter>
+        </Provider>
+      );
+
+      expect(mockHistoryReplace).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This is a release PR for `13.2.10`, cherry-picking three fixes from `develop` onto `foreman_3_18`:

- **#1183 - Fix blank screen when switching to host without Insights tabs**: When using the breadcrumb host switcher to navigate from a registered host (with Recommendations/Vulnerabilities tabs) to an unregistered host, the UI now redirects to the Overview tab instead of showing a blank screen with an infinite loading spinner.
- **#1196 - Pass through cloud error responses as-is (SAT-47604)**: `MachineTelemetriesController` and `UIRequestsController` no longer re-wrap non-200 cloud error responses in a custom JSON structure. Error bodies are now passed through with their original status code and content-type, the same way successful responses are handled, avoiding double-escaping of upstream JSON errors.
- **#1205 - Handle missing Foreman base host records gracefully (SAT-25889 / SAT-47605)**: `foreman_host` now returns `nil` instead of raising `ActiveRecord::RecordNotFound` when the base Foreman host record doesn't exist, and `foreman_host_name` uses `Setting[:foreman_url]` instead of `SmartProxy.default_capsule.name`. Call sites (metadata generation, inventory sync, insights notifications, host helper methods) were updated with nil guards so inventory upload, inventory sync, and recommendations sync keep working in `foremanctl` setups where the base host record isn't created. This fixes the `"can't find record with friendly id: 'satellite.example.com'"` error.

#### Considerations taken when implementing this change?

- All three commits were cherry-picked with `-x` to preserve a link back to the original commit on `develop`.
- Verified the exact commit SHAs against the source PRs before picking, since #1196 and #1205 were squash-merged into `develop` as a single commit each — the SHAs cherry-picked here are the actual squash-merge commits, not the original per-commit SHAs from the source branches.
- #1183 and #1196 applied cleanly; #1205 auto-merged three files (`lib/foreman_inventory_upload.rb`, `lib/foreman_inventory_upload/generators/fact_helpers.rb`, `test/jobs/inventory_self_host_sync_test.rb`) with no manual conflict resolution needed.

#### What are the testing steps for this pull request?

1. **Blank screen fix (#1183)**
   - Navigate to a registered RHEL host and open the Recommendations or Vulnerabilities tab.
   - Use the breadcrumb switcher to switch to an unregistered host (no Insights facet).
   - Expected: redirected to the Overview tab instead of a blank/loading screen.

2. **Cloud error pass-through (#1196)**
   - Trigger a request through the cloud request forwarder (e.g. insights-client request or telemetry call) that results in a non-200 response from the cloud service.
   - Expected: the error response body, status code, and content-type are returned as-is to the client, without being wrapped/double-escaped.

3. **Missing base host record (#1205)**
   - In a `foremanctl`/IoP-style setup where the Foreman base host record is not created for a given hostname, run inventory upload, inventory sync, and recommendations sync.
   - Expected: these tasks complete without raising `ActiveRecord::RecordNotFound` / "can't find record with friendly id" errors, and skip host-dependent logic gracefully when the host is `nil`.
