### PR TITLE
Fix prefer-pf-components lint error in HelpLabel to fix JS tests

### DIFF
--- a/webpack/common/Switcher/HelpLabel.js
+++ b/webpack/common/Switcher/HelpLabel.js
@@ -1,18 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Popover } from '@patternfly/react-core';
+import { Button, Popover } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
 export const HelpLabel = ({ text, id, className }) => {
   if (!text) return null;
   return (
     <Popover id={`${id}-help`} bodyContent={text} aria-label="help-text">
-      <button
-        onClick={e => e.preventDefault()}
-        className={`pf-v5-c-form__group-label-help ${className}`}
+      <Button
+        variant="plain"
+        ouiaId={`help-button-${id}`}
+        className={className}
       >
         <HelpIcon />
-      </button>
+      </Button>
     </Popover>
   );
 };


### PR DESCRIPTION
Replace raw <button> with pf-v5-c-form CSS class with PatternFly <Button variant="plain"> component to satisfy the
@theforeman/rules/prefer-pf-components ESLint rule.

Tested `inventory_upload` page
Tested Recommendations page

pop over text icon looks the same and works correctly. 