### PR TITLE
SAT-47603 - Add missing ouiaId labels to components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,11 @@
 {
-  "plugins": ["@theforeman/foreman", "spellcheck"],
+  "plugins": ["@theforeman/foreman", "@theforeman/rules", "spellcheck"],
   "extends": [
     "plugin:@theforeman/foreman/core",
     "plugin:@theforeman/foreman/plugins"
   ],
   "rules": {
+    "@theforeman/rules/require-ouiaid": "error",
     "spellcheck/spell-checker": [
       "error",
       {

--- a/webpack/ForemanInventoryUpload/Components/InventorySettings/MinimalInventoryDropdown.js
+++ b/webpack/ForemanInventoryUpload/Components/InventorySettings/MinimalInventoryDropdown.js
@@ -79,6 +79,7 @@ const MinimalInventoryDropdown = ({ setChosenValue }) => {
           isFullWidth
           onClick={onToggleClick}
           isExpanded={isOpen}
+          ouiaId="inventory-dropdown-toggle"
         >
           {dropdownValues[currentDropdownValue].title}
         </MenuToggle>

--- a/webpack/ForemanInventoryUpload/Components/PageHeader/PageTitle.js
+++ b/webpack/ForemanInventoryUpload/Components/PageHeader/PageTitle.js
@@ -59,6 +59,7 @@ const PageTitle = () => {
               variant="plain"
               onClick={() => setIsDropdownOpen(prev => !prev)}
               isExpanded={isDropdownOpen}
+              ouiaId="title-dropdown-toggle"
             >
               <EllipsisVIcon />
             </MenuToggle>

--- a/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTableConstants.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/InsightsTableConstants.js
@@ -31,7 +31,7 @@ export const actionsFormatter = rowData => {
   recommendationUrl &&
     !isLocalAdvisorEngine &&
     dropdownItems.push(
-      <DropdownItem key="recommendation-url">
+      <DropdownItem key="recommendation-url" ouiaId="insights-dropdown-item-recommendation-url">
         <a href={recommendationUrl} target="_blank" rel="noopener noreferrer">
           {__('View in Red Hat Insights')} <ExternalLinkAltIcon />
         </a>
@@ -40,7 +40,7 @@ export const actionsFormatter = rowData => {
 
   accessRHUrl &&
     dropdownItems.push(
-      <DropdownItem key="access-url">
+      <DropdownItem key="access-url" ouiaId="insights-dropdown-item-knowledgebase">
         <a href={accessRHUrl} target="_blank" rel="noopener noreferrer">
           {__('Knowledgebase article')} <ExternalLinkAltIcon />
         </a>

--- a/webpack/InsightsCloudSync/Components/InsightsTable/Pagination.js
+++ b/webpack/InsightsCloudSync/Components/InsightsTable/Pagination.js
@@ -42,6 +42,7 @@ const Pagination = ({ variant, ...props }) => {
 
   return (
     <PfPagination
+      ouiaId={`recommendations-pagination-${variant}`}
       itemCount={itemCount}
       widgetId={`recommendation-pagination-${variant}`}
       perPage={perPage}

--- a/webpack/InsightsCloudSync/Components/ToolbarDropdown.js
+++ b/webpack/InsightsCloudSync/Components/ToolbarDropdown.js
@@ -53,6 +53,7 @@ const ToolbarDropdown = ({ onRecommendationSync }) => {
           aria-label={__('Recommendations actions')}
           onClick={() => setIsDropdownOpen(prev => !prev)}
           isExpanded={isDropdownOpen}
+          ouiaId="recommendations-dropdown-toggle"
         >
           <EllipsisVIcon />
         </MenuToggle>

--- a/webpack/common/DropdownToggle.js
+++ b/webpack/common/DropdownToggle.js
@@ -18,6 +18,7 @@ const DropdownToggle = ({ items, ...props }) => {
           aria-label={__('Table actions')}
           onClick={() => setOpen(prev => !prev)}
           isExpanded={isOpen}
+          ouiaId="toggle-dropdown-toggle"
         >
           <EllipsisVIcon />
         </MenuToggle>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Enable `@theforeman/rules/require-ouiaid` for this repo.
Add missing ouiaId props to PatternFly components across the Insights and Inventory Upload UI
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Test plan
 - [ ] Verify Insights recommendations page renders with OUIA IDs in the DOM
 - [ ] Verify remediation modal table  renders correctly
 - [ ] Verify inventory upload pages show OUIA IDs on empty states
 - [ ] Spot-check `[data-ouia-component-id]` selectors in browser dev tools
 - [ ] Run ouiaId ESLint check and verify no violations:
Need https://github.com/theforeman/foreman/pull/11117. 
```
$ cp /home/vagrant/foreman/script/lint/@theforeman/eslint-plugin-rules/require-ouiaid.js \
   /home/vagrant/foreman/node_modules/@theforeman/eslint-plugin-rules/lib/require-ouiaid.js
$ cd /home/vagrant/foreman
$ npx eslint  ../foreman_rh_cloud/webpack/
```