### PR TITLE
fix(iop): add missing remed modal to pathway props

### DIFF
--- a/webpack/IopRecommendationDetails/IopRecommendationDetails.js
+++ b/webpack/IopRecommendationDetails/IopRecommendationDetails.js
@@ -25,6 +25,7 @@ const IopRecommendationDetails = props => {
           scope={scope}
           module={pathwayModule}
           pathwayId={pathwayMatch.params.slug}
+          IopRemediationModal={RemediationModal}
           {...props}
         />
       </div>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add missing remediations modal props so the pathway details systems table won't crash

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Test it in iop environment using https://github.com/RedHatInsights/insights-advisor-frontend/tree/foreman-pathways-dev-v2 branch and iop-dev repository instructions