### PR TITLE
fix(iop): separate route for pathway details

### DIFF
--- a/webpack/ForemanRhCloudPages.js
+++ b/webpack/ForemanRhCloudPages.js
@@ -5,6 +5,7 @@ import ForemanInventoryUpload from './ForemanInventoryUpload';
 import InsightsVulnerabilityListPage from './InsightsVulnerability/InsightsVulnerabilityListPage';
 import InsightsCloudSync from './InsightsCloudSync';
 import IopRecommendationDetails from './IopRecommendationDetails/IopRecommendationDetails';
+import IopPathwayDetails from './IopPathwayDetails/IopPathwayDetails';
 import InsightsHostDetailsTab from './InsightsHostDetailsTab';
 import CveDetailsPage from './CveDetailsPage';
 import InsightsComplianceReportsPage from './InsightsCompliance/InsightsComplianceReportsPage';
@@ -40,6 +41,11 @@ export const routes = [
     path: '/foreman_rh_cloud/insights_cloud',
     exact: true,
     render: props => <InsightsCloudSync {...props} />,
+  },
+  {
+    path: '/foreman_rh_cloud/recommendations/pathways/:slug',
+    exact: false,
+    render: props => <IopPathwayDetails {...props} />,
   },
   {
     path: '/foreman_rh_cloud/recommendations',

--- a/webpack/IopPathwayDetails/IopPathwayDetails.js
+++ b/webpack/IopPathwayDetails/IopPathwayDetails.js
@@ -7,33 +7,34 @@ import { createProviderOptions } from '../common/ScalprumModule/ScalprumContext'
 import { useInsightsPermissions } from '../common/Hooks/PermissionsHooks';
 
 const scope = 'advisor';
-const module = './RecommendationDetailsWrapped';
+const pathwayModule = './PathwayDetailsWrapped';
 
-const IopRecommendationDetails = props => {
-  const urlParams = useRouteMatch('/foreman_rh_cloud/recommendations/:rule_id');
-  // eslint-disable-next-line camelcase
-  const ruleId = urlParams?.params?.rule_id;
+const IopPathwayDetails = props => {
+  const pathwayMatch = useRouteMatch(
+    '/foreman_rh_cloud/recommendations/pathways/:slug'
+  );
+  const slug = pathwayMatch?.params?.slug;
 
   return (
-    <div className="iop-recommendation-details-scalprum advisor">
+    <div className="iop-pathway-details-scalprum advisor">
       <ScalprumComponent
         scope={scope}
-        module={module}
+        module={pathwayModule}
+        pathwayId={slug}
         IopRemediationModal={RemediationModal}
-        ruleId={ruleId}
         {...props}
       />
     </div>
   );
 };
 
-const IopRecommendationDetailsWrapped = props => {
+const IopPathwayDetailsWrapped = props => {
   const permissions = useInsightsPermissions();
   return (
     <ScalprumProvider {...createProviderOptions(permissions)}>
-      <IopRecommendationDetails {...props} />
+      <IopPathwayDetails {...props} />
     </ScalprumProvider>
   );
 };
 
-export default IopRecommendationDetailsWrapped;
+export default IopPathwayDetailsWrapped;


### PR DESCRIPTION
Pathway details and recommendation details were rendered by a single component (IopRecommendationDetails) on one catch-all route, using useRouteMatch internally to switch between views. 
When <Link> inside the federated PathwayDetailsWrapped module navigated to a recommendation details URL, the route still matched the same catch-all, so the host router never re-mounted the component and useRouteMatch didn't re-evaluate — leaving the user stuck on the Pathway details page despite the URL changing. 

Splitting into separate routes with a dedicated IopPathwayDetails component ensures the router treats pathway-to-recommendation navigation as a proper route change, unmounting one view and mounting the other.

How to repeat the bug:
Run the dev environment, open pathway details page, click on Link to the Recommendation details in Recommendations table - you will see URL is changed but you are still on the same page and not navigated to the Recommendation details page