### PR TITLE
SAT-32064 - update InsightsHostDetailsTab from pf3 to pf5

### DIFF
--- a/webpack/InsightsCloudSync/Components/InsightsTable/InsightsLabel.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/InsightsLabel.js
@@ -7,21 +7,22 @@ import {
 } from '@patternfly/react-icons';
 import { Label } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
 
 const VALUE_TO_STATE = {
-  1: { icon: <AngleDoubleDownIcon />, text: 'Low', color: 'blue' },
-  2: { icon: <EqualsIcon />, text: 'Moderate', color: 'yellow' },
-  3: { icon: <AngleDoubleUpIcon />, text: 'Important', color: 'orange' },
-  4: { icon: <CriticalRiskIcon />, text: 'Critical', color: 'red' },
+  1: { icon: <AngleDoubleDownIcon />, text: __('Low'), color: 'blue' },
+  2: { icon: <EqualsIcon />, text: __('Moderate'), color: 'yellow' },
+  3: { icon: <AngleDoubleUpIcon />, text: __('Important'), color: 'orange' },
+  4: { icon: <CriticalRiskIcon />, text: __('Critical'), color: 'red' },
 };
 
 const InsightsLabel = ({ value = 1, text, hideIcon, ...props }) => (
   <Label
     {...props}
-    color={VALUE_TO_STATE[value].color}
-    icon={!hideIcon && VALUE_TO_STATE[value].icon}
+    color={VALUE_TO_STATE[value]?.color}
+    icon={!hideIcon && VALUE_TO_STATE[value]?.icon}
   >
-    {text || VALUE_TO_STATE[value].text}
+    {text || VALUE_TO_STATE[value]?.text}
   </Label>
 );
 

--- a/webpack/InsightsHostDetailsTab/InsightsTab.js
+++ b/webpack/InsightsHostDetailsTab/InsightsTab.js
@@ -1,56 +1,70 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { orderBy } from 'lodash';
-import { Grid, ListView } from 'patternfly-react';
+import { Accordion, Grid, GridItem, Title } from '@patternfly/react-core';
 import { noop } from 'foremanReact/common/helpers';
 import { translate as __ } from 'foremanReact/common/I18n';
 import ListItem from './components/ListItem';
 import './InsightsTab.scss';
 
-class InsightsHostDetailsTab extends React.Component {
-  componentDidMount() {
-    const { fetchHits, hostID } = this.props;
+const InsightsHostDetailsTab = ({ fetchHits, hostID, hits }) => {
+  useEffect(() => {
     fetchHits(hostID);
-  }
+  }, [hostID]);
 
-  render() {
-    const { hits } = this.props;
-
-    if (!hits.length) {
-      return <h2>{__('No recommendations were found for this host!')}</h2>;
-    }
-    const hitsSorted = orderBy(hits, ['total_risk'], ['desc']);
-    const items = hitsSorted.map(
-      (
-        {
-          title,
-          total_risk: totalRisk,
-          results_url: resultsUrl,
-          solution_url: solutionUrl,
-        },
-        index
-      ) => (
-        <ListItem
-          key={index}
-          title={title}
-          totalRisk={totalRisk}
-          resultsUrl={resultsUrl}
-          solutionUrl={solutionUrl}
-        />
-      )
-    );
+  if (!hits.length) {
     return (
       <div id="host_details_insights_tab">
-        <Grid.Row>
-          <Grid.Col xs={12}>
-            <h2>{__('Recommendations')}</h2>
-            <ListView id="hits_list">{items}</ListView>
-          </Grid.Col>
-        </Grid.Row>
+        <Title
+          headingLevel="h2"
+          size="md"
+          ouiaId="insights-recommendations-empty-title"
+        >
+          {__('No recommendations were found for this host!')}
+        </Title>
       </div>
     );
   }
-}
+
+  const hitsSorted = orderBy(hits, ['total_risk'], ['desc']);
+
+  return (
+    <div id="host_details_insights_tab">
+      <Grid hasGutter>
+        <GridItem span={12}>
+          <Title
+            headingLevel="h2"
+            size="md"
+            ouiaId="insights-recommendations-title"
+          >
+            {__('Recommendations')}
+          </Title>
+          <div id="hits_list" data-testid="hits-list">
+            <Accordion>
+              {hitsSorted.map(
+                ({
+                  id,
+                  title,
+                  total_risk: totalRisk,
+                  results_url: resultsUrl,
+                  solution_url: solutionUrl,
+                }) => (
+                  <ListItem
+                    key={id}
+                    title={title}
+                    totalRisk={totalRisk}
+                    resultsUrl={resultsUrl}
+                    solutionUrl={solutionUrl}
+                  />
+                )
+              )}
+            </Accordion>
+          </div>
+        </GridItem>
+      </Grid>
+    </div>
+  );
+};
 
 InsightsHostDetailsTab.propTypes = {
   hostID: PropTypes.number.isRequired,

--- a/webpack/InsightsHostDetailsTab/InsightsTab.scss
+++ b/webpack/InsightsHostDetailsTab/InsightsTab.scss
@@ -1,84 +1,18 @@
 #host_details_insights_tab {
-  #btn_toolbar {
-    float: right;
-  }
-
-  #btn_fullscreen {
-    margin-left: 5px;
-
-    .fa-arrows-alt {
-      margin-left: 5px;
-    }
-  }
-
-  h2 {
-    margin-top: 5px;
-  }
-
   #hits_list {
     max-height: 650px;
     overflow-y: scroll;
     overflow-x: hidden;
-    margin-top: 15px;
-
-    .list-view-pf-expand {
-      padding: 0;
-    }
-
-    .list-group-item-header {
-      .list-view-pf-expand .fa-angle-right {
-        margin-top: 6px;
-      }
-
-      .list-view-pf-main-info .list-view-pf-description {
-        width: 83%;
-
-        .list-group-item-heading {
-          width: 375px;
-        }
-
-        p {
-          margin: 0;
-          font-size: 14px;
-        }
-      }
-
-      .list-view-pf-additional-info {
-        .risk-label {
-          padding: 5px 8px;
-          border-radius: 12px;
-
-          &.risk-1 {
-            background-color: #e7f1fa;
-          }
-
-          &.risk-2 {
-            background-color: #fdf7e7;
-          }
-
-          &.risk-3 {
-            background-color: #f9dddd;
-          }
-
-          &.risk-4 {
-            background-color: #ffecec;
-          }
-
-          p {
-            margin: 0;
-          }
-        }
-      }
-    }
+    margin-top: var(--pf-v5-global--spacer--md);
 
     &::-webkit-scrollbar {
-      width: 12px;
-      height: 12px;
+      width: var(--pf-v5-global--spacer--sm);
+      height: var(--pf-v5-global--spacer--sm);
     }
 
     &::-webkit-scrollbar-thumb {
-      background: #222;
-      border-radius: 6px;
+      background: var(--pf-v5-global--palette--black-900);
+      border-radius: var(--pf-v5-global--BorderRadius--sm);
       border: 3px solid transparent;
       background-clip: content-box;
     }
@@ -86,9 +20,9 @@
 }
 
 #new_host_details_insights_tab {
-  padding: 24px;
+  padding: var(--pf-v5-global--spacer--lg);
 }
 
 #total-risks-dropdown-container ul.pf-v5-c-menu__list {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }

--- a/webpack/InsightsHostDetailsTab/__tests__/InsightsTab.fixtures.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/InsightsTab.fixtures.js
@@ -2,6 +2,7 @@ export const hostID = 1234;
 
 export const hits = [
   {
+    id: 1,
     hostname: 'my-host.example.com',
     rhel_version: '7.8',
     uuid: '4739b323-a343-4e89-b71b-81991b8dc656',
@@ -15,6 +16,12 @@ export const hits = [
     results_url:
       'https://cloud.redhat.com/insights/advisor/recommendations/ansible_deprecated_repo%7CANSIBLE_DEPRECATED_REPO/4739b323-a343-4e89-b71b-81991b8dc656/',
   },
+];
+
+export const multipleHits = [
+  { ...hits[0], id: 1, title: 'Low risk', total_risk: 1 },
+  { ...hits[0], id: 2, title: 'High risk', total_risk: 4 },
+  { ...hits[0], id: 3, title: 'Medium risk', total_risk: 2 },
 ];
 
 export const props = {

--- a/webpack/InsightsHostDetailsTab/__tests__/InsightsTab.test.js
+++ b/webpack/InsightsHostDetailsTab/__tests__/InsightsTab.test.js
@@ -1,46 +1,68 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { rtlHelpers } from 'foremanReact/common/rtlTestHelpers';
 import InsightsTab from '../InsightsTab';
-import { hits, hostID } from './InsightsTab.fixtures';
+import { hits, hostID, multipleHits } from './InsightsTab.fixtures';
+
+const { renderWithI18n } = rtlHelpers;
+
+const renderInsightsTab = (props = {}) =>
+  renderWithI18n(
+    <InsightsTab hostID={hostID} hits={[]} fetchHits={jest.fn()} {...props} />
+  );
 
 describe('InsightsTab', () => {
-  it('renders "No recommendations" message when hits is empty', () => {
-    render(<InsightsTab hostID={hostID} hits={[]} />);
+  it('renders empty state heading when there are no recommendations', async () => {
+    renderInsightsTab({ hits: [] });
+
     expect(
-      screen.getByText('No recommendations were found for this host!')
-    ).toBeTruthy();
+      await screen.findByRole('heading', {
+        name: 'No recommendations were found for this host!',
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('heading', { name: 'Recommendations' })
+    ).not.toBeInTheDocument();
   });
 
-  it('renders Recommendations heading when hits exist', () => {
-    render(<InsightsTab hostID={hostID} hits={hits} />);
-    expect(screen.getByText('Recommendations')).toBeTruthy();
+  it('renders recommendations heading when hits exist', async () => {
+    renderInsightsTab({ hits });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Recommendations' })
+    ).toBeInTheDocument();
   });
 
-  it('displays hit titles', () => {
-    render(<InsightsTab hostID={hostID} hits={hits} />);
-    hits.forEach(hit => {
-      expect(screen.getByText(hit.title)).toBeTruthy();
+  it('displays recommendation titles in the list', async () => {
+    renderInsightsTab({ hits });
+
+    expect(
+      await screen.findByText(
+        'New Ansible Engine packages are inaccessible when dedicated Ansible repo is not enabled'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('requests recommendations for the host on mount', async () => {
+    const fetchHits = jest.fn();
+
+    renderInsightsTab({ hits: [], fetchHits });
+
+    await waitFor(() => {
+      expect(fetchHits).toHaveBeenCalledWith(hostID);
     });
   });
 
-  it('calls fetchHits on mount', () => {
-    const fetchHits = jest.fn();
-    render(<InsightsTab hostID={hostID} hits={[]} fetchHits={fetchHits} />);
-    expect(fetchHits).toHaveBeenCalledWith(hostID);
-  });
+  it('sorts recommendations by total risk descending', async () => {
+    renderInsightsTab({ hits: multipleHits });
 
-  it('sorts hits by total_risk descending', () => {
-    const multipleHits = [
-      { ...hits[0], title: 'Low risk', total_risk: 1 },
-      { ...hits[0], title: 'High risk', total_risk: 4 },
-      { ...hits[0], title: 'Medium risk', total_risk: 2 },
-    ];
-    render(<InsightsTab hostID={hostID} hits={multipleHits} />);
-    const titles = screen.getAllByText(/risk/i).map(el => el.textContent);
-    const highRiskIndex = titles.findIndex(t => t === 'High risk');
-    const mediumRiskIndex = titles.findIndex(t => t === 'Medium risk');
-    const lowRiskIndex = titles.findIndex(t => t === 'Low risk');
-    expect(highRiskIndex).toBeLessThan(mediumRiskIndex);
-    expect(mediumRiskIndex).toBeLessThan(lowRiskIndex);
+    const hitsList = await screen.findByTestId('hits-list');
+    const toggles = within(hitsList).getAllByRole('button');
+
+    expect(toggles[0]).toHaveTextContent('High risk');
+    expect(toggles[1]).toHaveTextContent('Medium risk');
+    expect(toggles[2]).toHaveTextContent('Low risk');
   });
 });

--- a/webpack/InsightsHostDetailsTab/components/ListItem/ListItem.js
+++ b/webpack/InsightsHostDetailsTab/components/ListItem/ListItem.js
@@ -1,33 +1,24 @@
-import React, { Fragment } from 'react';
-import { ListView, Icon } from 'patternfly-react';
+import React, { useState } from 'react';
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionToggle,
+  Flex,
+  FlexItem,
+  Truncate,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-
-const labelMapper = {
-  1: __('Low'),
-  2: __('Moderate'),
-  3: __('Important'),
-  4: __('Critical'),
-};
+import InsightsLabel from '../../../InsightsCloudSync/Components/InsightsTable/InsightsLabel';
 
 const ListItem = ({ title, totalRisk, resultsUrl, solutionUrl }) => {
-  const heading = (
-    <p className="ellipsis list-item-heading" title={title}>
-      {title}
-    </p>
-  );
-
-  const riskLabel = labelMapper[totalRisk];
-  const additionalInfo = [
-    <span key={`risk-info-${title}`} className={`risk-label risk-${totalRisk}`}>
-      <p>{riskLabel}</p>
-    </span>,
-  ];
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const knowledgebaseLink = solutionUrl && (
     <p>
       <a href={solutionUrl} target="_blank" rel="noopener noreferrer">
-        {__('Knowledgebase article')} <Icon name="external-link" />
+        {__('Knowledgebase article')} <ExternalLinkAltIcon />
       </a>
     </p>
   );
@@ -35,24 +26,41 @@ const ListItem = ({ title, totalRisk, resultsUrl, solutionUrl }) => {
   const insightsCloudLink = resultsUrl && (
     <p>
       <a href={resultsUrl} target="_blank" rel="noopener noreferrer">
-        {__('Read more about it in RH cloud insights')}{' '}
-        <Icon name="external-link" />
+        {__('Read more about it in RH cloud insights')}
+        <ExternalLinkAltIcon />
       </a>
     </p>
   );
 
   return (
-    <ListView.Item
-      heading={heading}
-      additionalInfo={additionalInfo}
-      hideCloseIcon
-    >
-      <Fragment>
-        <p>{title}</p>
-        {knowledgebaseLink}
-        {insightsCloudLink}
-      </Fragment>
-    </ListView.Item>
+    <AccordionItem>
+      <AccordionToggle
+        onClick={() => setIsExpanded(currentValue => !currentValue)}
+        isExpanded={isExpanded}
+      >
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          flexWrap={{ default: 'nowrap' }}
+        >
+          <FlexItem>
+            <Truncate content={title} />
+          </FlexItem>
+          <FlexItem>
+            <InsightsLabel value={totalRisk} />
+          </FlexItem>
+        </Flex>
+      </AccordionToggle>
+      <AccordionContent isHidden={!isExpanded}>
+        {isExpanded && (
+          <>
+            <p>{title}</p>
+            {knowledgebaseLink}
+            {insightsCloudLink}
+          </>
+        )}
+      </AccordionContent>
+    </AccordionItem>
   );
 };
 

--- a/webpack/InsightsHostDetailsTab/components/ListItem/__tests__/ListItem.test.js
+++ b/webpack/InsightsHostDetailsTab/components/ListItem/__tests__/ListItem.test.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { Accordion } from '@patternfly/react-core';
+import { rtlHelpers } from 'foremanReact/common/rtlTestHelpers';
+import ListItem from '../ListItem';
+
+const { renderWithI18n } = rtlHelpers;
+
+const defaultProps = {
+  title: 'Test recommendation title',
+  totalRisk: 2,
+  resultsUrl:
+    'https://cloud.redhat.com/insights/advisor/recommendations/example',
+  solutionUrl: 'https://access.redhat.com/solutions/123456',
+};
+
+const renderListItem = (props = {}) =>
+  renderWithI18n(
+    <Accordion>
+      <ListItem {...defaultProps} {...props} />
+    </Accordion>
+  );
+
+describe('ListItem', () => {
+  it('renders the recommendation title when collapsed', async () => {
+    renderListItem();
+
+    expect(
+      await screen.findByText('Test recommendation title')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the total risk label when collapsed', async () => {
+    renderListItem({ totalRisk: 2 });
+
+    expect(await screen.findByText('Moderate')).toBeInTheDocument();
+  });
+
+  it('does not show detail links before expanding', async () => {
+    renderListItem();
+
+    await screen.findByText('Test recommendation title');
+
+    expect(
+      screen.queryByRole('link', { name: /Knowledgebase article/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: /Read more about it in RH cloud insights/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows detail links after expanding the recommendation', async () => {
+    renderListItem();
+
+    await userEvent.click(await screen.findByRole('button'));
+
+    const knowledgebaseLink = screen.getByRole('link', {
+      name: /Knowledgebase article/i,
+    });
+    expect(knowledgebaseLink).toHaveAttribute('href', defaultProps.solutionUrl);
+    expect(knowledgebaseLink).toHaveAttribute('target', '_blank');
+    expect(knowledgebaseLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    const insightsCloudLink = screen.getByRole('link', {
+      name: /Read more about it in RH cloud insights/i,
+    });
+    expect(insightsCloudLink).toHaveAttribute('href', defaultProps.resultsUrl);
+    expect(insightsCloudLink).toHaveAttribute('target', '_blank');
+    expect(insightsCloudLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('omits the knowledgebase link when no solution URL is provided', async () => {
+    renderListItem({ solutionUrl: '' });
+
+    await userEvent.click(await screen.findByRole('button'));
+
+    expect(
+      screen.queryByRole('link', { name: /Knowledgebase article/i })
+    ).not.toBeInTheDocument();
+
+    const insightsCloudLink = screen.getByRole('link', {
+      name: /Read more about it in RH cloud insights/i,
+    });
+    expect(insightsCloudLink).toBeInTheDocument();
+    expect(insightsCloudLink).toHaveAttribute('target', '_blank');
+    expect(insightsCloudLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('omits the insights cloud link when no results URL is provided', async () => {
+    renderListItem({ resultsUrl: '' });
+
+    await userEvent.click(await screen.findByRole('button'));
+
+    const knowledgebaseLink = screen.getByRole('link', {
+      name: /Knowledgebase article/i,
+    });
+    expect(knowledgebaseLink).toBeInTheDocument();
+    expect(knowledgebaseLink).toHaveAttribute('target', '_blank');
+    expect(knowledgebaseLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    expect(
+      screen.queryByRole('link', {
+        name: /Read more about it in RH cloud insights/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/webpack/common/Switcher/HelpLabel.js
+++ b/webpack/common/Switcher/HelpLabel.js
@@ -5,6 +5,7 @@ import { HelpIcon } from '@patternfly/react-icons';
 
 export const HelpLabel = ({ text, id, className }) => {
   if (!text) return null;
+
   return (
     <Popover id={`${id}-help`} bodyContent={text} aria-label="help-text">
       <Button


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updated InsightsHostDetailsTab from PF3 to PF5

Before:
<img width="493" height="618" alt="Screenshot 2026-07-16 at 11 14 08" src="https://github.com/user-attachments/assets/e797df6b-f158-4bcf-aa12-35eb992a3a38" />
<img width="460" height="893" alt="Screenshot 2026-07-16 at 11 14 33" src="https://github.com/user-attachments/assets/70fedec8-fa4f-40c6-aa46-84317fd4008a" />

After:
<img width="499" height="814" alt="Screenshot 2026-07-16 at 11 14 20" src="https://github.com/user-attachments/assets/4e3f604a-7321-44dd-a289-1b3ff22caf7b" />
<img width="501" height="901" alt="Screenshot 2026-07-16 at 11 14 41" src="https://github.com/user-attachments/assets/baa78b25-69a4-4b00-a085-0af8ade028da" />

