### PR TITLE
Fix legacy host Insights tab when local recommendations are missing

### DIFF
--- a/app/controllers/insights_cloud/hits_controller.rb
+++ b/app/controllers/insights_cloud/hits_controller.rb
@@ -1,6 +1,7 @@
 module InsightsCloud
   class HitsController < ::ApplicationController
     include Foreman::Controller::AutoCompleteSearch
+    include ::ForemanRhCloud::CertAuth
 
     def index
       hits = resource_base_search_and_page.preload(:host, :rule)
@@ -12,14 +13,14 @@ module InsightsCloud
     end
 
     def show
-      host = Host.where(id: host_id_param).first
-      hits = host.insights&.hits
-
-      unless hits
+      host = Host.authorized.find_by(id: host_id_param)
+      unless host
         return render json: {
           error: 'No recommendations were found for this host',
         }, status: :not_found
       end
+
+      hits = host_hits(host)
 
       render json: {
         hits: hits,
@@ -82,6 +83,54 @@ module InsightsCloud
 
     def resource_base
       super.where(host: Host.authorized)
+    end
+
+    def host_hits(host)
+      hits = resource_base.where(host_id: host.id)
+      return hits unless hits.empty?
+
+      uuid = host.insights_uuid
+      return [] if uuid.blank?
+
+      cloud_hits(host, uuid)
+    end
+
+    def cloud_hits(host, uuid)
+      cloud_response = execute_cloud_request(
+        organization: host.organization,
+        method: :get,
+        url: "#{InsightsCloud.ui_base_url}/api/insights/v1/system/#{uuid}/reports"
+      )
+      payload = JSON.parse(cloud_response.to_s)
+      entries = if payload.is_a?(Array)
+                  payload
+                else
+                  payload['data'] || payload['reports'] || payload['hits'] || []
+                end
+      return [] unless entries.is_a?(Array)
+
+      entries.filter_map do |entry|
+        next unless entry.is_a?(Hash)
+
+        total_risk = entry['total_risk'].to_i
+        title =
+          entry['title'] ||
+          entry.dig('rule', 'description') ||
+          entry.dig('rule', 'summary') ||
+          entry['rule_id']
+
+        {
+          host_id: host.id,
+          title: title,
+          total_risk: total_risk.between?(1, 4) ? total_risk : 1,
+          results_url: entry['results_url'] || entry['url'],
+          solution_url: entry['solution_url'] || entry.dig('resolution', 'url'),
+          rule_id: entry['rule_id'] || entry.dig('rule', 'rule_id'),
+        }.compact
+      end
+    rescue StandardError => e
+      logger.debug("Cloud fallback for host #{host.id} failed: #{e}")
+      []
     end
   end
 end

--- a/test/controllers/insights_cloud/hits_controller_test.rb
+++ b/test/controllers/insights_cloud/hits_controller_test.rb
@@ -1,0 +1,76 @@
+require 'test_plugin_helper'
+
+module InsightsCloud
+  class HitsControllerTest < ActionController::TestCase
+    setup do
+      @controller = ::InsightsCloud::HitsController.new
+      @org = FactoryBot.create(:organization)
+      @loc = FactoryBot.create(:location)
+    end
+
+    test 'show returns hits for the requested host' do
+      host = FactoryBot.create(:host, :with_insights_hits, organization: @org, location: @loc)
+
+      get :show, params: { host_id: host.id }, session: set_session
+
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal 1, body['hits'].size
+      assert_equal host.id, body['hits'].first['host_id']
+    end
+
+    test 'show returns not found for unknown host id' do
+      get :show, params: { host_id: 0 }, session: set_session
+
+      assert_response :not_found
+      body = JSON.parse(response.body)
+      assert_equal 'No recommendations were found for this host', body['error']
+    end
+
+    test 'show returns empty hits when host has no insights uuid and local hits are missing' do
+      host = FactoryBot.create(:host, :managed, organization: @org, location: @loc)
+
+      get :show, params: { host_id: host.id }, session: set_session
+
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal [], body['hits']
+    end
+
+    test 'show falls back to cloud reports when local hits are missing' do
+      host = FactoryBot.create(:host, :managed, organization: @org, location: @loc)
+      host.insights = FactoryBot.create(:insights_facet, host_id: host.id, uuid: 'cloud-system-uuid')
+
+      cloud_payload = {
+        data: [
+          {
+            title: 'Cloud recommendation',
+            total_risk: 3,
+            results_url: 'https://console.redhat.com/insights/advisor/recommendations/test',
+            solution_url: 'https://access.redhat.com/solutions/123',
+            rule_id: 'test|RULE',
+          },
+        ],
+      }.to_json
+
+      ::InsightsCloud::HitsController.any_instance.expects(:execute_cloud_request).returns(cloud_payload)
+
+      get :show, params: { host_id: host.id }, session: set_session
+
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal 1, body['hits'].size
+      assert_equal 'Cloud recommendation', body['hits'].first['title']
+      assert_equal host.id, body['hits'].first['host_id']
+    end
+
+    private
+
+    def set_session
+      set_session_user.merge(
+        organization_id: @org.id,
+        location_id: @loc.id
+      )
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Legacy host-details Insights tab can show “No recommendations were found for this host” even when recommendations exist in Insights cloud. The tab relies on GET /insights_cloud/hits/:host_id, which previously returned only locally synced InsightsHit records; when local mapping/sync is stale, the response is empty and the UI is incorrect.

This change keeps local hits as the primary source and adds a cloud fallback (by host insights_uuid) when local hits are empty, then maps the response back to the legacy hit format. It also normalizes risk values to the legacy UI range so recommendations render consistently instead of disappearing behind invalid risk data.

#### Considerations taken when implementing this change?
- Backward compatibility: local DB hits remain the primary source; fallback is only used when local data is empty.
- Scope minimization: fix is isolated to hits#show logic; no UI component changes required.
- Authorization safety: host lookup is done through Host.authorized.
- Resilience: cloud fallback failures return hits: [] instead of breaking the page.
- Legacy UI compatibility: normalized total_risk to valid legacy range (1..4) to avoid rendering issues.

#### What are the testing steps for this pull request?
1. Open Legacy host details page for a host with local InsightsHit rows:
    - verify GET /insights_cloud/hits/:host_id returns local hits.
2. Open Legacy host details page for a host with no local hits but valid insights_uuid and cloud recommendations:
    - verify API returns fallback cloud hits and tab shows recommendations.
3. Open Legacy host details page for a host with no local hits and no insights_uuid:
    - verify API returns {"hits":[]} and tab shows empty state.
4. Request an invalid/non-authorized host id:
    - verify API returns 404 with existing error message.
5. Run controller tests:
    - bundle exec rake test TEST=/home/nalfassi/git/foreman_rh_cloud/test/controllers/insights_cloud/hits_controller_test.rb (from Foreman repo).
